### PR TITLE
Add VCF docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,17 +7,32 @@ This page provides an auto-generated summary of sgkits's API.
 IO/imports
 ==========
 
+PLINK
+-----
+
 .. currentmodule:: sgkit.io.plink
 .. autosummary::
    :toctree: generated/
 
-    read_plink
+   read_plink
+
+VCF
+---
+
+.. currentmodule:: sgkit.io.vcf
+.. autosummary::
+   :toctree: generated/
+
+   partition_into_regions
+   vcf_to_zarr
+   vcf_to_zarrs
+   zarrs_to_dataset
 
 .. currentmodule:: sgkit
 .. autosummary::
    :toctree: generated/
 
-    read_vcfzarr
+   read_vcfzarr
 
 .. currentmodule:: sgkit
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ both popular Python genetics toolkits with a respective focus on population and 
     getting_started
     api
     user_guide
+    vcf
     contributing
 
 Indices and tables

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -13,13 +13,22 @@ IO
 PLINK
 -----
 
-The :func:`sgkit.io.plink.read_plink` loads a single PLINK dataset as Dask
-arrays within an ``xr.Dataset`` from bed, bim, and fam files.
+The :func:`sgkit.io.plink.read_plink` function loads a single PLINK dataset as Dask
+arrays within an :class:`xarray.Dataset` from ``bed``, ``bim``, and ``fam`` files.
 
 PLINK IO support is an "extra" feature within sgkit and requires additional
 dependencies. To install sgkit with PLINK support using pip::
 
     $ pip install git+https://github.com/pystatgen/sgkit#egg=sgkit[plink]
+
+VCF
+---
+
+The :func:`sgkit.io.vcf.vcf_to_zarr` function converts one or more VCF files to
+Zarr files stored in sgkit's Xarray data representation, which can then be opened
+as a :class:`xarray.Dataset`.
+
+See :ref:`vcf` for installation instructions, and details on using VCF in sgkit.
 
 Converting genetic data to Zarr
 ===============================

--- a/docs/vcf.rst
+++ b/docs/vcf.rst
@@ -1,0 +1,194 @@
+.. _vcf:
+
+Reading VCF
+===========
+
+.. contents:: Table of contents:
+   :local:
+
+The :func:`sgkit.io.vcf.vcf_to_zarr` function converts one or more VCF files to Zarr files stored in
+sgkit's Xarray data representation.
+
+Highlights
+----------
+
+* Reads bgzip-compressed VCF and BCF files.
+* Large VCF files can be partitioned into regions using a Tabix (``.tbi``) or CSI (``.csi``)
+  index, and each region is processed in parallel using `Dask <https://dask.org/>`_.
+* VCF parsing is performed by `cyvcf2 <https://github.com/brentp/cyvcf2>`_,
+  a Cython wrapper around `htslib <https://github.com/samtools/htslib>`_,
+  the industry-standard VCF library.
+* Control over Zarr chunk sizes allows VCFs with a large number of samples
+  to be converted efficiently.
+* Input and output files can reside on local filesystems, Amazon S3, or
+  Google Cloud Storage.
+
+Installation
+------------
+
+VCF support is an "extra" feature within sgkit and requires additional
+dependencies. It relies on ``cyvcf2`` and ``htslib``, so you will have to
+have, at a minimum, ``libcurl`` installed on your machine (you can check by typing ``curl -V``).
+
+To install sgkit with VCF support using pip::
+
+    $ pip install git+https://github.com/pystatgen/sgkit#egg=sgkit[vcf]
+
+There are `installation instructions for cyvcf2 <https://github.com/brentp/cyvcf2#installation>`_,
+which may be helpful if you encounter errors during installation.
+
+.. warning::
+   Reading VCFs is not supported on Windows, since ``cyvcf2`` and ``htslib`` do
+   not `currently work on Windows <https://github.com/brentp/cyvcf2/issues/90>`_.
+   As a workaround, consider using scikit-allel's ``vcf_to_zarr`` function
+   to write a VCF in Zarr format, followed by :func:`sgkit.read_vcfzarr` to
+   read the VCF as a :class:`xarray.Dataset`.
+
+Usage
+-----
+
+To convert a single VCF or BCF file to Zarr, just specify the input and output file names::
+
+    >>> from sgkit.io.vcf import vcf_to_zarr
+    >>> vcf_to_zarr("CEUTrio.20.21.gatk3.4.g.vcf.bgz", "output.zarr")
+    >>> import xarray as xr
+    >>> ds = xr.open_zarr("output.zarr")
+    >>> ds
+    <xarray.Dataset>
+    Dimensions:               (alleles: 4, ploidy: 2, samples: 1, variants: 19910)
+    Dimensions without coordinates: alleles, ploidy, samples, variants
+    Data variables:
+        call_genotype         (variants, samples, ploidy) int8 dask.array<chunksize=(10000, 1, 2), meta=np.ndarray>
+        call_genotype_mask    (variants, samples, ploidy) bool dask.array<chunksize=(10000, 1, 2), meta=np.ndarray>
+        call_genotype_phased  (variants, samples) bool dask.array<chunksize=(10000, 1), meta=np.ndarray>
+        sample_id             (samples) <U7 dask.array<chunksize=(1,), meta=np.ndarray>
+        variant_allele        (variants, alleles) object dask.array<chunksize=(10000, 4), meta=np.ndarray>
+        variant_contig        (variants) int8 dask.array<chunksize=(10000,), meta=np.ndarray>
+        variant_id            (variants) object dask.array<chunksize=(10000,), meta=np.ndarray>
+        variant_id_mask       (variants) bool dask.array<chunksize=(10000,), meta=np.ndarray>
+        variant_position      (variants) int32 dask.array<chunksize=(10000,), meta=np.ndarray>
+    Attributes:
+        contigs:                    ['20', '21']
+        max_variant_allele_length:  48
+        max_variant_id_length:      1
+
+The :func:`sgkit.io.vcf.vcf_to_zarr` function can accept multiple files, and furthermore, each of these
+files can be partitioned to enable parallel processing.
+
+Multiple files
+--------------
+
+If there are multiple files, then pass a list::
+
+    >>> from sgkit.io.vcf import vcf_to_zarr
+    >>> vcf_to_zarr(["CEUTrio.20.gatk3.4.g.vcf.bgz", "CEUTrio.21.gatk3.4.g.vcf.bgz"], "output.zarr")
+
+Processing multiple inputs is more work than a single file, since behind the scenes each input is
+converted to a separate temporary Zarr file on disk, then these files are concatenated and rechunked
+to form the final output Zarr file.
+
+In the single file case, the input VCF is converted to the output Zarr file in a single sequential
+pass with no need for intermediate temporary files. For small files this is fine, but for very large
+files it's a good idea to partition them so the conversion runs faster.
+
+Partitioning
+------------
+
+Partitioning a large VCF file involves breaking it into a number of roughly equal-sized parts that can
+be processed in parallel. The parts are specified using genomic regions that follow the regions format
+used in `bcftools <http://samtools.github.io/bcftools/bcftools.html>`_: ``chr:beg-end``,
+where positions are 1-based and inclusive.
+
+All files to be partitioned must have either a Tabix (``.tbi``) or CSI (``.csi``) index. If both are present
+for a particular file, then Tabix is used for finding partitions.
+
+The :func:`sgkit.io.vcf.partition_into_regions` function will create a list of region strings for a VCF
+file, given a desired number of parts to split the file into:
+
+    >>> from sgkit.io.vcf import partition_into_regions
+    >>> partition_into_regions("CEUTrio.20.21.gatk3.4.g.vcf.bgz", num_parts=10)
+    ['20:1-10108928', '20:10108929-10207232', '20:10207233-', '21:1-10027008', '21:10027009-10043392', '21:10043393-10108928', '21:10108929-10141696', '21:10141697-10174464', '21:10174465-10190848', '21:10190849-10207232', '21:10207233-']
+
+It's important to note that the number of regions returned may not be exactly the number of parts
+requested: it may be more or less. However, it is guaranteed that the regions will be contiguous and
+will cover the whole VCF file.
+
+The region strings are passed to ``vcf_to_zarr`` so it can process the parts in parallel:
+
+    >>> from sgkit.io.vcf import partition_into_regions, vcf_to_zarr
+    >>> regions = partition_into_regions("CEUTrio.20.21.gatk3.4.g.vcf.bgz", num_parts=10)
+    >>> vcf_to_zarr("CEUTrio.20.21.gatk3.4.g.vcf.bgz", "output.zarr", regions=regions)
+
+It's also possible to produce parts that have an approximate target size (in bytes). This is useful
+if you are partitioning multiple files, and want all the parts to be roughly the same size.
+
+    >>> from sgkit.io.vcf import partition_into_regions, vcf_to_zarr
+    >>> inputs = ["CEUTrio.20.gatk3.4.g.vcf.bgz", "CEUTrio.21.gatk3.4.g.vcf.bgz"]
+    >>> regions = [partition_into_regions(input, target_part_size=100_000) for input in inputs]
+    >>> vcf_to_zarr(inputs, "output.zarr", regions=regions)
+
+As a special case, ``None`` is used to represent a single partition.
+
+    >>> from sgkit.io.vcf import partition_into_regions
+    >>> partition_into_regions("CEUTrio.20.21.gatk3.4.g.vcf.bgz", num_parts=1)
+    None
+
+Chunk sizes
+-----------
+
+One key advantage of using Zarr as a storage format is its ability to store
+large files in chunks, making it straightforward to process the data in
+parallel.
+
+You can control the chunk *length* (in the variants dimension) and *width*
+(in the samples dimension) by setting the ``chunk_length`` and ``chunk_width``
+parameters to :func:`sgkit.io.vcf.vcf_to_zarr`.
+
+Due to the way that VCF files are parsed, all of the sample data for a given
+chunk of variants are loaded into memory at one time. In other words,
+``chunk_length`` is honored at read time, whereas ``chunk_width`` is honored
+at write time. For files with very large numbers of samples, this can
+exceed working memory. The solution is to also set ``temp_chunk_length`` to be a
+smaller number (than ``chunk_length``), so that fewer variants are loaded
+into memory at one time, while still having the desired output chunk sizes
+(``chunk_length`` and ``chunk_width``). Note that ``temp_chunk_length`` must
+divide ``chunk_length`` evenly.
+
+Cloud storage
+-------------
+
+VCF files can be read from various file systems including cloud stores. However,
+since different underlying libraries are used in different functions, there are
+slight differences in configuration that are outlined here.
+
+The :func:`sgkit.io.vcf.partition_into_regions` function uses `fsspec <https://filesystem-spec.readthedocs.io/en/latest/>`_
+to read VCF metadata and their indexes. Therefore, to access files stored on Amazon S3 or Google Cloud Storage
+install the ``s3fs`` or ``gcsfs`` Python packages, and use ``s3://`` or ``gs://`` URLs.
+
+You can also pass ``storage_options`` to :func:`sgkit.io.vcf.partition_into_regions` to configure the ``fsspec`` backend.
+This provides a way to pass any credentials or other necessary arguments needed to ``s3fs`` or ``gcsfs``.
+
+The :func:`sgkit.io.vcf.vcf_to_zarr` function does *not* use ``fsspec``, since it
+relies on ``htslib`` for file handling, and therefore has its own way of accessing
+cloud storage. You can access files stored on Amazon S3 or Google Cloud Storage
+using ``s3://`` or ``gs://`` URLs. Setting credentials or other options is
+typically achieved using environment variables for the underlying cloud store.
+
+Low-level operation
+-------------------
+
+Calling :func:`sgkit.io.vcf.vcf_to_zarr` runs a two-step operation:
+
+1. Write the output for each input region to a separate temporary Zarr store
+2. Concatenate and rechunk the temporary stores into the final output Zarr store
+
+Each step is run as a Dask computation, which means you can use any Dask configuration
+mechanisms to control aspects of the computation.
+
+For example, you can set the Dask scheduler to run on a cluster. In this case you
+would set the temporary Zarr store to be a cloud storage URL (by setting ``tempdir``) so
+that all workers can access the store (both for reading and writing).
+
+For debugging, or for more control over the steps, consider using
+:func:`sgkit.io.vcf.vcf_to_zarrs` followed by :func:`sgkit.io.vcf.zarrs_to_dataset`,
+then saving the dataset using Xarray's :meth:`xarray.Dataset.to_zarr` method.

--- a/sgkit/io/vcf/vcf_partition.py
+++ b/sgkit/io/vcf/vcf_partition.py
@@ -77,44 +77,43 @@ def partition_into_regions(
     """
     Calculate genomic region strings to partition a compressed VCF or BCF file into roughly equal parts.
 
-    A .tbi or .csi file is used to find BGZF boundaries in the compressed VCF file, which are then
+    A ``.tbi`` or ``.csi`` file is used to find BGZF boundaries in the compressed VCF file, which are then
     used to divide the file into parts.
 
-    The number of parts can specified directly by providing `num_parts`, or by specifying the
-    desired size (in bytes) of each (compressed) part by providing `target_part_size`. Exactly one of `num_parts` or
-    `target_part_size` must be provided.
+    The number of parts can specified directly by providing ``num_parts``, or by specifying the
+    desired size (in bytes) of each (compressed) part by providing ``target_part_size``.
+    Exactly one of ``num_parts`` or ``target_part_size`` must be provided.
 
-    Both `num_parts` and `target_part_size` serve as hints: the number of parts and their sizes
+    Both ``num_parts`` and ``target_part_size`` serve as hints: the number of parts and their sizes
     may be more or less than these parameters.
 
     Parameters
     ----------
-    vcf_path : PathType
+    vcf_path
         The path to the VCF file.
-    index_path : Optional[PathType], optional
-        The path to the VCF index (`.tbi` or `.csi`), by default None. If not specified, the
-        index path is constructed by appending the index suffix (`.tbi` or `.csi`) to the VCF path.
-    num_parts : Optional[int], optional
+    index_path
+        The path to the VCF index (``.tbi`` or ``.csi``), by default None. If not specified, the
+        index path is constructed by appending the index suffix (``.tbi`` or ``.csi``) to the VCF path.
+    num_parts
         The desired number of parts to partition the VCF file into, by default None
-    target_part_size : Optional[int], optional
+    target_part_size
         The desired size, in bytes, of each (compressed) part of the partitioned VCF, by default None
-    storage_options: Optional[Dict[str, str]], optional
-        Any additional parameters for the storage backend (see `fsspec.open`).
+    storage_options:
+        Any additional parameters for the storage backend (see ``fsspec.open``).
 
     Returns
     -------
-    Optional[Sequence[str]]
-        The region strings that partition the VCF file, or None if the VCF file should not be partitioned
-        (so there is only a single partition).
+    The region strings that partition the VCF file, or None if the VCF file should not be partitioned
+    (so there is only a single partition).
 
     Raises
     ------
     ValueError
-        If neither of `num_parts` or `target_part_size` has been specified.
+        If neither of ``num_parts`` or ``target_part_size`` has been specified.
     ValueError
-        If both of `num_parts` and `target_part_size` have been specified.
+        If both of ``num_parts`` and ``target_part_size`` have been specified.
     ValueError
-        If either of `num_parts` or `target_part_size` is not a positive integer.
+        If either of ``num_parts`` or ``target_part_size`` is not a positive integer.
     """
     if num_parts is None and target_part_size is None:
         raise ValueError("One of num_parts or target_part_size must be specified")

--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -203,32 +203,30 @@ def vcf_to_zarrs(
     chunk_width: int = 1_000,
     output_storage_options: Optional[Dict[str, str]] = None,
 ) -> Sequence[str]:
-    """Convert specified regions of one or more VCF files to multiple Zarr on-disk stores,
-    one per region.
+    """Convert VCF files to multiple Zarr on-disk stores, one per region.
 
     Parameters
     ----------
-    input : Union[PathType, Sequence[PathType]]
+    input
         A path (or paths) to the input BCF or VCF file (or files). VCF files should
-        be compressed and have a .tbi or .csi index file. BCF files should have a .csi
-        index file.
-    output : PathType
+        be compressed and have a ``.tbi`` or ``.csi`` index file. BCF files should
+        have a ``.csi`` index file.
+    output
         Path to directory containing the multiple Zarr output stores.
-    regions : Union[None, Sequence[str], Sequence[Optional[Sequence[str]]]], optional
+    regions
         Genomic region or regions to extract variants for. For multiple inputs, multiple
         input regions are specified as a sequence of values which may be None, or a
         sequence of region strings.
-    chunk_length : int, optional
-        Length (number of variants) of chunks in which data are stored, by default 10_000.
-    chunk_width : int, optional
-        Width (number of samples) to use when storing chunks in output, by default 1_000.
-    output_storage_options : Optional[Dict[str, str]], optional
-        Any additional parameters for the storage backend, for the output (see `fsspec.open`).
+    chunk_length
+        Length (number of variants) of chunks in which data are stored, by default 10,000.
+    chunk_width
+        Width (number of samples) to use when storing chunks in output, by default 1,000.
+    output_storage_options
+        Any additional parameters for the storage backend, for the output (see ``fsspec.open``).
 
     Returns
     -------
-    Sequence[str]
-        A list of URLs to the Zarr outputs.
+    A list of URLs to the Zarr outputs.
     """
 
     output_storage_options = output_storage_options or {}
@@ -282,26 +280,25 @@ def zarrs_to_dataset(
     chunk_width: int = 1_000,
     storage_options: Optional[Dict[str, str]] = None,
 ) -> xr.Dataset:
-    """Combine multiple Zarr stores to a single Xarray dataset.
+    """Combine multiple Zarr stores into a single Xarray dataset.
 
     The Zarr stores are concatenated and rechunked to produce a single combined dataset.
 
     Parameters
     ----------
-    urls : Sequence[Path]
+    urls
         A list of URLs to the Zarr stores to combine, typically the return value of
-        `vcf_to_zarrs`.
-    chunk_length : int, optional
-        Length (number of variants) of chunks in which data are stored, by default 10_000.
-    chunk_width : int, optional
-        Width (number of samples) to use when storing chunks in output, by default 1_000.
-    storage_options : Optional[Dict[str, str]], optional
-        Any additional parameters for the storage backend (see `fsspec.open`).
+        :func:`vcf_to_zarrs`.
+    chunk_length
+        Length (number of variants) of chunks in which data are stored, by default 10,000.
+    chunk_width
+        Width (number of samples) to use when storing chunks in output, by default 1,000.
+    storage_options
+        Any additional parameters for the storage backend (see ``fsspec.open``).
 
     Returns
     -------
-    xr.Dataset
-        A dataset representing the combined dataset.
+    A dataset representing the combined dataset.
     """
 
     storage_options = storage_options or {}
@@ -345,44 +342,45 @@ def vcf_to_zarr(
     tempdir: Optional[PathType] = None,
     tempdir_storage_options: Optional[Dict[str, str]] = None,
 ) -> None:
-    """Convert specified regions of one or more VCF files to a single Zarr on-disk store.
+    """Convert VCF files to a single Zarr on-disk store.
 
     For a single input and a single region, the conversion is carried out sequentially.
 
     For multiple outputs or regions, the conversion is carried out in parallel, by writing
-    the output for each region to a separate, intermediate Zarr store in `tempdir`. Then,
+    the output for each region to a separate, intermediate Zarr store in ``tempdir``. Then,
     in a second step the intermediate outputs are concatenated and rechunked into the final
-    output Zarr store in `output`.
+    output Zarr store in ``output``.
 
-    For more control over these two steps, consider using `vcf_to_zarrs` followed by
-    `zarrs_to_dataset`, then saving the dataset using Xarray's `to_zarr` function.
+    For more control over these two steps, consider using :func:`vcf_to_zarrs` followed by
+    :func:`zarrs_to_dataset`, then saving the dataset using Xarray's
+    :meth:`xarray.Dataset.to_zarr` method.
 
     Parameters
     ----------
-    input : Union[PathType, Sequence[PathType]]
+    input
         A path (or paths) to the input BCF or VCF file (or files). VCF files should
-        be compressed and have a .tbi or .csi index file. BCF files should have a .csi
-        index file.
-    output : Union[PathType, MutableMapping[str, bytes]]
+        be compressed and have a ``.tbi`` or ``.csi`` index file. BCF files should
+        have a ``.csi`` index file.
+    output
         Zarr store or path to directory in file system.
-    regions : Union[None, Sequence[str], Sequence[Optional[Sequence[str]]]], optional
+    regions
         Genomic region or regions to extract variants for. For multiple inputs, multiple
         input regions are specified as a sequence of values which may be None, or a
         sequence of region strings.
-    chunk_length : int, optional
-        Length (number of variants) of chunks in which data are stored, by default 10_000.
-    chunk_width : int, optional
-        Width (number of samples) to use when storing chunks in output, by default 1_000.
-    temp_chunk_length : Optional[int], optional
+    chunk_length
+        Length (number of variants) of chunks in which data are stored, by default 10,000.
+    chunk_width
+        Width (number of samples) to use when storing chunks in output, by default 1,000.
+    temp_chunk_length
         Length (number of variants) of chunks for temporary intermediate files. Set this
-        to be smaller than `chunk_length` to avoid memory errors when loading files with
-        very large numbers of samples. Must be evenly divisible into `chunk_length`.
-        Defaults to `chunk_length` if not set.
-    tempdir : Optional[PathType], optional
+        to be smaller than ``chunk_length`` to avoid memory errors when loading files with
+        very large numbers of samples. Must be evenly divisible into ``chunk_length``.
+        Defaults to ``chunk_length`` if not set.
+    tempdir
         Temporary directory where intermediate files are stored. The default None means
         use the system default temporary directory.
-    tempdir_storage_options: Optional[Dict[str, str]], optional
-        Any additional parameters for the storage backend for tempdir (see `fsspec.open`).
+    tempdir_storage_options:
+        Any additional parameters for the storage backend for tempdir (see ``fsspec.open``).
     """
 
     if temp_chunk_length is not None:

--- a/sgkit/io/vcfzarr_reader.py
+++ b/sgkit/io/vcfzarr_reader.py
@@ -14,7 +14,7 @@ def _ensure_2d(arr: ArrayLike) -> ArrayLike:
 
 
 def read_vcfzarr(path: PathType) -> xr.Dataset:
-    """Read a VCF Zarr file.
+    """Read a VCF Zarr file created using scikit-allel.
 
     Loads VCF variant, sample, and genotype data as Dask arrays within a Dataset
     from a Zarr file created using scikit-allel's `vcf_to_zarr` function.


### PR DESCRIPTION
First (draft) attempt to include VCF docs for https://github.com/pystatgen/sgkit-vcf.

The API docs are included, but I needed to install the sgkit-vcf package ~~(with `--no-deps`, to avoid having to install cyvcf2, which is not needed for API signatures)~~.

![sgkit-vcf](https://user-images.githubusercontent.com/85085/92397853-67719a80-f11f-11ea-9703-9b4ed9a35b08.png)


Refs #54