### PR TITLE
Validation Suite (PC Relate)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,23 @@
+name: Validation suite
+
+on:
+  schedule:
+    # Run at the end of every day
+    - cron: "0 0 * * *"
+  # manual trigger
+  workflow_dispatch:
+
+jobs:
+  validation_suite:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        project_id: ${{ secrets.GCP_PROJECT_ID }}
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
+    - name: Download public test data (real HapMap data)
+      run: gsutil -u $GCLOUD_PROJECT cp gs://sgkit-data/validation/hapmap_JPT_CHB_r23a_filtered.zip /tmp/
+    - name: Validate PC Relate
+      run: ./validation/gwas/method/pc_relate/run.sh /tmp/hapmap_JPT_CHB_r23a_filtered.zip

--- a/validation/gwas/method/pc_relate/Dockerfile
+++ b/validation/gwas/method/pc_relate/Dockerfile
@@ -1,0 +1,18 @@
+FROM rstudio/r-base:4.0-focal
+
+# Note: We freeze versions because we want point in time validation
+#       See: https://github.com/pystatgen/sgkit/pull/228
+RUN R -e 'install.packages("tictoc", version = "1.0", repos = "http://cran.us.r-project.org")'
+RUN R -e 'install.packages("https://cran.r-project.org/src/contrib/data.table_1.13.0.tar.gz", type="source", repos=NULL)'
+RUN R -e 'install.packages("BiocManager", version = "1.30.10", repos = "http://cran.us.r-project.org")'
+RUN R -e 'BiocManager::install("SNPRelate")'
+RUN R -e 'BiocManager::install("gdsfmt")'
+RUN R -e 'BiocManager::install("GWASTools")'
+RUN R -e 'BiocManager::install("GENESIS")'
+
+RUN apt-get update \
+ && apt-get install python3 python3-pip git -y \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /requirements.txt
+RUN pip3 install -r /requirements.txt

--- a/validation/gwas/method/pc_relate/README.md
+++ b/validation/gwas/method/pc_relate/README.md
@@ -2,7 +2,7 @@ This runs test to validate our implementation gets the same
 exact results as the reference R implementation for production
 HapMap data.
 
-This code gets executed weekly as part of the Github Actions CI.
+This code is scheduled as part of the Github Actions CI.
 
 To run manually:
 

--- a/validation/gwas/method/pc_relate/README.md
+++ b/validation/gwas/method/pc_relate/README.md
@@ -4,7 +4,11 @@ HapMap data.
 
 This code is scheduled as part of the Github Actions CI.
 
-To run manually:
+To run manually, you need to first download the test data
+from `gs://sgkit-data/validation/hapmap_JPT_CHB_r23a_filtered.zip`,
+keep in mind that `sgkit-data` GCS bucket uses
+[Requester Pays config](https://cloud.google.com/storage/docs/requester-pays),
+and the file size is about 32MB.
 
 ```bash
 gsutil -u $BILLING_PROJECT cp gs://sgkit-data/validation/hapmap_JPT_CHB_r23a_filtered.zip /tmp/

--- a/validation/gwas/method/pc_relate/README.md
+++ b/validation/gwas/method/pc_relate/README.md
@@ -1,0 +1,19 @@
+This runs test to validate our implementation gets the same
+exact results as the reference R implementation for production
+HapMap data.
+
+This code gets executed weekly as part of the Github Actions CI.
+
+To run manually:
+
+```bash
+gsutil -u $BILLING_PROJECT cp gs://sgkit-data/validation/hapmap_JPT_CHB_r23a_filtered.zip /tmp/
+./run.sh /tmp/hapmap_JPT_CHB_r23a_filtered.zip
+```
+
+`run.sh` will:
+ * convert plink data to GDS
+ * run reference [R PC-Relate implementation](pc_relate.R)  
+ * run [our PC-Relate and compare results](validate_pc_relate.py)
+
+The only requirement is that you have Docker and Bash installed.

--- a/validation/gwas/method/pc_relate/convert_plink_to_gds.R
+++ b/validation/gwas/method/pc_relate/convert_plink_to_gds.R
@@ -1,0 +1,15 @@
+#!/usr/bin/env Rscript
+
+library(gdsfmt)
+library(SNPRelate)
+
+args <- commandArgs(trailingOnly=TRUE)
+
+if (length(args) < 2) {
+  stop("usage: <file_name> <out>", call.=FALSE)
+}
+
+snpgdsBED2GDS(bed.fn=paste(args[1], ".bed", sep = ""),
+              bim.fn=paste(args[1], ".bim", sep = ""),
+              fam.fn=paste(args[1], ".fam", sep = ""),
+              out.gdsfn=args[2])

--- a/validation/gwas/method/pc_relate/pc_relate.R
+++ b/validation/gwas/method/pc_relate/pc_relate.R
@@ -1,0 +1,47 @@
+#!/usr/bin/env Rscript
+
+library(gdsfmt)
+library(SNPRelate)
+library(GWASTools)
+library(GENESIS)
+library(tictoc)
+
+args <- commandArgs(trailingOnly=TRUE)
+
+if (length(args) < 1) {
+  stop("usage: <gds_file>", call.=FALSE)
+}
+
+gds_filepath = args[1]
+
+tic("KING kinship")
+genofile <- snpgdsOpen(gds_filepath)
+king_mat <- snpgdsIBDKING(genofile, num.thread=8)
+king_mat_2 = kingToMatrix(king_mat)
+toc(log = TRUE)
+snpgdsClose(genofile)
+
+reader <- GdsGenotypeReader(gds_filepath, "scan,snp")
+geno_data <- GenotypeData(reader)
+
+tic("PC-AIR")
+pcair_result <- pcair(geno_data,
+                      kinobj = king_mat_2,
+                      divobj = king_mat_2)
+toc(log = TRUE)
+summary(pcair_result)
+
+write.csv(pcair_result$vectors[,1:2], file = "pcs.csv")
+
+geno_data <- GenotypeBlockIterator(geno_data)
+tic("PC-Relate")
+pcrelate_result <- pcrelate(geno_data,
+                            pcs = pcair_result$vectors[,1:2])
+toc(log = TRUE)
+
+
+write.csv(pcrelate_result$kinSelf, "kinself.csv")
+write.csv(pcrelate_result$kinBtwn, "kinbtwe.csv")
+write.csv(pcair_result$unrels, "unrels.csv")
+write.csv(pcair_result$rels, "rels.csv")
+summary(pcrelate_result)

--- a/validation/gwas/method/pc_relate/requirements.txt
+++ b/validation/gwas/method/pc_relate/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/pystatgen/sgkit-plink
+pytest

--- a/validation/gwas/method/pc_relate/run.sh
+++ b/validation/gwas/method/pc_relate/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPO_ROOT="$( cd "$DIR/../../../.." >/dev/null 2>&1 && pwd )"
+
+TEST_DATA="$1"
+
+if [[ -z "$TEST_DATA" ]]; then
+  echo "usage $0 <PATH_TO_TEST_DATA>" >&2
+  echo "You can download real test data from gs://sgkit-data/validation/hapmap_JPT_CHB_r23a_filtered.zip" >&2
+  echo "sgkit-data GCS bucket uses Requester Pays config: https://cloud.google.com/storage/docs/requester-pays" >&2
+  exit 1
+fi
+
+if [[ -z "$RUNNING_IN_SGKIT_PC_RELATE_VALIDATION_DOCKER" ]]; then
+  # Note: to speed up the process up, we could:
+  #       * build the docker image and push it to the GHCR/GCR
+  #       * or add docker layer caching https://github.com/marketplace/actions/docker-layer-caching
+  #
+  #       For now, we just build new docker image each time, if we want to run
+  #       validation more often than weekly or just want to get results
+  #       faster we could add any of the above in the future.
+  echo "Building validation docker image, this will take about ~20 minutes ..."
+  docker build -t sgkit_pc_relate_validation -f "$DIR/Dockerfile" "$DIR"
+  docker run --rm \
+  -v $DIR:/work \
+  -v $REPO_ROOT:/code \
+  -v $TEST_DATA:/test_data.zip \
+  -e RUNNING_IN_SGKIT_PC_RELATE_VALIDATION_DOCKER=1 \
+  sgkit_pc_relate_validation /work/run.sh "$1"
+else
+  echo "Running inside docker, will crunch data ..."
+  unzip test_data.zip
+  /work/convert_plink_to_gds.R hapmap_JPT_CHB_r23a_filtered hapmap_JPT_CHB_r23a_filtered.gds
+  /work/pc_relate.R hapmap_JPT_CHB_r23a_filtered.gds
+  cp /work/validate_pc_relate.py .
+  pip3 install -r /code/requirements.txt
+  PYTHONPATH=/code:$PYTHONPATH pytest ./validate_pc_relate.py
+fi

--- a/validation/gwas/method/pc_relate/validate_pc_relate.py
+++ b/validation/gwas/method/pc_relate/validate_pc_relate.py
@@ -6,7 +6,7 @@ import pandas as pd
 import xarray as xr
 from sgkit_plink import read_plink
 
-from sgkit.stats.pc_relate import pc_relate
+from sgkit import pc_relate
 
 
 def test_same_as_the_reference_implementation() -> None:

--- a/validation/gwas/method/pc_relate/validate_pc_relate.py
+++ b/validation/gwas/method/pc_relate/validate_pc_relate.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import pandas as pd
+import xarray as xr
+from sgkit_plink import read_plink
+
+from sgkit.stats.pc_relate import pc_relate
+
+
+def test_same_as_the_reference_implementation() -> None:
+    """
+    This test validates that our implementation gets exactly
+    the same results as the reference R implementation.
+    """
+
+    d = Path(__file__).parent
+    ds = read_plink(path="hapmap_JPT_CHB_r23a_filtered")
+
+    pcs = da.from_array(
+        pd.read_csv(d.joinpath("pcs.csv").as_posix(), usecols=[1, 2]).to_numpy()
+    ).T
+    ds["sample_pcs"] = (("components", "samples"), pcs)
+    phi = pc_relate(ds).pc_relate_phi.compute()
+
+    n_samples = 90
+    assert isinstance(phi, xr.DataArray)
+    assert phi.shape == (n_samples, n_samples)
+
+    # Get genesis/reference results:
+    genesis_phi = pd.read_csv(d.joinpath("kinbtwe.csv"))
+    genesis_phi = genesis_phi[["kin"]].to_numpy()
+
+    phi_s = phi.data[np.triu_indices_from(phi.data, 1)]
+    assert phi_s.size == genesis_phi.size
+    assert np.allclose(phi_s, genesis_phi.T)


### PR DESCRIPTION
Depends on #228 (related: #24)

See: https://github.com/pystatgen/sgkit/pull/228#issuecomment-687607928 for context.

Todo:
 - [x] merge #228 
 - [x] freeze all versions of R packages etc
 - [x] stage public data to a GCS bucket
 - [x] configure github actions to allow to read from the GCS bucket

This validation job currently tests sgkit_plink's `read_plink` + sgkit's `pc_relate` on HapMap data.

This is blocked on pystatgen/sgkit-plink#32.