### PR TITLE
Add missing typing_extensions to setup.cfg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict", "--show-error-codes"]
-        additional_dependencies: ["numpy", "xarray", "dask[array]", "scipy", "zarr", "numba"]
+        additional_dependencies: ["numpy", "xarray", "dask[array]", "scipy", "typing-extensions", "zarr", "numba"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     scipy
     zarr
     numba
+    typing-extensions
     setuptools >= 41.2  # For pkg_resources
 setup_requires =
     setuptools >= 41.2


### PR DESCRIPTION
Example of failure (from sgkit_vcf): https://github.com/pystatgen/sgkit-vcf/pull/11/checks?check_run_id=1112654920, reason `typing_extensions` are not in the ~requirements.~ setup.cfg.

Re: #255 