### PR TITLE
Display genotypes function

### DIFF
--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -5,6 +5,7 @@ from .api import (  # noqa: F401
     DIM_VARIANT,
     create_genotype_call_dataset,
     create_genotype_dosage_dataset,
+    display_genotypes,
 )
 from .stats.aggregation import count_alleles
 from .stats.association import gwas_linear_regression
@@ -17,5 +18,6 @@ __all__ = [
     "create_genotype_call_dataset",
     "count_alleles",
     "create_genotype_dosage_dataset",
+    "display_genotypes",
     "gwas_linear_regression",
 ]

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -5,8 +5,8 @@ from .api import (  # noqa: F401
     DIM_VARIANT,
     create_genotype_call_dataset,
     create_genotype_dosage_dataset,
-    display_genotypes,
 )
+from .display import display_genotypes
 from .stats.aggregation import count_alleles
 from .stats.association import gwas_linear_regression
 

--- a/sgkit/api.py
+++ b/sgkit/api.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Hashable, List
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from .utils import check_array_like
@@ -136,3 +137,53 @@ def create_genotype_dosage_dataset(
         data_vars["variant_id"] = ([DIM_VARIANT], variant_id)
     attrs: Dict[Hashable, Any] = {"contigs": variant_contig_names}
     return xr.Dataset(data_vars=data_vars, attrs=attrs)
+
+
+class GenotypeDisplay:
+    """
+    A printable object to display genotype information.
+    """
+
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+
+    def __repr__(self) -> Any:
+        return self.df.__repr__()
+
+    def _repr_html_(self) -> Any:
+        return self.df._repr_html_()
+
+
+def display_genotypes(ds: xr.Dataset) -> GenotypeDisplay:
+    """Display genotype calls.
+
+    Display genotype calls in a tabular format, with rows for variants,
+    and columns for samples. Genotypes are displayed in the same manner
+    as in VCF. For example, `1/0` is a diploid call of the first alternate
+    allele and the reference allele (0). Phased calls are denoted by a `|`
+    separator. Missing values are denoted by `.`.
+
+    Parameters
+    ----------
+    ds : Dataset
+        The dataset containing genotype calls in the `call/genotype`
+        variable, and (optionally) phasing information in the
+        `call/genotype_phased` variable. If no phasing information is
+        present genotypes are assumed to be unphased.
+
+    Returns
+    -------
+    GenotypeDisplay
+        A printable object to display genotype information.
+    """
+    calls = ds["call/genotype"].to_series().unstack().astype(str)
+    missing = ds["call/genotype_mask"].to_series().unstack()
+    calls[missing] = "."
+    df = calls.apply("/".join, axis=1).unstack()
+
+    if "call/genotype_phased" in ds:
+        is_phased = ds["call/genotype_phased"].to_series().unstack()
+        df_phased = calls.apply("|".join, axis=1).unstack()
+        df[is_phased] = df_phased
+
+    return GenotypeDisplay(df)

--- a/sgkit/display.py
+++ b/sgkit/display.py
@@ -1,0 +1,192 @@
+from typing import Any, Tuple
+
+import pandas as pd
+import xarray as xr
+
+from .typing import ArrayLike
+
+
+class GenotypeDisplay:
+    """
+    A printable object to display genotype information.
+    """
+
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        shape: Tuple[int, int],
+        max_variants: int,
+        max_samples: int,
+    ):
+        self.df = df
+        self.shape = shape
+        self.max_variants = max_variants
+        self.max_samples = max_samples
+        self.pd_options = [
+            "display.max_rows",
+            self.max_variants,
+            "display.min_rows",
+            self.max_variants,
+            "display.max_columns",
+            self.max_samples,
+            "display.show_dimensions",
+            False,
+        ]
+
+    def __repr__(self) -> Any:
+        with pd.option_context(*self.pd_options):
+            if (
+                len(self.df) > self.max_variants
+                or len(self.df.columns) > self.max_samples
+            ):
+                return (
+                    self.df.__repr__()
+                    + f"\n\n[{self.shape[0]} rows x {self.shape[1]} columns]"
+                )
+            return self.df.__repr__()
+
+    def _repr_html_(self) -> Any:
+        with pd.option_context(*self.pd_options):
+            if (
+                len(self.df) > self.max_variants
+                or len(self.df.columns) > self.max_samples
+            ):
+                return self.df._repr_html_().replace(
+                    "</div>",
+                    f"<p>{self.shape[0]} rows x {self.shape[1]} columns</p></div>",
+                )
+            return self.df._repr_html_()
+
+
+def _truncate(
+    arr: xr.DataArray,
+    variants: xr.DataArray,
+    samples: xr.DataArray,
+    max_variants: int,
+    max_samples: int,
+) -> xr.DataArray:
+    """Truncate the given array so it is of size (at most) `(max_variants + 1, max_samples + 1)`.
+
+    The reason the size may exceed `(max_variants, max_samples)` is so that pandas can be used to
+    display the array as a table, and correctly truncate rows or columns (shown as ellipses ...).
+    """
+
+    n_variant = arr.sizes["variants"]
+    n_sample = arr.sizes["samples"]
+
+    if n_variant <= max_variants:
+        # slice in half and recombine below
+        v_slice_0 = slice(0, n_variant // 2)
+        v_slice_1 = slice(n_variant // 2, n_variant)
+    else:
+        v_slice_0 = slice(0, max_variants // 2 + 1)
+        v_slice_1 = slice(n_variant - max_variants // 2, n_variant)
+
+    if n_sample <= max_samples:
+        # slice in half and recombine below
+        s_slice_0 = slice(0, n_sample // 2)
+        s_slice_1 = slice(n_sample // 2, n_sample)
+    else:
+        s_slice_0 = slice(0, max_samples // 2 + 1)
+        s_slice_1 = slice(n_sample - max_samples // 2, n_sample)
+
+    grid = [
+        [
+            arr.isel(variants=v_slice_0, samples=s_slice_0),
+            arr.isel(variants=v_slice_0, samples=s_slice_1),
+        ],
+        [
+            arr.isel(variants=v_slice_1, samples=s_slice_0),
+            arr.isel(variants=v_slice_1, samples=s_slice_1),
+        ],
+    ]
+    combined: xr.DataArray = xr.combine_nested(grid, concat_dim=["variants", "samples"])  # type: ignore[no-untyped-call]
+
+    variants_subset: xr.DataArray = xr.combine_nested([variants.isel(variants=v_slice_0), variants.isel(variants=v_slice_1)], concat_dim=["variants"])  # type: ignore[no-untyped-call]
+    samples_subset: xr.DataArray = xr.combine_nested([samples.isel(samples=s_slice_0), samples.isel(samples=s_slice_1)], concat_dim=["samples"])  # type: ignore[no-untyped-call]
+    combined = combined.assign_coords(variants=variants_subset)  # type: ignore[no-untyped-call]
+    combined = combined.assign_coords(samples=samples_subset)  # type: ignore[no-untyped-call]
+
+    assert combined.shape[0] <= max_variants + 1
+    assert combined.shape[1] <= max_samples + 1
+
+    return combined
+
+
+def display_genotypes(
+    ds: xr.Dataset, max_variants: int = 60, max_samples: int = 10
+) -> GenotypeDisplay:
+    """Display genotype calls.
+
+    Display genotype calls in a tabular format, with rows for variants,
+    and columns for samples. Genotypes are displayed in the same manner
+    as in VCF. For example, `1/0` is a diploid call of the first alternate
+    allele and the reference allele (0). Phased calls are denoted by a `|`
+    separator. Missing values are denoted by `.`.
+
+    Parameters
+    ----------
+    ds : Dataset
+        The dataset containing genotype calls in the `call/genotype`
+        variable, and (optionally) phasing information in the
+        `call/genotype_phased` variable. If no phasing information is
+        present genotypes are assumed to be unphased.
+    max_variants : int
+        The maximum number of variants (rows) to display. If there are
+        more variants than this then the table is truncated.
+    max_samples : int
+        The maximum number of samples (columns) to display. If there are
+        more samples than this then the table is truncated.
+
+    Returns
+    -------
+    GenotypeDisplay
+        A printable object to display genotype information.
+    """
+
+    variants = ds["variant_id"] if "variant_id" in ds else ds["variant_position"]
+
+    gt = _truncate(
+        ds["call_genotype"], variants, ds["sample_id"], max_variants, max_samples
+    ).astype(str)
+    missing = _truncate(
+        ds["call_genotype_mask"], variants, ds["sample_id"], max_variants, max_samples
+    )
+    calls = xr.where(missing, ".", gt)  # type: ignore[no-untyped-call]
+
+    def make_unphased_genotype(x: ArrayLike) -> str:
+        return "/".join(map(str, x))
+
+    arr = xr.apply_ufunc(
+        make_unphased_genotype, calls, input_core_dims=[["ploidy"]], vectorize=True
+    )
+
+    if "call_genotype_phased" in ds:
+
+        def make_phased_genotype(x: ArrayLike) -> str:
+            return "|".join(map(str, x))
+
+        arr_phased = xr.apply_ufunc(
+            make_phased_genotype, calls, input_core_dims=[["ploidy"]], vectorize=True
+        )
+
+        is_phased = _truncate(
+            ds["call_genotype_phased"],
+            variants,
+            ds["sample_id"],
+            max_variants,
+            max_samples,
+        )
+        arr = xr.where(is_phased, arr_phased, arr)  # type: ignore[no-untyped-call]
+
+    df_stacked = arr.to_series()
+    df = df_stacked.unstack()
+    # Reset the index so that column names are in the original order (not sorted)
+    # https://stackoverflow.com/questions/17156662/pandas-dataframe-unstack-changes-order-of-row-and-column-headers
+    df = df.reindex(df_stacked.index.get_level_values(1).unique(), axis=1)
+    return GenotypeDisplay(
+        df,
+        (ds["call_genotype"].sizes["variants"], ds["call_genotype"].sizes["samples"]),
+        max_variants,
+        max_samples,
+    )

--- a/sgkit/tests/test_api.py
+++ b/sgkit/tests/test_api.py
@@ -55,44 +55,12 @@ def test_create_genotype_call_dataset():
     assert (
         str(disp)
         == """
-samples     0    1    2
-variants               
-0         0|0  0|1  1/0
-1         .|0  0/.  ./.
+samples  sample_1 sample_2 sample_3
+variants                           
+rs1           0|0      0|1      1/0
+rs2           .|0      0/.      ./.
 """.strip()  # noqa: W291
     )
-
-    expected_html = """<table border="1" class="dataframe">
-  <thead>
-    <tr style="text-align: right;">
-      <th>samples</th>
-      <th>0</th>
-      <th>1</th>
-      <th>2</th>
-    </tr>
-    <tr>
-      <th>variants</th>
-      <th></th>
-      <th></th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>0</th>
-      <td>0|0</td>
-      <td>0|1</td>
-      <td>1/0</td>
-    </tr>
-    <tr>
-      <th>1</th>
-      <td>.|0</td>
-      <td>0/.</td>
-      <td>./.</td>
-    </tr>
-  </tbody>
-</table>"""
-    assert expected_html in disp._repr_html_()
 
 
 def test_create_genotype_dosage_dataset():

--- a/sgkit/tests/test_api.py
+++ b/sgkit/tests/test_api.py
@@ -8,6 +8,7 @@ from sgkit import (
     DIM_VARIANT,
     create_genotype_call_dataset,
     create_genotype_dosage_dataset,
+    display_genotypes,
 )
 
 
@@ -49,6 +50,49 @@ def test_create_genotype_call_dataset():
     assert_array_equal(ds["call_genotype"], call_genotype)
     assert_array_equal(ds["call_genotype_mask"], call_genotype < 0)
     assert_array_equal(ds["call_genotype_phased"], call_genotype_phased)
+
+    disp = display_genotypes(ds)
+    assert (
+        str(disp)
+        == """
+samples     0    1    2
+variants               
+0         0|0  0|1  1/0
+1         .|0  0/.  ./.
+""".strip()  # noqa: W291
+    )
+
+    expected_html = """<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th>samples</th>
+      <th>0</th>
+      <th>1</th>
+      <th>2</th>
+    </tr>
+    <tr>
+      <th>variants</th>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0|0</td>
+      <td>0|1</td>
+      <td>1/0</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>.|0</td>
+      <td>0/.</td>
+      <td>./.</td>
+    </tr>
+  </tbody>
+</table>"""
+    assert expected_html in disp._repr_html_()
 
 
 def test_create_genotype_dosage_dataset():

--- a/sgkit/tests/test_display.py
+++ b/sgkit/tests/test_display.py
@@ -1,0 +1,176 @@
+from sgkit import display_genotypes
+from sgkit.testing import simulate_genotype_call_dataset
+
+
+def test_display_genotypes():
+    ds = simulate_genotype_call_dataset(n_variant=3, n_sample=3, seed=0)
+    disp = display_genotypes(ds)
+    assert (
+        str(disp)
+        == """
+samples    S0   S1   S2
+variants               
+0         0/0  1/0  1/0
+1         0/1  1/0  0/1
+2         0/0  1/0  1/1
+""".strip()  # noqa: W291
+    )
+
+    expected_html = """<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th>samples</th>
+      <th>S0</th>
+      <th>S1</th>
+      <th>S2</th>
+    </tr>
+    <tr>
+      <th>variants</th>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0/0</td>
+      <td>1/0</td>
+      <td>1/0</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0/1</td>
+      <td>1/0</td>
+      <td>0/1</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>0/0</td>
+      <td>1/0</td>
+      <td>1/1</td>
+    </tr>
+  </tbody>
+</table>""".strip()
+    assert expected_html in disp._repr_html_()
+
+
+def test_display_genotypes__truncated():
+    ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10, seed=0)
+    disp = display_genotypes(ds, max_variants=4, max_samples=4)
+    assert (
+        str(disp)
+        == """
+samples    S0   S1  ...   S8   S9
+variants            ...          
+0         0/0  1/0  ...  1/1  0/0
+1         1/0  0/1  ...  1/0  1/1
+...       ...  ...  ...  ...  ...
+8         0/1  0/0  ...  1/0  1/0
+9         1/1  0/1  ...  1/1  1/0
+
+[10 rows x 10 columns]
+""".strip()  # noqa: W291
+    )
+
+    expected_html = """<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th>samples</th>
+      <th>S0</th>
+      <th>S1</th>
+      <th>...</th>
+      <th>S8</th>
+      <th>S9</th>
+    </tr>
+    <tr>
+      <th>variants</th>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0/0</td>
+      <td>1/0</td>
+      <td>...</td>
+      <td>1/1</td>
+      <td>0/0</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>1/0</td>
+      <td>0/1</td>
+      <td>...</td>
+      <td>1/0</td>
+      <td>1/1</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+      <td>...</td>
+    </tr>
+    <tr>
+      <th>8</th>
+      <td>0/1</td>
+      <td>0/0</td>
+      <td>...</td>
+      <td>1/0</td>
+      <td>1/0</td>
+    </tr>
+    <tr>
+      <th>9</th>
+      <td>1/1</td>
+      <td>0/1</td>
+      <td>...</td>
+      <td>1/1</td>
+      <td>1/0</td>
+    </tr>
+  </tbody>
+</table>
+<p>10 rows x 10 columns</p>""".strip()
+    assert expected_html in disp._repr_html_()
+
+
+def test_display_genotypes__large():
+    ds = simulate_genotype_call_dataset(n_variant=100_000, n_sample=1000, seed=0)
+    disp = display_genotypes(ds, max_variants=4, max_samples=4)
+    assert (
+        str(disp)
+        == """
+samples    S0   S1  ... S998 S999
+variants            ...          
+0         0/0  1/0  ...  0/1  1/1
+1         1/1  1/1  ...  0/1  1/1
+...       ...  ...  ...  ...  ...
+99998     0/1  1/1  ...  1/0  0/1
+99999     1/0  1/0  ...  1/0  1/0
+
+[100000 rows x 1000 columns]
+""".strip()  # noqa: W291
+    )
+
+
+def test_display_genotypes__sample_order():
+    # Test that samples are not reordered lexicograpically (S10 is after S9)
+    ds = simulate_genotype_call_dataset(n_variant=4, n_sample=12, seed=0)
+    disp = display_genotypes(ds)
+    assert (
+        str(disp)
+        == """samples    S0   S1   S2   S3   S4  ...   S7   S8   S9  S10  S11
+variants                           ...                         
+0         0/0  1/0  1/0  0/1  1/0  ...  1/0  1/1  0/0  1/0  0/1
+1         1/0  1/1  1/1  1/0  1/0  ...  1/1  1/1  1/1  0/0  0/0
+2         0/1  1/0  1/0  1/0  0/0  ...  0/0  0/0  0/0  0/1  0/1
+3         0/1  1/0  1/0  0/0  0/1  ...  0/1  1/0  1/1  0/0  1/0
+
+[4 rows x 12 columns]
+""".strip()  # noqa: W291
+    )

--- a/sgkit/tests/test_display.py
+++ b/sgkit/tests/test_display.py
@@ -1,4 +1,7 @@
+import pytest
+
 from sgkit import display_genotypes
+from sgkit.display import truncate
 from sgkit.testing import simulate_genotype_call_dataset
 
 
@@ -55,7 +58,50 @@ variants
     assert expected_html in disp._repr_html_()
 
 
-def test_display_genotypes__truncated():
+def test_display_genotypes__truncated_rows():
+    ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10, seed=0)
+    disp = display_genotypes(ds, max_variants=4, max_samples=10)
+    assert (
+        str(disp)
+        == """
+samples    S0   S1   S2   S3   S4   S5   S6   S7   S8   S9
+variants                                                  
+0         0/0  1/0  1/0  0/1  1/0  0/1  0/0  1/0  1/1  0/0
+1         1/0  0/1  1/0  1/1  1/1  1/0  1/0  0/0  1/0  1/1
+...       ...  ...  ...  ...  ...  ...  ...  ...  ...  ...
+8         0/1  0/0  1/0  0/1  0/1  1/0  1/0  0/1  1/0  1/0
+9         1/1  0/1  1/0  0/1  1/0  1/1  0/1  1/0  1/1  1/0
+
+[10 rows x 10 columns]
+""".strip()  # noqa: W291
+    )
+
+
+def test_display_genotypes__truncated_columns():
+    ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10, seed=0)
+    disp = display_genotypes(ds, max_variants=10, max_samples=4)
+    assert (
+        str(disp)
+        == """
+samples    S0   S1  ...   S8   S9
+variants            ...          
+0         0/0  1/0  ...  1/1  0/0
+1         1/0  0/1  ...  1/0  1/1
+2         1/1  1/1  ...  0/0  1/0
+3         0/1  0/0  ...  1/0  0/0
+4         0/1  0/0  ...  0/0  1/1
+5         1/1  1/0  ...  0/0  1/0
+6         1/1  0/0  ...  1/0  0/1
+7         1/0  0/1  ...  0/1  0/0
+8         0/1  0/0  ...  1/0  1/0
+9         1/1  0/1  ...  1/1  1/0
+
+[10 rows x 10 columns]
+""".strip()  # noqa: W291
+    )
+
+
+def test_display_genotypes__truncated_rows_and_columns():
     ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10, seed=0)
     disp = display_genotypes(ds, max_variants=4, max_samples=4)
     assert (
@@ -158,19 +204,9 @@ variants            ...
     )
 
 
-def test_display_genotypes__sample_order():
-    # Test that samples are not reordered lexicograpically (S10 is after S9)
-    ds = simulate_genotype_call_dataset(n_variant=4, n_sample=12, seed=0)
-    disp = display_genotypes(ds)
-    assert (
-        str(disp)
-        == """samples    S0   S1   S2   S3   S4  ...   S7   S8   S9  S10  S11
-variants                           ...                         
-0         0/0  1/0  1/0  0/1  1/0  ...  1/0  1/1  0/0  1/0  0/1
-1         1/0  1/1  1/1  1/0  1/0  ...  1/1  1/1  1/1  0/0  0/0
-2         0/1  1/0  1/0  1/0  0/0  ...  0/0  0/0  0/0  0/1  0/1
-3         0/1  1/0  1/0  0/0  0/1  ...  0/1  1/0  1/1  0/0  1/0
-
-[4 rows x 12 columns]
-""".strip()  # noqa: W291
-    )
+def test_truncate_fails_with_only_one_dimension():
+    ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10, seed=0)
+    with pytest.raises(
+        ValueError, match="Truncation is only supported for two dimensions"
+    ):
+        truncate(ds, {"variants": 10})


### PR DESCRIPTION
Fixes #37.

The `GenotypeDisplay` class just delegates to the Pandas dataframe, but it is probably worth having the wrapper to hide the implementation, and also because it allows us to customize (or completely change) the representation in the future.