### PR TITLE
Initial proposal for CLI plugin system.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click
 numpy
 xarray
 dask[array]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,10 @@ install_requires =
 setup_requires =
     setuptools >= 41.2
     setuptools_scm
+
+[options.entry_points]
+console_scripts =
+    sgkit = sgkit.cli:skgit_main
     
 [coverage:report]
 fail_under = 100

--- a/sgkit/__main__.py
+++ b/sgkit/__main__.py
@@ -1,0 +1,4 @@
+from . import cli
+
+if __name__ == "__main__":
+    cli.sgkit_main()

--- a/sgkit/__main__.py
+++ b/sgkit/__main__.py
@@ -1,4 +1,3 @@
 from . import cli
 
-if __name__ == "__main__":
-    cli.sgkit_main()
+cli.main()

--- a/sgkit/cli.py
+++ b/sgkit/cli.py
@@ -1,0 +1,166 @@
+"""
+Command line utilities.
+"""
+import argparse
+import os
+import pathlib
+import signal
+import sys
+
+import xarray as xr
+from dask.diagnostics import ProgressBar
+
+format_plugins = []
+
+
+# TODO should we use attrs for this sort of stuff?
+class FormatPlugin:
+    """
+    Encapsulates the necessary information for a format plugin to be
+    used in sgkit.
+    """
+
+    def __init__(
+        self,
+        format_name,
+        import_func=None,
+        import_args=None,
+        export_func=None,
+        export_args=None,
+        sniff_func=None,
+    ):
+        self.format_name = format_name
+        self.import_func = import_func
+        self.import_args = import_args
+        self.export_func = export_func
+        self.export_args = export_args
+        self.sniff_func = sniff_func
+
+
+try:
+    import sgkit_plink  # NOQA
+
+    # TODO if we agree on this interface, then the data format module
+    # would agree to implement a function that returns this information,
+    # so we'd do something like:
+    # format_plugins.append(sgkit_plink.get_format_plugin())
+
+    # For now:
+    format_plugins.append(
+        FormatPlugin(
+            format_name="plink",
+            import_func=sgkit_plink.read_plink,
+            import_args=[
+                # TODO we'd have another simple dataclass for this.
+                ("bim_sep", "\t", "Separator used when parsing BIM files"),
+                ("fam_sep", "\t", "Separator used when parsing FAM files"),
+            ],
+        )
+    )
+
+except ImportError:
+    # TODO logging.info("plink module not found")
+    pass
+
+# from . import read_plink
+
+
+def set_sigpipe_handler():
+    if os.name == "posix":
+        # Set signal handler for SIGPIPE to quietly kill the program.
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+
+# This function is useful when we're testing as it avoids mocking
+# sys.exit, which can be tricky.
+def sys_exit(message):
+    sys.exit(message)
+
+
+def load_dataset(path):
+    """
+    Attempt to load an sgkit dataset from the specified path, or
+    fail with a meaningful error message.
+    """
+    # We need to do this because the xr.open_zarr function doesn't
+    # give very good error messages.
+    path = pathlib.Path(path)
+    if not path.exists():
+        sys_exit(f"Path {path} does not exist")
+    try:
+        # We need to convert back to a string because xarray doesn't
+        # support pathlib.
+        return xr.open_zarr(str(path))
+    except ValueError as ve:
+        sys_exit(f"Error opening dataset {path}: {ve}")
+
+
+def run_list(args):
+    ds = load_dataset(args.sgkit_dataset)
+    # TODO do something more sophisticated.
+    print(ds)
+
+
+def add_import_command(subparsers, plugin):
+
+    parser = subparsers.add_parser(
+        f"import-{plugin.format_name}",
+        help=f"Convert data in {plugin.format_name} to sgkit",
+    )
+    parser.add_argument("input", help="The input data in {plugin.format_name} format")
+    parser.add_argument("output", help="The path to store the converted dataset")
+    for name, default, help_text in plugin.import_args:
+        # TODO might be nice to define short args form as well.
+        parser.add_argument(f"--{name}", default=default, help=help_text)
+
+    def run(args):
+
+        # TODO progress bar here - there will be formats where this
+        # is a lot of work.
+        # Yah, we need a dataclass for args all right, this is horrible!
+        import_args = {name: getattr(args, name) for name, _, _ in plugin.import_args}
+        ds = plugin.import_func(args.input, **import_args)
+        # TODO progress bar here
+        ds.to_zarr(args.output, mode="w")
+
+    parser.set_defaults(runner=run)
+
+
+def add_sgkit_dataset_argument(parser):
+    parser.add_argument("sgkit_dataset", help="The path for an sgkit dataset")
+
+
+def add_list_arguments(parser):
+    add_sgkit_dataset_argument(parser)
+    # TODO add arguments like --long, --human, etc.
+
+
+def get_sgkit_parser():
+    top_parser = argparse.ArgumentParser(
+        description=("Utilities for manipulating sgkit datasets")
+    )
+    subparsers = top_parser.add_subparsers(dest="subcommand")
+    subparsers.required = True
+
+    parser = subparsers.add_parser(
+        "list", aliases=["ls"], help="List the arrays stored in a dataset"
+    )
+    parser.set_defaults(runner=run_list)
+    add_list_arguments(parser)
+
+    for plugin in format_plugins:
+        if plugin.import_func is not None:
+            add_import_command(subparsers, plugin)
+        # Similarly for export
+
+    return top_parser
+
+
+def sgkit_main(arg_list=None):
+    """
+    Top-level hook called when running python -m sgkit.
+    """
+    parser = get_sgkit_parser()
+    set_sigpipe_handler()
+    args = parser.parse_args(arg_list)
+    args.runner(args)

--- a/sgkit/cli.py
+++ b/sgkit/cli.py
@@ -1,48 +1,66 @@
 """
 Command line utilities.
 """
-import argparse
 import os
 import functools
 import pathlib
 import signal
 import sys
+from dataclasses import dataclass
+from typing import List
 
+import click
 import xarray as xr
 from dask.diagnostics import ProgressBar
 
-format_plugins = []
 
-
+@dataclass
 class PluginOption:
-    def __init__(self, name, default, help_text):
-        self.name = name
-        self.default = default
-        self.help_text = help_text
+    """
+    An option that we pass to a format plugin function.
+
+    NOTE: We could probably we us a click.Option for this although
+    that does mean the format repos will need to import click also.
+    Probably not a big deal, in reality, and it would save us
+    inventing this wheel.
+    """
+
+    name: str
+    # TODO default probably isn't always a str
+    default: str
+    help_text: str
 
 
-# TODO should we use attrs for this sort of stuff?
+@dataclass
 class FormatPlugin:
     """
     Encapsulates the necessary information for a format plugin to be
     used in sgkit.
     """
 
-    def __init__(
-        self,
-        format_name,
-        import_func=None,
-        import_args=None,
-        export_func=None,
-        export_args=None,
-        sniff_func=None,
-    ):
-        self.format_name = format_name
-        self.import_func = import_func
-        self.import_args = import_args
-        self.export_func = export_func
-        self.export_args = export_args
-        self.sniff_func = sniff_func
+    format_name: str
+    import_func: callable
+    import_args: List[PluginOption]
+    export_func: callable = None
+    export_args: List[PluginOption] = None
+    sniff_func: callable = None
+
+
+format_plugins = []
+# Map CLI command names to the corresponding plugin
+import_plugin_map = {}
+export_plugin_map = {}
+
+
+def register_format_plugin(plugin):
+    """
+    Registers the specified format plugin for use with the CLI.
+    """
+    format_plugins.append(plugin)
+    if plugin.import_func is not None:
+        import_plugin_map[f"import-{plugin.format_name}"] = plugin
+    if plugin.export_func is not None:
+        export_plugin_map[f"export-{plugin.format_name}"] = plugin
 
 
 try:
@@ -51,10 +69,10 @@ try:
     # TODO if we agree on this interface, then the data format module
     # would agree to implement a function that returns this information,
     # so we'd do something like:
-    # format_plugins.append(sgkit_plink.get_format_plugin())
+    # register_format_plugin(sgkit_plink.get_format_plugin())
 
     # For now:
-    format_plugins.append(
+    register_format_plugin(
         FormatPlugin(
             format_name="plink",
             import_func=sgkit_plink.read_plink,
@@ -70,113 +88,75 @@ except ImportError:
     pass
 
 
-def set_sigpipe_handler():
-    if os.name == "posix":
-        # Set signal handler for SIGPIPE to quietly kill the program.
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
-
-# This function is useful when we're testing as it avoids mocking
-# sys.exit, which can be tricky.
-def sys_exit(message):
-    sys.exit(message)
-
-
 def load_dataset(path):
     """
     Attempt to load an sgkit dataset from the specified path, or
     fail with a meaningful error message.
     """
-    # We need to do this because the xr.open_zarr function doesn't
-    # give very good error messages.
-    path = pathlib.Path(path)
-    if not path.exists():
-        sys_exit(f"Path {path} does not exist")
     try:
-        # We need to convert back to a string because xarray doesn't
-        # support pathlib.
-        return xr.open_zarr(str(path))
+        return xr.open_zarr(path)
     except ValueError as ve:
-        sys_exit(f"Error opening dataset {path}: {ve}")
+        raise click.ClickException(str(ve))
 
 
-def run_list(args):
-    ds = load_dataset(args.sgkit_dataset)
-    # TODO do something more sophisticated.
-    print(ds)
+def run_import(import_func, input_path, output_path, **import_args):
 
-
-def run_import(plugin, args):
-    import_args = {
-        option.name: getattr(args, option.name) for option in plugin.import_args
-    }
     # TODO progress bar here - there will be formats where this
-    # is a lot of work.
-    ds = plugin.import_func(args.input, **import_args)
+    # is a lot of work. We should really return a dask future
+    # or something which will allow us to control the execution.
+    ds = import_func(input_path, **import_args)
 
-    # We want to be able to have different types of store,
-    # but it looks like this doesn't work, as zarr doesn't
-    # have some of the functionality we'd need.
-    # store = zarr.ZipStore(args.output, mode="w")
-    # store = zarr.DirectoryStore(args.output, mode="w")
-
+    # TODO can we use a click progress bar instead?
     with ProgressBar():
         # We can call this with a pre-created zarr store, which
         # would give us a lot of flexibility.
-        ds.to_zarr(args.output, mode="w")
+        ds.to_zarr(output_path, mode="w")
 
 
-def add_import_command(subparsers, plugin):
+class ImportCommands(click.MultiCommand):
+    def list_commands(self, ctx):
+        return import_plugin_map.keys()
 
-    parser = subparsers.add_parser(
-        f"import-{plugin.format_name}",
-        help=f"Convert data in {plugin.format_name} to sgkit",
-    )
-    parser.add_argument("input", help=f"The input data in {plugin.format_name} format")
-    parser.add_argument("output", help="The path to store the converted dataset")
-    for option in plugin.import_args:
-        # TODO might be nice to define short args form as well.
-        parser.add_argument(
-            f"--{option.name}", default=option.default, help=option.help_text
+    def get_command(self, ctx, name):
+        # TODO this is fragile when we call an unknown command.
+        plugin = import_plugin_map[name]
+        params = [
+            click.Argument(["input-path"], required=True),
+            click.Argument(["output-path"], required=True),
+        ]
+        # TODO add common import options - zarr defails
+        for option in plugin.import_args:
+            params.append(
+                click.Option(
+                    [f"--{option.name}"], default=option.default, help=option.help_text
+                )
+            )
+        command = click.Command(
+            name=name,
+            params=params,
+            callback=functools.partial(run_import, plugin.import_func),
         )
-    parser.set_defaults(runner=functools.partial(run_import, plugin))
+        return command
 
 
-def add_sgkit_dataset_argument(parser):
-    parser.add_argument("sgkit_dataset", help="The path for an sgkit dataset")
+# The command group for all the miscellaneous commands that are not
+# related to import and export.
+@click.group()
+def misc_main():
+    pass
 
 
-def add_list_arguments(parser):
-    add_sgkit_dataset_argument(parser)
-    # TODO add arguments like --long, --human, etc.
+@click.command()
+@click.argument("path", type=click.Path(exists=True))
+def ls(path):
+    ds = load_dataset(path)
+    # TODO do something more sophisticated.
+    click.echo(ds)
 
 
-def get_sgkit_parser():
-    top_parser = argparse.ArgumentParser(
-        description=("Utilities for manipulating sgkit datasets")
-    )
-    subparsers = top_parser.add_subparsers(dest="subcommand")
-    subparsers.required = True
+misc_main.add_command(ls)
 
-    parser = subparsers.add_parser(
-        "list", aliases=["ls"], help="List the arrays stored in a dataset"
-    )
-    parser.set_defaults(runner=run_list)
-    add_list_arguments(parser)
+main = click.CommandCollection(sources=[misc_main, ImportCommands()])
 
-    for plugin in format_plugins:
-        if plugin.import_func is not None:
-            add_import_command(subparsers, plugin)
-        # Similarly for export
-
-    return top_parser
-
-
-def sgkit_main(arg_list=None):
-    """
-    Top-level hook called when running python -m sgkit.
-    """
-    parser = get_sgkit_parser()
-    set_sigpipe_handler()
-    args = parser.parse_args(arg_list)
-    args.runner(args)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Following on from https://github.com/pystatgen/sgkit-plink/pull/8 and addressing #53, here's an initial proposal for how the plugin system might work.

So, basically sgkit needs to know about all the plugins it might support, but only loads the ones that are installed. I've included a ``sniffer`` function here, as this should then allow us to implement the generic ``sgkit import`` command.

With this, we get
```
$ python3 -m sgkit  --help
usage: __main__.py [-h] {list,ls,import-plink} ...

Utilities for manipulating sgkit datasets

positional arguments:
  {list,ls,import-plink}
    list (ls)           List the arrays stored in a dataset
    import-plink        Convert data in plink to sgkit

optional arguments:
  -h, --help            show this help message and exit
```
and 
```
$ python3 -m sgkit import-plink --help
usage: __main__.py import-plink [-h] [--bim_sep BIM_SEP] [--fam_sep FAM_SEP]
                                input output

positional arguments:
  input              The input data in {plugin.format_name} format
  output             The path to store the converted dataset

optional arguments:
  -h, --help         show this help message and exit
  --bim_sep BIM_SEP  Separator used when parsing BIM files
  --fam_sep FAM_SEP  Separator used when parsing FAM files
```

It's not ideal, but seems like a reasonable compromise setup?