### PR TITLE
Keyword-only arguments

### DIFF
--- a/sgkit/api.py
+++ b/sgkit/api.py
@@ -12,6 +12,7 @@ DIM_GENOTYPE = "genotypes"
 
 
 def create_genotype_call_dataset(
+    *,
     variant_contig_names: List[str],
     variant_contig: Any,
     variant_position: Any,

--- a/sgkit/tests/test_api.py
+++ b/sgkit/tests/test_api.py
@@ -24,12 +24,12 @@ def test_create_genotype_call_dataset():
         [[True, True, False], [True, False, False]], dtype=bool
     )
     ds = create_genotype_call_dataset(
-        variant_contig_names,
-        variant_contig,
-        variant_position,
-        variant_alleles,
-        sample_id,
-        call_genotype,
+        variant_contig_names=variant_contig_names,
+        variant_contig=variant_contig,
+        variant_position=variant_position,
+        variant_alleles=variant_alleles,
+        sample_id=sample_id,
+        call_genotype=call_genotype,
         call_genotype_phased=call_genotype_phased,
         variant_id=variant_id,
     )


### PR DESCRIPTION
Make all arguments to `create_genotype_call_dataset` keyword-only arguments (PEP 3102).

There is no particular natural order to the arguments and it would be easy to mix up the order; this change makes things more explicit, and allows the positional args to be reordered by the caller if desired.