### PR TITLE
POC: Dataset with schema

### DIFF
--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -3,6 +3,8 @@ import numpy as np
 import xarray as xr
 from xarray import DataArray, Dataset
 
+from sgkit.typing import SgkitSchema
+
 
 def count_alleles(ds: Dataset) -> DataArray:
     """Compute allele count from genotype calls.
@@ -10,8 +12,10 @@ def count_alleles(ds: Dataset) -> DataArray:
     Parameters
     ----------
     ds : Dataset
-        Genotype call dataset such as from
-        `sgkit.create_genotype_call_dataset`.
+        Genotype call dataset such as from `sgkit.create_genotype_call_dataset`.
+        Must hold:
+        * `sgkit.typing.SgkitSchema.call_genotype`
+        * `sgkit.typing.SgkitSchema.call_genotype_mask`
 
     Returns
     -------
@@ -40,10 +44,13 @@ def count_alleles(ds: Dataset) -> DataArray:
            [2, 2],
            [4, 0]])
     """
+    schm = SgkitSchema.schema_has(
+        ds, SgkitSchema.call_genotype, SgkitSchema.call_genotype_mask
+    )
     # Count each allele index individually as a 1D vector and
     # restack into new alleles dimension with same order
-    G = ds["call_genotype"].stack(calls=("samples", "ploidy"))
-    M = ds["call_genotype_mask"].stack(calls=("samples", "ploidy"))
+    G = ds[schm["call_genotype"][0]].stack(calls=("samples", "ploidy"))
+    M = ds[schm["call_genotype_mask"][0]].stack(calls=("samples", "ploidy"))
     n_variant, n_allele = G.shape[0], ds.dims["alleles"]
     max_allele = n_allele + 1
 

--- a/sgkit/tests/test_hwe.py
+++ b/sgkit/tests/test_hwe.py
@@ -14,6 +14,7 @@ from sgkit.stats.hwe import hardy_weinberg_p_value_vec as hwep_vec
 from sgkit.stats.hwe import hardy_weinberg_p_value_vec_jit as hwep_vec_jit
 from sgkit.stats.hwe import hardy_weinberg_test as hwep_test
 from sgkit.testing import simulate_genotype_call_dataset
+from sgkit.typing import SgkitSchema
 
 
 def simulate_genotype_calls(
@@ -139,7 +140,9 @@ def test_hwep_dataset__precomputed_counts(ds_neq: Dataset) -> None:
     cts = [1, 0, 2]  # arg order: hets, hom1, hom2
     gtc = xr.concat([(ac == ct).sum(dim="samples") for ct in cts], dim="counts").T  # type: ignore[no-untyped-call]
     ds = ds.assign(**{"variant_genotype_counts": gtc})
-    p = hwep_test(ds, genotype_counts="variant_genotype_counts")
+    p = hwep_test(
+        SgkitSchema.spec(ds, (SgkitSchema.genotype_counts, ["variant_genotype_counts"]))
+    )
     assert np.all(p < 1e-8)
 
 

--- a/sgkit/tests/test_typing.py
+++ b/sgkit/tests/test_typing.py
@@ -1,0 +1,42 @@
+import _pickle as pickle  # type: ignore[import]
+import pytest
+import xarray as xr
+
+from sgkit.testing import simulate_genotype_call_dataset
+from sgkit.typing import SgkitSchema
+
+
+@pytest.fixture(scope="module")
+def ds() -> xr.Dataset:
+    return simulate_genotype_call_dataset(n_variant=100, n_sample=5)
+
+
+def test_validate_should_work_on_valid_dataset(ds):
+    SgkitSchema.schema_has(
+        ds, SgkitSchema.call_genotype, SgkitSchema.call_genotype_mask
+    )
+    assert SgkitSchema.dosage not in SgkitSchema.get_schema(ds).keys()
+
+
+def test_validate_should_work_on_valid_dataset__many_vars(ds):
+    ds = ds.copy()
+    ds["call_genotype_2"] = ds["call_genotype"]
+    SgkitSchema.spec(
+        ds, (SgkitSchema.call_genotype, ["call_genotype_2", "call_genotype"])
+    )
+
+
+def test_validate_should_fail_on_invalid_dataset__wrong_type(ds):
+    with pytest.raises(TypeError, match="Array dtype kind"):
+        SgkitSchema.spec(ds, (SgkitSchema.call_genotype, ["call_genotype_mask"]))
+
+
+def test_validate_should_fail_on_invalid_dataset__missing_var(ds):
+    with pytest.raises(ValueError, match="call_genotype not present"):
+        ds = ds.drop_vars("call_genotype")
+        SgkitSchema.spec(ds, SgkitSchema.call_genotype)
+
+
+def test_serde_roundtrip(ds):
+    roundtrip_ds = pickle.loads(pickle.dumps(ds, protocol=-1))
+    SgkitSchema.schema_has(roundtrip_ds, SgkitSchema.call_genotype)

--- a/sgkit/typing.py
+++ b/sgkit/typing.py
@@ -1,9 +1,194 @@
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Dict, Hashable, List, Set, Tuple, Union, cast, overload
 
 import dask.array as da
 import numpy as np
+import xarray as xr
 
 ArrayLike = Union[np.ndarray, da.Array]
 DType = Any
 PathType = Union[str, Path]
+
+
+@dataclass(frozen=True)
+class Spec:
+    """Root type Spec"""
+
+    default_name: str
+
+
+@dataclass(frozen=True)
+class ArrayLikeSpec(Spec):
+    """ArrayLike type spec"""
+
+    # TODO: add dim names check
+
+    kind: Union[None, str, Set[str]] = None
+    ndim: Union[None, int, Set[int]] = None
+
+    def __repr__(self) -> str:
+        return self.default_name
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, str):
+            return self.default_name == other
+        else:
+            return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        return hash(self.default_name)
+
+
+class SgkitSchema:
+    """
+    Array/data spec + pointer to variable.
+    Essentially allows to specify that a generic xarray dataset contains
+    specific useful arrays of specific spec under specific variables, then
+    algorithms can use this schema to fetch arrays it requires for computation.
+    """
+
+    SCHEMA_ATTR_KEY = "schema"
+    """
+    All these specs lives here, but could be separated into multiple locations,
+    or live next to the methods as a documentation of the inputs and outputs.
+    """
+    call_genotype = ArrayLikeSpec("call_genotype", kind="i", ndim=3)
+    """
+    Genotype, encoded as allele values (0 for the reference, 1 for
+    the first allele, 2 for the second allele), or -1 to indicate a
+    missing value.
+    """
+    call_genotype_mask = ArrayLikeSpec("call_genotype_mask", kind="b", ndim=3)
+    variant_contig = ArrayLikeSpec("variant_contig", kind="i", ndim=1)
+    """The (index of the) contig for each variant"""
+    variant_position = ArrayLikeSpec("variant_position", kind="i", ndim=1)
+    """The reference position of the variant"""
+    variant_allele = ArrayLikeSpec("variant_allele", kind={"S", "O"}, ndim=2)
+    """The possible alleles for the variant"""
+    sample_id = ArrayLikeSpec("sample_id", kind={"U", "O"}, ndim=1)
+    """The unique identifier of the sample"""
+    call_genotype_phased = ArrayLikeSpec("call_genotype_phased", kind="b", ndim=2)
+    """
+    A flag for each call indicating if it is phased or not. If
+    omitted all calls are unphased.
+    """
+    variant_id = ArrayLikeSpec("variant_id", kind="U", ndim=1)
+    """The unique identifier of the variant"""
+    call_dosage = ArrayLikeSpec("call_dosage", kind="f", ndim=2)
+    """Dosages, encoded as floats, with NaN indicating a missing value"""
+    call_dosage_mask = ArrayLikeSpec("call_dosage_mask", kind="b", ndim=2)
+    # TODO: discuss/finish these specs:
+    genotype_counts = ArrayLikeSpec("genotype_counts")
+    """
+    Genotype counts, must correspond to an (`N`, 3) array where `N` is equal
+    to the number of variants and the 3 columns contain heterozygous,
+    homozygous reference, and homozygous alternate counts (in that order)
+    across all samples for a variant.
+    """
+    variant_hwe_p_value = ArrayLikeSpec("variant_hwe_p_value", kind="f")
+    """P values from HWE test for each variant as float in [0, 1]"""
+    variant_beta = ArrayLikeSpec("variant_beta")
+    """Beta values associated with each variant and trait"""
+    variant_t_value = ArrayLikeSpec("variant_t_value")
+    """T statistics for each beta"""
+    variant_p_value = ArrayLikeSpec("variant_p_value", kind="f")
+    """P values as float in [0, 1]"""
+    covariates = ArrayLikeSpec("covariates", ndim={1, 2})
+    """
+    Covariate variable names, must correspond to 1 or 2D dataset
+    variables of shape (samples[, covariates]). All covariate arrays
+    will be concatenated along the second axis (columns).
+    """
+    traits = ArrayLikeSpec("traits", ndim={1, 2})
+    """
+    Trait (e.g. phenotype) variable names, must all be continuous and
+    correspond to 1 or 2D dataset variables of shape (samples[, traits]).
+    2D trait arrays will be assumed to contain separate traits within columns
+    and concatenated to any 1D traits along the second axis (columns).
+    """
+    dosage = ArrayLikeSpec("dosage")
+    """
+    Dosage variable name where "dosage" array can contain represent
+    one of several possible quantities, e.g.:
+        - Alternate allele counts
+        - Recessive or dominant allele encodings
+        - True dosages as computed from imputed or probabilistic variant calls
+        - Any other custom encoding in a user-defined variable
+    """
+
+    @classmethod
+    @overload
+    def spec(
+        cls, xr_dataset: xr.Dataset, *args: Tuple[ArrayLikeSpec, List[str]]
+    ) -> xr.Dataset:
+        """
+        Specify that xr_dataset contains array(s) of interest with alternative
+        variable name(s).
+        """
+        ...
+
+    @classmethod
+    @overload
+    def spec(cls, xr_dataset: xr.Dataset, *args: ArrayLikeSpec) -> xr.Dataset:
+        """
+        Specify that xr_dataset contains array(s) of interest with default
+        variable name(s).
+        """
+        ...
+
+    @classmethod
+    def spec(
+        cls,
+        xr_dataset: xr.Dataset,
+        *specs: Union[ArrayLikeSpec, Tuple[ArrayLikeSpec, List[str]]],
+    ) -> xr.Dataset:
+        new_ds = xr_dataset.copy(deep=False)
+        for s in specs:
+            if isinstance(s, ArrayLikeSpec):
+                field_spec = s
+                alternative_names: List[str] = []
+            else:
+                field_spec, alternative_names = s
+            fname = alternative_names or [field_spec.default_name]
+            cls._check_field(new_ds, field_spec, fname)
+            try:
+                new_ds.attrs[SgkitSchema.SCHEMA_ATTR_KEY][field_spec] = fname
+            except KeyError:
+                new_ds.attrs[SgkitSchema.SCHEMA_ATTR_KEY] = {}
+                new_ds = cls.spec(new_ds, (field_spec, alternative_names))
+        return new_ds
+
+    @classmethod
+    def _check_field(
+        cls, xr_dataset: xr.Dataset, field_spec: ArrayLikeSpec, fields: List[str]
+    ) -> None:
+        from sgkit.utils import check_array_like
+
+        for n in fields:
+            if n not in xr_dataset:
+                raise ValueError(f"{n} not present in {xr_dataset}")
+            check_array_like(xr_dataset[n], kind=field_spec.kind, ndim=field_spec.ndim)
+
+    @classmethod
+    def get_schema(
+        cls, xr_dataset: xr.Dataset
+    ) -> Dict[Union[Hashable, ArrayLikeSpec], List[str]]:
+        """Return Sgkit schema attribute of xr_dataset"""
+        return cast(
+            Dict[Union[Hashable, ArrayLikeSpec], List[str]],
+            xr_dataset.attrs[cls.SCHEMA_ATTR_KEY],
+        )
+
+    @classmethod
+    def schema_has(
+        cls, xr_dataset: xr.Dataset, *specs: ArrayLikeSpec
+    ) -> Dict[Union[Hashable, ArrayLikeSpec], List[str]]:
+        """Validate that Sgkit schema contains required variables"""
+        schema = cls.get_schema(xr_dataset)
+        for s in specs:
+            if s not in schema:
+                raise ValueError(
+                    f"Required `{s}` missing in schema of  {xr_dataset}\nUse SgkitSchema to define schema"
+                )
+        return schema


### PR DESCRIPTION
This is a POC. And I would like to first get your feedback about the idea, before finishing up tests, doc and coverage. This comes from the #43, follows up from the comment in #103. #43 is a lot more elaborated since it's trying to strive for statically typed feedback, whilst this is a lot more stripped down.

I have tried to:
 * not use extra wrapper around xr Dataset (since we have discussed that we would like to avoid it)
 * strive for a consistent API whilst still be concise and relatively flexible

The core idea is:
 * hold a "schema" in `attrs` of the xr Dataset
 * define specs of meaningful/useful arrays and validate the spec against variables in the Dataset at schema spec
 * schema then is essentially a data/array spec + pointer to variable in a Dataset
 * schema spec can point to many variables, and by default points to the default variable

Benefits:
 * A single place for definition of useful/reserved variable and their constraints
 * A single way to declare that specific variable(s) have specific meaning and spec
 * As the pipeline flows and results are merged into a single dataset, that dataset can be used for different function even if it contains custom variable names (which would be declared once)

As a user:
 * if you don't change any of the precomputed variable names, you don't need to do anything
 * if a function requires that you specify which variables to use for computation, you must do so via `SgkitSchema.spec` before calling the function
 * `SgkitSchema.spec` returns a new Dataset (shallow copied) with updated schema/attrs

What is missing:
 - [ ] get your feedback, and pending on your feedback:
 - [ ] polish the API (eg. make it easier to fetch a single name variables)
 - [ ] discuss and complete all the specs constraints 
 - [ ] make it easier to merge DS together with schema
 - [ ] more documentation
 - [ ] more tests
 - [ ] update `regenie` (essentially the same as regression)

This POC removes all the required/optional variable names from function arguments, and if those need to be specified or are custom user needs to specify it via `SgkitSchema.spec`, alternatively we could keep those where necessary ([example](https://github.com/pystatgen/sgkit/pull/124/files#diff-560e2369465eff5d67bd278b69c381acL115-L117)) and call `SgkitSchema.spec` inside the functions (triggering validation etc).

One more point: we could make it redundant to declare default names in schema, and if missing in schema, but requested: assume default name, check variable against the spec, and return name.