### PR TITLE
Allow untyped decorators in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,5 +84,6 @@ ignore_missing_imports = True
 allow_redefinition = True
 [mypy-sgkit.tests.*]
 disallow_untyped_defs = False
+disallow_untyped_decorators = False
 [mypy-validation.*]
 ignore_errors = True

--- a/sgkit/tests/test_association.py
+++ b/sgkit/tests/test_association.py
@@ -92,7 +92,7 @@ def _generate_test_dataset(**kwargs: Any) -> Dataset:
     return xr.Dataset(data_vars, attrs=attrs)  # type: ignore[arg-type]
 
 
-@pytest.fixture(scope="module")  # type: ignore[misc]
+@pytest.fixture(scope="module")
 def ds() -> Dataset:
     return _generate_test_dataset()
 
@@ -185,7 +185,7 @@ def test_gwas_linear_regression__multi_trait(ds):
     pd.testing.assert_frame_equal(dfr_single, dfr_multi)
 
 
-def test_gwas_linear_regression__scalar_vars(ds):
+def test_gwas_linear_regression__scalar_vars(ds: xr.Dataset) -> None:
     res_scalar = gwas_linear_regression(
         ds, dosage="dosage", covariates="covar_0", traits="trait_0"
     )

--- a/sgkit/tests/test_regenie.py
+++ b/sgkit/tests/test_regenie.py
@@ -383,8 +383,8 @@ def test_ridge_regression__raise_on_non_equal_first_dim():
         ridge_regression(np.ones((2, 2)), np.ones((1, 1)), np.array([1.0]))
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
-    "x,size,expected_index,expected_sizes",  # type: ignore[no-untyped-def]
+@pytest.mark.parametrize(
+    "x,size,expected_index,expected_sizes",
     [
         ([0], 1, [0], [1]),
         ([0], 2, [0], [1]),
@@ -397,7 +397,7 @@ def test_ridge_regression__raise_on_non_equal_first_dim():
 )
 def test_index_array_blocks__basic(
     x: Any, size: int, expected_index: Any, expected_sizes: Any
-):
+) -> None:
     index, sizes = index_array_blocks(x, size)
     np.testing.assert_equal(index, expected_index)
     np.testing.assert_equal(sizes, expected_sizes)
@@ -425,7 +425,7 @@ def test_index_array_blocks__raise_on_not_monotonic_increasing():
         index_array_blocks([0, 1, 1, 1, 0], 3)
 
 
-@st.composite  # type: ignore[misc]
+@st.composite
 def monotonic_increasing_ints(draw: Any) -> ndarray:
     # Draw increasing ints with repeats, e.g. [0, 0, 5, 7, 7, 7]
     n = draw(st.integers(min_value=0, max_value=5))
@@ -439,9 +439,9 @@ def monotonic_increasing_ints(draw: Any) -> ndarray:
     return np.repeat(values, repeats)
 
 
-@given(st_data(), monotonic_increasing_ints())  # type: ignore[misc]
-@settings(max_examples=50)  # type: ignore[misc]
-def test_index_array_blocks__coverage(data: Any, x: ndarray):  # type: ignore[no-untyped-def]
+@given(st_data(), monotonic_increasing_ints())
+@settings(max_examples=50)
+def test_index_array_blocks__coverage(data: Any, x: ndarray) -> None:
     # Draw block size that is no less than 1 but possibly
     # greater than or equal to the size of the array
     size = data.draw(st.integers(min_value=1, max_value=len(x) + 1))
@@ -459,8 +459,8 @@ def test_index_array_blocks__coverage(data: Any, x: ndarray):  # type: ignore[no
         np.testing.assert_equal(np.concatenate(chunks), x)
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
-    "chunks,expected_index",  # type: ignore[no-untyped-def]
+@pytest.mark.parametrize(
+    "chunks,expected_index",
     [
         ([1], [0]),
         ([1, 1], [0, 1]),
@@ -469,7 +469,7 @@ def test_index_array_blocks__coverage(data: Any, x: ndarray):  # type: ignore[no
         ([10, 1, 1, 10], [0, 10, 11, 12]),
     ],
 )
-def test_index_block_sizes__basic(chunks: Any, expected_index: Any):
+def test_index_block_sizes__basic(chunks: Any, expected_index: Any) -> None:
     index, sizes = index_block_sizes(chunks)
     np.testing.assert_equal(index, expected_index)
     np.testing.assert_equal(sizes, chunks)

--- a/sgkit/tests/test_stats_utils.py
+++ b/sgkit/tests/test_stats_utils.py
@@ -46,8 +46,8 @@ def test_r2_score__batch_dims():
     np.testing.assert_allclose(r2_actual.ravel(), r2_expected)
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
-    "predicted,actual,expected_r2",  # type: ignore[no-untyped-def]
+@pytest.mark.parametrize(
+    "predicted,actual,expected_r2",
     [
         ([1, 1], [1, 2], -1.0),
         ([1, 0], [1, 2], -7.0),
@@ -65,13 +65,13 @@ def test_r2_score__batch_dims():
 )
 def test_r2_score__sklearn_comparison(
     predicted: List[Any], actual: List[Any], expected_r2: float
-):
+) -> None:
     yp, yt = np.array(predicted), np.array(actual)
     assert r2_score(yp, yt) == expected_r2
 
 
-@given(st.integers(0, 25))  # type: ignore[misc]
-@settings(max_examples=10)  # type: ignore[misc]
+@given(st.integers(0, 25))
+@settings(max_examples=10)
 def test_concat_2d__values(n: int) -> None:
     x, y = np.arange(n), np.arange(n * n).reshape(n, n)
     z = np.copy(y)
@@ -119,9 +119,9 @@ def sample_dataset(draw):
     return ds
 
 
-@given(sample_dataset())  # type: ignore[misc]
-@settings(max_examples=25)  # type: ignore[misc]
-def test_concat_2d__variables(ds: Dataset):  # type: ignore[no-untyped-def]
+@given(sample_dataset())
+@settings(max_examples=25)
+def test_concat_2d__variables(ds: Dataset) -> None:
     # Select data variables expected to remain after extract
     data_vars = [v for v in ds if ds[v].dims[0] == "dim-0-0"]
     # Sum the number of columns for the kept variables

--- a/sgkit/tests/test_utils.py
+++ b/sgkit/tests/test_utils.py
@@ -37,8 +37,8 @@ def test_check_array_like():
         check_array_like(a, ndim={2, 3})
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
-    "x,expected_values,expected_names",  # type: ignore[no-untyped-def]
+@pytest.mark.parametrize(
+    "x,expected_values,expected_names",
     [
         ([], [], []),
         (["a"], [0], ["a"]),
@@ -60,14 +60,14 @@ def test_check_array_like():
 )
 def test_encode_array(
     x: List[Any], expected_values: List[Any], expected_names: List[Any]
-):
+) -> None:
     v, n = encode_array(np.array(x))
     np.testing.assert_equal(v, expected_values)
     np.testing.assert_equal(n, expected_names)
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
-    "n,blocks,expected_chunks",  # type: ignore[no-untyped-def]
+@pytest.mark.parametrize(
+    "n,blocks,expected_chunks",
     [
         (1, 1, [1]),
         (2, 1, [2]),
@@ -82,12 +82,12 @@ def test_encode_array(
 )
 def test_split_array_chunks__precomputed(
     n: int, blocks: int, expected_chunks: List[int]
-):
+) -> None:
     assert split_array_chunks(n, blocks) == tuple(expected_chunks)
 
 
-@given(st.integers(1, 50), st.integers(0, 50))  # type: ignore[misc]
-@settings(max_examples=50)  # type: ignore[misc]
+@given(st.integers(1, 50), st.integers(0, 50))
+@settings(max_examples=50)
 def test_split_array_chunks__size(a: int, b: int) -> None:
     res = split_array_chunks(a + b, a)
     assert sum(res) == a + b


### PR DESCRIPTION
Related: #74. This allows to use untyped decorators in tests, ex: hypothesis decorators.