### PR TITLE
Extend GWAS linear regression for multiple phenotypes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: pre-commit/action@v2.0.0
     - name: Test with pytest and coverage
       run: |
-        pytest -v --cov=sgkit --cov-report term-missing
+        pytest -v --cov=sgkit --cov-report=term-missing
     - name: Upload coverage to Codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/sgkit/stats/association.py
+++ b/sgkit/stats/association.py
@@ -216,9 +216,9 @@ def gwas_linear_regression(
             P values as float in [0, 1]
     """
     G = _get_loop_covariates(ds, dosage=dosage)
-    Z = _get_core_covariates(ds, covariates, add_intercept=add_intercept)
+    X = _get_core_covariates(ds, covariates, add_intercept=add_intercept)
     Y = _get_outcomes(ds, traits)
-    res = linear_regression(G.T, Z, Y)
+    res = linear_regression(G.T, X, Y)
     return xr.Dataset(
         {
             "variant/beta": (("variants", "traits"), res.beta),

--- a/sgkit/stats/association.py
+++ b/sgkit/stats/association.py
@@ -162,15 +162,6 @@ def gwas_linear_regression(
     rotation is that effect sizes and significances cannot be reported for
     covariates, only variants.
 
-    Warning: Regression statistics from this implementation are only valid when an
-    intercept is present. The `add_intercept` flag is a convenience for adding one
-    when not already present, but there is currently no parameterization for
-    intercept-free regression.
-
-    Warning: Both covariate and trait arrays will be rechunked to have blocks
-    along the sample (row) dimension but not the column dimension (i.e.
-    they must be tall and skinny).
-
     Parameters
     ----------
     ds : Dataset
@@ -193,6 +184,17 @@ def gwas_linear_regression(
         and concatenated to any 1D traits along the second axis (columns).
     add_intercept : bool, optional
         Add intercept term to covariate set, by default True
+
+    Warnings
+    --------
+    Regression statistics from this implementation are only valid when an
+    intercept is present. The `add_intercept` flag is a convenience for adding one
+    when not already present, but there is currently no parameterization for
+    intercept-free regression.
+
+    Additionally, both covariate and trait arrays will be rechunked to have blocks
+    along the sample (row) dimension but not the column dimension (i.e.
+    they must be tall and skinny).
 
     References
     ----------

--- a/sgkit/tests/test_association.py
+++ b/sgkit/tests/test_association.py
@@ -118,7 +118,7 @@ def _get_statistics(
         dsr = gwas_linear_regression(
             ds,
             dosage="dosage",
-            trait=f"trait_{i}",
+            traits=[f"trait_{i}"],
             add_intercept=add_intercept,
             **kwargs,
         )
@@ -165,5 +165,5 @@ def test_linear_regression_statistics(ds):
 def test_linear_regression_raise_on_no_covars(ds):
     with pytest.raises(ValueError, match="At least one covariate must be provided"):
         gwas_linear_regression(
-            ds, covariates=[], dosage="dosage", trait="trait_0", add_intercept=False
+            ds, covariates=[], dosage="dosage", traits=["trait_0"], add_intercept=False
         )

--- a/sgkit/tests/test_association.py
+++ b/sgkit/tests/test_association.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -8,7 +8,7 @@ import xarray as xr
 from pandas import DataFrame
 from xarray import Dataset
 
-from sgkit.stats.association import gwas_linear_regression
+from sgkit.stats.association import gwas_linear_regression, linear_regression
 from sgkit.typing import ArrayLike
 
 with warnings.catch_warnings():
@@ -79,12 +79,16 @@ def _generate_test_data(
 def _generate_test_dataset(**kwargs: Any) -> Dataset:
     g, x, bg, ys = _generate_test_data(**kwargs)
     data_vars = {}
-    data_vars["dosage"] = (["variant", "sample"], g.T)
+    data_vars["dosage"] = (["variants", "samples"], g.T)
     for i in range(x.shape[1]):
-        data_vars[f"covar_{i}"] = (["sample"], x[:, i])
-    for i in range(len(ys)):
-        data_vars[f"trait_{i}"] = (["sample"], ys[i])
-    attrs = dict(beta=bg)
+        data_vars[f"covar_{i}"] = (["samples"], x[:, i])
+    for i in range(ys.shape[0]):
+        # Traits are NOT multivariate simulations based on
+        # values of multiple variants; they instead correspond
+        # 1:1 with variants such that variant i has no causal
+        # relationship with trait j where i != j
+        data_vars[f"trait_{i}"] = (["samples"], ys[i])
+    attrs = dict(beta=bg, n_trait=ys.shape[0], n_covar=x.shape[1])
     return xr.Dataset(data_vars, attrs=attrs)  # type: ignore[arg-type]
 
 
@@ -102,7 +106,7 @@ def _sm_statistics(
     for v in [c for c in list(ds.keys()) if c.startswith("covar_")]:
         X.append(ds[v].values)
     if add_intercept:
-        X.append(np.ones(ds.dims["sample"]))
+        X.append(np.ones(ds.dims["samples"]))
     X = np.stack(X).T
     y = ds[f"trait_{i}"].values
 
@@ -114,7 +118,7 @@ def _get_statistics(
 ) -> Tuple[DataFrame, DataFrame]:
     df_pred: List[Dict[str, Any]] = []
     df_true: List[Dict[str, Any]] = []
-    for i in range(ds.dims["variant"]):
+    for i in range(ds.dims["variants"]):
         dsr = gwas_linear_regression(
             ds,
             dosage="dosage",
@@ -129,19 +133,20 @@ def _get_statistics(
             .iloc[i]
             .to_dict()
         )
+        # First result in satsmodels RegressionResultsWrapper for
+        # [t|p]values will correspond to variant (not covariate/intercept)
         df_true.append(dict(t_value=res.tvalues[0], p_value=res.pvalues[0]))
     return pd.DataFrame(df_pred), pd.DataFrame(df_true)
 
 
-def test_linear_regression_statistics(ds):
+def test_gwas_linear_regression__validate_statistics(ds):
+    # Validate regression statistics against statsmodels for
+    # exact equality (within floating point tolerance)
     def validate(dfp: DataFrame, dft: DataFrame) -> None:
-        print(dfp)
-        print(dft)
-
         # Validate results at a higher level, looking only for recapitulation
         # of more obvious inferences based on how the data was simulated
         np.testing.assert_allclose(dfp["beta"], ds.attrs["beta"], atol=1e-3)
-        mid_idx = ds.dims["variant"] // 2
+        mid_idx = ds.dims["variants"] // 2
         assert np.all(dfp["p_value"].iloc[:mid_idx] > 0.05)
         assert np.all(dfp["p_value"].iloc[mid_idx:] < 0.05)
 
@@ -155,15 +160,90 @@ def test_linear_regression_statistics(ds):
     validate(dfp, dft)
 
     dfp, dft = _get_statistics(
-        ds.assign(covar_3=("sample", np.ones(ds.dims["sample"]))),
+        ds.assign(covar_3=("samples", np.ones(ds.dims["samples"]))),
         covariates=["covar_0", "covar_1", "covar_2", "covar_3"],
         add_intercept=False,
     )
     validate(dfp, dft)
 
 
-def test_linear_regression_raise_on_no_covars(ds):
+def test_gwas_linear_regression__multi_trait(ds):
+    def run(traits: Sequence[str]) -> Dataset:
+        return gwas_linear_regression(
+            ds,
+            dosage="dosage",
+            covariates=["covar_0"],
+            traits=traits,
+            add_intercept=True,
+        )
+
+    traits = [f"trait_{i}" for i in range(ds.attrs["n_trait"])]
+    # Run regressions on individual traits and concatenate resulting statistics
+    dfr_single = xr.concat([run([t]) for t in traits], dim="traits").to_dataframe()  # type: ignore[no-untyped-call]
+    # Run regressions on all traits simulatenously
+    dfr_multi: DataFrame = run(traits).to_dataframe()  # type: ignore[no-untyped-call]
+    pd.testing.assert_frame_equal(dfr_single, dfr_multi)
+
+
+def test_gwas_linear_regression__raise_on_no_covars(ds):
     with pytest.raises(ValueError, match="At least one covariate must be provided"):
         gwas_linear_regression(
             ds, covariates=[], dosage="dosage", traits=["trait_0"], add_intercept=False
         )
+
+
+def test_gwas_linear_regression__raise_on_no_traits(ds):
+    with pytest.raises(ValueError, match="At least one trait must be provided"):
+        gwas_linear_regression(
+            ds, covariates=["covar_0"], dosage="dosage", traits=[], add_intercept=False
+        )
+
+
+def test_gwas_linear_regression__raise_on_non_2D_covar(ds):
+    with pytest.raises(
+        ValueError, match="All covariate arrays must have <= 2 dimensions"
+    ):
+        covar = np.ones((ds.dims["samples"], 1, 1))
+        ds = ds.assign(
+            covar=xr.DataArray(covar, dims=("samples", "covars", "extra_for_error"))
+        )
+        gwas_linear_regression(
+            ds,
+            covariates=["covar"],
+            dosage="dosage",
+            traits=["trait_0"],
+            add_intercept=False,
+        )
+
+
+def test_gwas_linear_regression__raise_on_non_2D_trait(ds):
+    with pytest.raises(ValueError, match="All trait arrays must have <= 2 dimensions"):
+        trait = np.ones((ds.dims["samples"], 1, 1))
+        ds = ds.assign(
+            trait=xr.DataArray(trait, dims=("samples", "traits", "extra_for_error"))
+        )
+        gwas_linear_regression(
+            ds,
+            covariates=["covar_0"],
+            dosage="dosage",
+            traits=["trait"],
+            add_intercept=False,
+        )
+
+
+def test_linear_regression__raise_on_non_2D():
+    XL = np.ones((10, 5, 1))  # Add 3rd dimension
+    XC = np.ones((10, 5))
+    Y = np.ones((10, 3))
+    with pytest.raises(ValueError, match="All arguments must be 2D"):
+        linear_regression(XL, XC, Y)
+
+
+def test_linear_regression__raise_on_dof_lte_0():
+    # Sample count too low relative to core covariate will cause
+    # degrees of freedom to be zero
+    XL = np.ones((2, 10))
+    XC = np.ones((2, 5))
+    Y = np.ones((2, 3))
+    with pytest.raises(ValueError, match=r"Number of observations \(N\) too small"):
+        linear_regression(XL, XC, Y)


### PR DESCRIPTION
This PR contains some fairly minor adjustments/improvements to https://github.com/pystatgen/sgkit/pull/16 that allow for regression against multiple phenotypes.  Changes made:

- Shifts outcomes into batch dimensions of the algebra functions
- Makes the internal `linear_regression` function no longer hidden so that it can be used in other modules such as https://github.com/pystatgen/sgkit/issues/50
- Allows for covariates and traits to be specified as any combination of 1 or 2D data variables, all of which are concatenated column-wise
- Forces covariates and outcomes to be chunked along the variant dimension only, i.e. this won't scale to giant (100k+) numbers of either of those things
- Introduces a convention where all Dask operations are followed immediately by assertions on shape (and chunk structure if an algorithm explicitly manipulates blocks).  I like this more for the sake of reading the code than anything else, b/c dimension size constants w/ informative names make it clear what the arrays contain.  The extra safety is great too.  Eventually, it would be nice to have a set of assertion utilities that would spit out more informative errors than these currently would.