### PR TITLE
Add mypy type checking to GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
         pip install -r requirements.txt -r requirements-dev.txt
     - name: Run pre-commit
       uses: pre-commit/action@v2.0.0
+    - name: Check types with mypy
+      run: |
+        mypy --strict .
     - name: Test with pytest and coverage
       run: |
         pytest -v --cov=sgkit

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ You can use [pre-commit](https://pre-commit.com/) to check or enforce the coding
 ```bash
 pre-commit install
 ```
+
+Note that pre-commit does not run the `mypy` check, so you will need to run that manually before submitting a pull request.

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,9 @@ line_length = 88
 
 [mypy-numpy.*]
 ignore_missing_imports = True
-
+[mypy-pytest.*]
+ignore_missing_imports = True
+[mypy-setuptools]
+ignore_missing_imports = True
 [mypy-sgkit.tests.*]
 disallow_untyped_defs = False

--- a/sgkit/api.py
+++ b/sgkit/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Hashable, List, Mapping
+from typing import Any, Dict, Hashable, List
 
 import xarray as xr
 
@@ -57,7 +57,7 @@ def create_genotype_call_dataset(
     check_array_like(variant_alleles, kind="S", ndim=2)
     check_array_like(sample_id, kind="U", ndim=1)
     check_array_like(call_genotype, kind="i", ndim=3)
-    data_vars: Mapping[Hashable, Any] = {
+    data_vars: Dict[Hashable, Any] = {
         "variant/contig": ([DIM_VARIANT], variant_contig),
         "variant/position": ([DIM_VARIANT], variant_position),
         "variant/alleles": ([DIM_VARIANT, DIM_ALLELE], variant_alleles),
@@ -77,5 +77,5 @@ def create_genotype_call_dataset(
     if variant_id is not None:
         check_array_like(variant_id, kind="U", ndim=1)
         data_vars["variant/id"] = ([DIM_VARIANT], variant_id)
-    attrs = {"contigs": variant_contig_names}
+    attrs: Dict[Hashable, Any] = {"contigs": variant_contig_names}
     return xr.Dataset(data_vars=data_vars, attrs=attrs)

--- a/sgkit/typing.py
+++ b/sgkit/typing.py
@@ -1,0 +1,3 @@
+from typing import Any
+
+DType = Any

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -5,7 +5,7 @@ import numpy as np
 
 def check_array_like(
     a: Any,
-    dtype: Union[None, str, Set[str]] = None,
+    dtype: Any = None,
     kind: Union[None, str, Set[str]] = None,
     ndim: Union[None, int, Set[int]] = None,
 ) -> None:

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -2,10 +2,12 @@ from typing import Any, Set, Union
 
 import numpy as np
 
+from .typing import DType
+
 
 def check_array_like(
     a: Any,
-    dtype: Any = None,
+    dtype: DType = None,
     kind: Union[None, str, Set[str]] = None,
     ndim: Union[None, int, Set[int]] = None,
 ) -> None:

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -1,7 +1,14 @@
+from typing import Any, Set, Union
+
 import numpy as np
 
 
-def check_array_like(a, dtype=None, kind=None, ndim=None):
+def check_array_like(
+    a: Any,
+    dtype: Union[None, str, Set[str]] = None,
+    kind: Union[None, str, Set[str]] = None,
+    ndim: Union[None, int, Set[int]] = None,
+) -> None:
     array_attrs = "ndim", "dtype", "shape"
     for k in array_attrs:
         if not hasattr(a, k):


### PR DESCRIPTION
I couldn't see a way of getting [mypy precommit](https://github.com/pre-commit/mirrors-mypy) to use the settings in `setup.cfg`, so instead I added a separate GH step to run mypy. This also means you have to run mypy yourself manually on your machine to check types.

Fixes #27.