### PR TITLE
Conda doesn't like sklearn name, we need to use scikit-learn

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,4 @@ zarr
 msprime
 sphinx
 sphinx_rtd_theme
-sklearn
+scikit-learn


### PR DESCRIPTION
Otherwise `conda install --file requirements-dev.txt` fails, we should probably test this in CI btw.