### PR TITLE
Allele count implementation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ setup_requires =
 [coverage:report]
 fail_under = 100
 
+[tool:pytest]
+addopts = --doctest-modules
+
 [flake8]
 ignore =
     # whitespace before ':' - doesn't work well with black

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -5,6 +5,7 @@ from .api import (  # noqa: F401
     DIM_VARIANT,
     create_genotype_call_dataset,
 )
+from .stats.aggregation import allele_count
 
 __all__ = [
     "DIM_ALLELE",
@@ -12,4 +13,5 @@ __all__ = [
     "DIM_SAMPLE",
     "DIM_VARIANT",
     "create_genotype_call_dataset",
+    "allele_count",
 ]

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -5,7 +5,7 @@ from .api import (  # noqa: F401
     DIM_VARIANT,
     create_genotype_call_dataset,
 )
-from .stats.aggregation import allele_count
+from .stats.aggregation import count_alleles
 from .stats.association import gwas_linear_regression
 
 __all__ = [
@@ -14,6 +14,6 @@ __all__ = [
     "DIM_SAMPLE",
     "DIM_VARIANT",
     "create_genotype_call_dataset",
-    "allele_count",
+    "count_alleles",
     "gwas_linear_regression",
 ]

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -3,20 +3,20 @@ from xarray import DataArray, Dataset
 
 
 def allele_count(ds: Dataset) -> DataArray:
-    """Compute allele count from genotype calls
+    """Compute allele count from genotype calls.
 
     Parameters
     ----------
     ds : Dataset
         Genotype call dataset such as from
-        `sgkit.create_genotype_call_dataset`
+        `sgkit.create_genotype_call_dataset`.
 
     Returns
     -------
-    DataArray
+    variant/allele_count : DataArray
         Allele counts with shape (variants, alleles) and values
         corresponding to the number of non-missing occurrences
-        of each allele
+        of each allele.
 
     Examples
     --------

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -25,7 +25,7 @@ def count_alleles(ds: Dataset) -> DataArray:
 
     >>> import sgkit as sg
     >>> from sgkit.testing import simulate_genotype_call_dataset
-    >>> ds = simulate_genotype_call_dataset(n_variant=3, n_sample=2, seed=1)
+    >>> ds = simulate_genotype_call_dataset(n_variant=4, n_sample=2, seed=1)
     >>> ds['call/genotype'].to_series().unstack().astype(str).apply('/'.join, axis=1).unstack()
     samples 0   1
     variants
@@ -34,13 +34,11 @@ def count_alleles(ds: Dataset) -> DataArray:
     2       0/1	1/0
     3       0/0	0/0
 
-    >>> sg.allele_count(ds)
-    <xarray.DataArray 'variant/allele_count' (variants: 4, alleles: 2)>
+    >>> sg.count_alleles(ds).values
     array([[2, 2],
-        [1, 3],
-        [2, 2],
-        [4, 0]])
-    Dimensions without coordinates: variants, alleles
+           [1, 3],
+           [2, 2],
+           [4, 0]])
     """
     # Count each allele index individually as a 1D vector and
     # restack into new alleles dimension with same order

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -1,0 +1,55 @@
+import xarray as xr
+from xarray import DataArray, Dataset
+
+
+def allele_count(ds: Dataset) -> DataArray:
+    """Compute allele count from genotype calls
+
+    Parameters
+    ----------
+    ds : Dataset
+        Genotype call dataset such as from
+        `sgkit.create_genotype_call_dataset`
+
+    Examples
+    --------
+
+    >>> import sgkit as sg
+    >>> from sgkit.testing import simulate_genotype_call_dataset
+    >>> ds = simulate_genotype_call_dataset(n_variant=3, n_sample=2, seed=1)
+    # TODO: Should we expose visual convenience functions like this?
+    >>> ds['call/genotype'].to_series().unstack().astype(str).apply('/'.join, axis=1).unstack()
+    samples 0   1
+    variants
+    0       1/0	1/0
+    1       1/0	1/1
+    2       0/1	1/0
+    3       0/0	0/0
+
+    >>> allele_count(ds)
+    <xarray.DataArray 'variant/allele_count' (variants: 4, alleles: 2)>
+    array([[2, 2],
+        [1, 3],
+        [2, 2],
+        [4, 0]])
+    Dimensions without coordinates: variants, alleles
+
+    Returns
+    -------
+    DataArray
+        Allele counts with shape (variants, alleles) and values
+        corresponding to the number of non-missing occurrences
+        of each allele
+    """
+    # Collapse 3D calls into 2D array where calls are flattened into columns
+    gt = ds["call/genotype"].stack(calls=("samples", "ploidy"))
+    mask = ds["call/genotype_mask"].stack(calls=("samples", "ploidy"))
+
+    # Count each allele index individually as a 1D vector and
+    # restack into new alleles dimension with same order
+    acs = [
+        xr.where(mask, 0, gt == i).sum(dim="calls") for i in range(ds.dims["alleles"])
+    ]
+    ac = xr.concat(acs, dim="alleles")
+    ac = ac.T.rename("variant/allele_count")
+    return ac

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -2,7 +2,7 @@ import xarray as xr
 from xarray import DataArray, Dataset
 
 
-def allele_count(ds: Dataset) -> DataArray:
+def count_alleles(ds: Dataset) -> DataArray:
     """Compute allele count from genotype calls.
 
     Parameters
@@ -32,7 +32,7 @@ def allele_count(ds: Dataset) -> DataArray:
     2       0/1	1/0
     3       0/0	0/0
 
-    >>> allele_count(ds)
+    >>> sg.allele_count(ds)
     <xarray.DataArray 'variant/allele_count' (variants: 4, alleles: 2)>
     array([[2, 2],
         [1, 3],

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -11,13 +11,20 @@ def allele_count(ds: Dataset) -> DataArray:
         Genotype call dataset such as from
         `sgkit.create_genotype_call_dataset`
 
+    Returns
+    -------
+    DataArray
+        Allele counts with shape (variants, alleles) and values
+        corresponding to the number of non-missing occurrences
+        of each allele
+
     Examples
     --------
 
     >>> import sgkit as sg
     >>> from sgkit.testing import simulate_genotype_call_dataset
     >>> ds = simulate_genotype_call_dataset(n_variant=3, n_sample=2, seed=1)
-    # TODO: Should we expose visual convenience functions like this?
+    # TODO: Use solution for https://github.com/pystatgen/sgkit/issues/37 here instead
     >>> ds['call/genotype'].to_series().unstack().astype(str).apply('/'.join, axis=1).unstack()
     samples 0   1
     variants
@@ -33,22 +40,13 @@ def allele_count(ds: Dataset) -> DataArray:
         [2, 2],
         [4, 0]])
     Dimensions without coordinates: variants, alleles
-
-    Returns
-    -------
-    DataArray
-        Allele counts with shape (variants, alleles) and values
-        corresponding to the number of non-missing occurrences
-        of each allele
     """
-    # Collapse 3D calls into 2D array where calls are flattened into columns
-    gt = ds["call/genotype"].stack(calls=("samples", "ploidy"))
-    mask = ds["call/genotype_mask"].stack(calls=("samples", "ploidy"))
-
     # Count each allele index individually as a 1D vector and
     # restack into new alleles dimension with same order
+    gt, mask = ds["call/genotype"], ds["call/genotype_mask"]
     acs = [
-        xr.where(mask, 0, gt == i).sum(dim="calls") for i in range(ds.dims["alleles"])
+        xr.where(mask, 0, gt == i).sum(dim=("samples", "ploidy"))
+        for i in range(ds.dims["alleles"])
     ]
     ac = xr.concat(acs, dim="alleles")
     ac = ac.T.rename("variant/allele_count")

--- a/sgkit/testing.py
+++ b/sgkit/testing.py
@@ -13,7 +13,15 @@ def simulate_genotype_call_dataset(
     n_contig: int = 1,
     seed: Optional[int] = None,
 ):
-    """Simulate genotype calls and variant/sample data
+    """Simulate genotype calls and variant/sample data.
+
+    Note that the data simulated by this function has no
+    biological interpretation and that summary statistics
+    or other methods applied to it will produce meaningless
+    results.  This function is primarily a convenience on
+    generating `Dataset` containers so quantities of interest
+    should be overwritten, where appropriate, within the
+    context of a more specific application.
 
     Parameters
     ----------
@@ -33,7 +41,7 @@ def simulate_genotype_call_dataset(
     Returns
     -------
     Dataset
-        Dataset from `sgkit.create_genotype_call_dataset`
+        Dataset from `sgkit.create_genotype_call_dataset`.
     """
     rs = np.random.RandomState(seed=seed)
     call_genotype = rs.randint(

--- a/sgkit/testing.py
+++ b/sgkit/testing.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import numpy as np
+from xarray import Dataset
 
 from .api import create_genotype_call_dataset
 
@@ -12,7 +13,7 @@ def simulate_genotype_call_dataset(
     n_allele: int = 2,
     n_contig: int = 1,
     seed: Optional[int] = None,
-):
+) -> Dataset:
     """Simulate genotype calls and variant/sample data.
 
     Note that the data simulated by this function has no
@@ -31,6 +32,8 @@ def simulate_genotype_call_dataset(
         Number of samples to simulate
     n_ploidy : int
         Number of chromosome copies in each sample
+    n_allele: int
+        Number of alleles to simulate
     n_contig : int, optional
         Number of contigs to partition variants with,
         controlling values in `variant/contig`. Values

--- a/sgkit/testing.py
+++ b/sgkit/testing.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+import numpy as np
+
+from .api import create_genotype_call_dataset
+
+
+def simulate_genotype_call_dataset(
+    n_variant: int,
+    n_sample: int,
+    n_ploidy: int = 2,
+    n_allele: int = 2,
+    n_contig: int = 1,
+    seed: Optional[int] = None,
+):
+    """Simulate genotype calls and variant/sample data
+
+    Parameters
+    ----------
+    n_variant : int
+        Number of variants to simulate
+    n_sample : int
+        Number of samples to simulate
+    n_ploidy : int
+        Number of chromosome copies in each sample
+    n_contig : int, optional
+        Number of contigs to partition variants with,
+        controlling values in `variant/contig`. Values
+        will all be 0 by default with `n_contig` == 1.
+    seed : int, optional
+        Seed for random number generation
+
+    Returns
+    -------
+    Dataset
+        Dataset from `sgkit.create_genotype_call_dataset`
+    """
+    rs = np.random.RandomState(seed=seed)
+    call_genotype = rs.randint(
+        0, n_allele, size=(n_variant, n_sample, n_ploidy), dtype=np.int8
+    )
+    contig_size = np.ceil(n_variant / n_contig).astype(int)
+    contig = np.arange(n_variant) // contig_size
+    contig_names = np.unique(contig)
+    position = np.concatenate([np.arange(contig_size) for i in range(n_contig)])
+    position = position[:n_variant]
+    alleles = rs.choice(["A", "C", "G", "T"], size=(n_variant, n_allele)).astype("S")
+    sample_id = np.array([f"S{i}" for i in range(n_sample)])
+    return create_genotype_call_dataset(
+        variant_contig_names=list(contig_names),
+        variant_contig=contig,
+        variant_position=position,
+        variant_alleles=alleles,
+        sample_id=sample_id,
+        call_genotype=call_genotype,
+    )

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -1,11 +1,15 @@
+from typing import Any
+
 import numpy as np
 import xarray as xr
+from xarray import Dataset
 
-from sgkit.stats.aggregation import allele_count
+from sgkit.stats.aggregation import count_alleles
 from sgkit.testing import simulate_genotype_call_dataset
+from sgkit.typing import ArrayLike
 
 
-def get_dataset(calls, **kwargs):
+def get_dataset(calls: ArrayLike, **kwargs: Any) -> Dataset:
     calls = np.asarray(calls)
     ds = simulate_genotype_call_dataset(
         n_variant=calls.shape[0], n_sample=calls.shape[1], **kwargs
@@ -16,21 +20,23 @@ def get_dataset(calls, **kwargs):
     return ds
 
 
-def test_allele_count():
-    # Single-variant, single-sample case
-    ac = allele_count(get_dataset([[[1, 0]]]))
+def test_count_alleles__single_variant_single_sample():
+    ac = count_alleles(get_dataset([[[1, 0]]]))
     np.testing.assert_equal(ac, np.array([[1, 1]]))
 
-    # Multi-variant, single-sample case
-    ac = allele_count(get_dataset([[[0, 0]], [[0, 1]], [[1, 0]], [[1, 1]]]))
+
+def test_count_alleles__multi_variant_single_sample():
+    ac = count_alleles(get_dataset([[[0, 0]], [[0, 1]], [[1, 0]], [[1, 1]]]))
     np.testing.assert_equal(ac, np.array([[2, 0], [1, 1], [1, 1], [0, 2]]))
 
-    # Single-variant, multi-sample case
-    ac = allele_count(get_dataset([[[0, 0], [1, 0], [0, 1], [1, 1]]]))
+
+def test_count_alleles__single_variant_multi_sample():
+    ac = count_alleles(get_dataset([[[0, 0], [1, 0], [0, 1], [1, 1]]]))
     np.testing.assert_equal(ac, np.array([[4, 4]]))
 
-    # Multi-variant, multi-sample case
-    ac = allele_count(
+
+def test_count_alleles__multi_variant_multi_sample():
+    ac = count_alleles(
         get_dataset(
             [
                 [[0, 0], [0, 0], [0, 0]],
@@ -42,8 +48,9 @@ def test_allele_count():
     )
     np.testing.assert_equal(ac, np.array([[6, 0], [5, 1], [2, 4], [0, 6]]))
 
-    # Missing data
-    ac = allele_count(
+
+def test_count_alleles__missing_data():
+    ac = count_alleles(
         get_dataset(
             [
                 [[-1, -1], [-1, -1], [-1, -1]],
@@ -55,8 +62,9 @@ def test_allele_count():
     )
     np.testing.assert_equal(ac, np.array([[0, 0], [2, 1], [1, 2], [0, 6]]))
 
-    # Higher ploidy / alleles
-    ac = allele_count(
+
+def test_count_alleles__higher_ploidy():
+    ac = count_alleles(
         get_dataset(
             [
                 [[-1, -1, 0], [-1, -1, 1], [-1, -1, 2]],

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -1,0 +1,70 @@
+import numpy as np
+import xarray as xr
+
+from sgkit.stats.aggregation import allele_count
+from sgkit.testing import simulate_genotype_call_dataset
+
+
+def get_dataset(calls, **kwargs):
+    calls = np.asarray(calls)
+    ds = simulate_genotype_call_dataset(
+        n_variant=calls.shape[0], n_sample=calls.shape[1], **kwargs
+    )
+    if calls is not None:
+        dims = ds["call/genotype"].dims
+        ds["call/genotype"] = xr.DataArray(calls, dims=dims)
+        ds["call/genotype_mask"] = xr.DataArray(calls < 0, dims=dims)
+    return ds
+
+
+def test_allele_count():
+    # Single-variant, single-sample case
+    ac = allele_count(get_dataset([[[1, 0]]]))
+    np.testing.assert_equal(ac, np.array([[1, 1]]))
+
+    # Multi-variant, single-sample case
+    ac = allele_count(get_dataset([[[0, 0]], [[0, 1]], [[1, 0]], [[1, 1]]]))
+    np.testing.assert_equal(ac, np.array([[2, 0], [1, 1], [1, 1], [0, 2]]))
+
+    # Single-variant, multi-sample case
+    ac = allele_count(get_dataset([[[0, 0], [1, 0], [0, 1], [1, 1]]]))
+    np.testing.assert_equal(ac, np.array([[4, 4]]))
+
+    # Multi-variant, multi-sample case
+    ac = allele_count(
+        get_dataset(
+            [
+                [[0, 0], [0, 0], [0, 0]],
+                [[0, 0], [0, 0], [0, 1]],
+                [[1, 1], [0, 1], [1, 0]],
+                [[1, 1], [1, 1], [1, 1]],
+            ]
+        )
+    )
+    np.testing.assert_equal(ac, np.array([[6, 0], [5, 1], [2, 4], [0, 6]]))
+
+    # Missing data
+    ac = allele_count(
+        get_dataset(
+            [
+                [[-1, -1], [-1, -1], [-1, -1]],
+                [[-1, -1], [0, 0], [-1, 1]],
+                [[1, 1], [-1, -1], [-1, 0]],
+                [[1, 1], [1, 1], [1, 1]],
+            ]
+        )
+    )
+    np.testing.assert_equal(ac, np.array([[0, 0], [2, 1], [1, 2], [0, 6]]))
+
+    # Higher ploidy / alleles
+    ac = allele_count(
+        get_dataset(
+            [
+                [[-1, -1, 0], [-1, -1, 1], [-1, -1, 2]],
+                [[0, 1, 2], [1, 2, 3], [-1, -1, -1]],
+            ],
+            n_allele=4,
+            n_ploidy=3,
+        )
+    )
+    np.testing.assert_equal(ac, np.array([[1, 1, 1, 0], [1, 2, 2, 1]]))

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -10,10 +10,9 @@ def get_dataset(calls, **kwargs):
     ds = simulate_genotype_call_dataset(
         n_variant=calls.shape[0], n_sample=calls.shape[1], **kwargs
     )
-    if calls is not None:
-        dims = ds["call/genotype"].dims
-        ds["call/genotype"] = xr.DataArray(calls, dims=dims)
-        ds["call/genotype_mask"] = xr.DataArray(calls < 0, dims=dims)
+    dims = ds["call/genotype"].dims
+    ds["call/genotype"] = xr.DataArray(calls, dims=dims)
+    ds["call/genotype_mask"] = xr.DataArray(calls < 0, dims=dims)
     return ds
 
 


### PR DESCRIPTION
This is an implementation for https://github.com/pystatgen/sgkit/issues/3. 

A few notes/questions:

- I was initially going to parameterize these tests across all array backends, and possibly mixtures of them.  I decided not to though because it doesn't seem like this is the right level to be validating ufunc reduce implementations that Xarray is ultimately dispatching to.  A convention I'd like to propose is that we don't write tests for multiple backends unless we're writing code that makes special accommodations for them (you'd need to to get 100% coverage anyhow).  I don't feel very strongly about that though so let me know what you guys think.
- We definitely need a convenient way to generate Dataset instances given that they'll often be the sole input to functions.  I put a method for this in `sgkit/testing.py`, but I'm happy to move that around.  I also think at least one simple function like [simulate_genotype_call_dataset](https://github.com/eric-czech/sgkit/blob/allele_count/sgkit/testing.py#L8) should probably be a part of the public API.  It's hard to write examples/tests without it.
- I put the function in `sgkit/stats/aggregation.py` under the assumption that a lot of similarly simple axis-wise aggregation functions will eventually make sense in the same location.