### PR TITLE
PCA implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict", "--show-error-codes"]
-        additional_dependencies: ["numpy", "xarray", "dask[array]", "scipy", "typing-extensions", "zarr", "numba"]
+        additional_dependencies: ["numpy", "xarray", "dask[array]", "scipy", "typing-extensions", "zarr", "numba", "dask-ml"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pytest-cov
 pytest-datadir
 pytest-mock
 hypothesis
+scikit-allel
 statsmodels
 zarr
 msprime
@@ -18,3 +19,4 @@ git+https://github.com/pangeo-data/rechunker.git
 cbgen
 cyvcf2; platform_system != "Windows"
 yarl
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 xarray
 dask[array]
+dask-ml
 scipy
 typing-extensions
 numba

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     numpy
     xarray
     dask[array]
+    dask-ml
     scipy
     zarr
     numba
@@ -87,15 +88,14 @@ ignore =
 profile = black
 default_section = THIRDPARTY
 known_first_party = sgkit
-known_third_party = dask,fire,glow,hail,hypothesis,invoke,msprime,numba,numpy,pandas,pkg_resources,pyspark,pytest,setuptools,sgkit_plink,sklearn,sphinx,typing_extensions,xarray,yaml,zarr
+known_third_party = allel,dask,fire,glow,hail,hypothesis,invoke,msprime,numba,numpy,pandas,pkg_resources,pyspark,pytest,setuptools,sgkit_plink,sklearn,sphinx,typing_extensions,xarray,yaml,zarr
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
 
-[mypy-allel.*]
-ignore_missing_imports = True
+
 [mypy-callee.*]
 ignore_missing_imports = True
 [mypy-cyvcf2.*]
@@ -103,6 +103,8 @@ ignore_missing_imports = True
 [mypy-dask.*]
 ignore_missing_imports = True
 [mypy-fsspec.*]
+ignore_missing_imports = True
+[mypy-dask_ml.*]
 ignore_missing_imports = True
 [mypy-numpy.*]
 ignore_missing_imports = True
@@ -131,6 +133,8 @@ ignore_missing_imports = True
 [mypy-sphinx.*]
 ignore_missing_imports = True
 [mypy-yarl.*]
+ignore_missing_imports = True
+[mypy-allel.*]
 ignore_missing_imports = True
 [mypy-sgkit.*]
 allow_redefinition = True

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -12,6 +12,7 @@ from .stats.aggregation import count_call_alleles, count_variant_alleles, varian
 from .stats.association import gwas_linear_regression
 from .stats.hwe import hardy_weinberg_test
 from .stats.pc_relate import pc_relate
+from .stats.pca import pca
 from .stats.popgen import Fst, Tajimas_D, divergence, diversity
 from .stats.regenie import regenie
 from .testing import simulate_genotype_call_dataset
@@ -38,4 +39,5 @@ __all__ = [
     "pc_relate",
     "simulate_genotype_call_dataset",
     "variables",
+    "pca",
 ]

--- a/sgkit/stats/pca.py
+++ b/sgkit/stats/pca.py
@@ -1,0 +1,343 @@
+from typing import Any, Optional, Union
+
+import dask.array as da
+import numpy as np
+import xarray as xr
+from dask_ml.decomposition import TruncatedSVD
+from sklearn.base import BaseEstimator
+from sklearn.pipeline import Pipeline
+from typing_extensions import Literal
+from xarray import DataArray, Dataset
+
+from sgkit import variables
+
+from ..typing import ArrayLike, DType, RandomStateType
+from ..utils import conditional_merge_datasets
+from .aggregation import count_call_alleles
+from .preprocessing import PattersonScaler
+
+
+def pca_est(
+    ds: Dataset,
+    n_components: int = 10,
+    *,
+    ploidy: Optional[int] = None,
+    scaler: Optional[Union[BaseEstimator, str]] = None,
+    algorithm: Optional[Literal["tsqr", "randomized"]] = None,
+    n_iter: int = 0,
+    random_state: RandomStateType = 0,
+    variable: str = "call_alternate_allele_count",
+) -> BaseEstimator:
+    """ Create PCA estimator """
+    if ploidy is None:
+        if "ploidy" not in ds.dims:
+            raise ValueError(
+                "`ploidy` must be specified explicitly when not present in dataset dimensions"
+            )
+        ploidy = ds.dims["ploidy"]
+    scaler = scaler or "patterson"
+    if isinstance(scaler, str):
+        if scaler != "patterson":
+            raise ValueError(
+                f"Only 'patterson' scaler currently supported (not '{scaler}')"
+            )
+    algorithm = algorithm or "tsqr"
+    if algorithm not in {"tsqr", "randomized"}:
+        raise ValueError(
+            f"`algorithm` must be one of ['tsqr', 'randomized'] (not '{algorithm}')"
+        )
+
+    numblocks = da.asarray(_allele_counts(ds, variable, check_missing=False)).numblocks
+    if all(s > 1 for s in numblocks) and algorithm != "randomized":
+        raise ValueError(
+            "PCA can only be performed on arrays chunked in 2 dimensions if algorithm='randomized'. "
+            "Consider using this algorithm instead or rechunking the alternate allele counts array "
+            "(e.g. ds.call_alternate_allele_count.chunk((None, -1)))."
+        )
+
+    return Pipeline(
+        [
+            ("scaler", PattersonScaler(ploidy=ploidy)),
+            (
+                "pca",
+                TruncatedSVD(
+                    n_components=n_components,
+                    algorithm=algorithm,
+                    n_iter=n_iter,
+                    random_state=random_state,
+                    compute=False,
+                ),
+            ),
+        ]
+    )
+
+
+def pca_fit(
+    ds: Dataset,
+    est: BaseEstimator,
+    *,
+    variable: str = "call_alternate_allele_count",
+    check_missing: bool = True,
+) -> BaseEstimator:
+    """ Fit PCA estimator """
+    AC = _allele_counts(ds, variable, check_missing=check_missing)
+    return est.fit(da.asarray(AC).T)
+
+
+def pca_transform(
+    ds: Dataset,
+    est: BaseEstimator,
+    *,
+    variable: str = "call_alternate_allele_count",
+    check_missing: bool = True,
+    merge: bool = True,
+) -> Dataset:
+    """ Apply PCA estimator to new data """
+    AC = _allele_counts(ds, variable, check_missing=check_missing)
+    projection = est.transform(da.asarray(AC).T)
+    new_ds = Dataset(
+        {variables.sample_pca_projection: (("samples", "components"), projection)}
+    )
+    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+
+
+def _get(est: BaseEstimator, attr: str, fn: Any = lambda v: v) -> Optional[ArrayLike]:
+    try:
+        if hasattr(est, "named_steps"):
+            est = est["pca"]
+        return fn(getattr(est, attr))
+    except Exception:
+        return None
+
+
+def pca_stats(ds: Dataset, est: BaseEstimator, *, merge: bool = True) -> Dataset:
+    """ Extract attributes from PCA estimator """
+    new_ds = {
+        variables.sample_pca_component: (
+            ("variants", "components"),
+            _get(est, "components_", fn=lambda v: v.T),
+        ),
+        variables.sample_pca_explained_variance: (
+            "components",
+            _get(est, "explained_variance_"),
+        ),
+        variables.sample_pca_explained_variance_ratio: (
+            "components",
+            _get(est, "explained_variance_ratio_"),
+        ),
+    }
+    new_ds = Dataset({k: v for k, v in new_ds.items() if v[1] is not None})
+    if "sample_pca_component" in new_ds and "sample_pca_explained_variance" in new_ds:
+        new_ds[variables.sample_pca_loading] = new_ds[
+            variables.sample_pca_component
+        ] * np.sqrt(new_ds[variables.sample_pca_explained_variance])
+    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+
+
+def pca(
+    ds: Dataset,
+    n_components: int = 10,
+    *,
+    ploidy: Optional[int] = None,
+    scaler: Optional[Union[BaseEstimator, str]] = None,
+    algorithm: Optional[Literal["tsqr", "randomized"]] = None,
+    n_iter: int = 0,
+    random_state: RandomStateType = 0,
+    variable: str = "call_alternate_allele_count",
+    check_missing: bool = True,
+    merge: bool = True,
+) -> Dataset:
+    """Run principal component analysis (PCA) via singular value decomposition (SVD).
+
+    Parameters
+    ----------
+    ds
+        Dataset containing genotypes to run PCA on.
+    n_components
+        Number of principal components to compute.
+    ploidy
+        Ploidy for genotypes, will be inferred based on `ploidy`
+        dimension in provided dataset if not passed explicitly.
+    scaler
+        Scaler implementation used to normalize alternate allele counts, by default 'patterson'.
+        This is currently the only supported scaler but a custom estimator may also be passed.
+        See ``sgkit.stats.preprocessing.PattersonScaler`` for more details.
+    algorithm
+        Name of SVD algorithm to use, by default "tsqr". Must be in ["tsqr", "randomized"].
+        The "tsqr" [1] algorithm is deterministic but can be slower than the "randomized" [2] implementation.
+        It also only supports arrays that are chunked in one dimension so it is inherently
+        less scalable.
+    n_iter
+        Number of power iterations used to decrease approximation error when singular values decay slowly,
+        by default 0. Error decreases exponentially as ``n_iter`` increases. In practice, set ``n_iter`` <= 4.
+        Has no effect unless ``algorithm="randomized"``.
+    random_state
+        Random state for randomized SVD.
+        Has no effect unless ``algorithm="randomized"``.
+    variable
+        Name of variable containing data to run PCA on.
+        This can be any 2D non-negative float or integer array with shape (n_variants, n_samples),
+        but it is generally assumed to contain alternate allele counts.
+        If this variable is not present, then alternate allele counts will be added to
+        the provided dataset via ``sgkit.count_call_alternate_alleles``.
+        Lastly, missing values in this variable are assumed to be represented by ``NaN`` or negative values.
+    check_missing
+        Whether or not to check for missing values in data preemptively, by default True.
+        If missing values are present and this check is skipped, errors of a less obvious
+        nature will be raised.
+    merge
+        If True (the default), merge the input dataset and the computed
+        output variables into a single dataset, otherwise return only
+        the computed output variables.
+        See :ref:`dataset_merge` for more details.
+
+    Warnings
+    --------
+    This method does NOT support missing data. Missing values should be imputed or the data should be
+    filtered to complete cases before running PCA.
+
+    When using the "tsqr" algorithm, the ``variable`` used in SVD cannot contain chunking in both dimensions.
+    Use a command like this to remove chunking from the samples dimension:
+    ``ds['call_alternate_allele_count'] = ds['call_alternate_allele_count'].chunk(dict(variants=1000, samples=-1))``.
+
+    The data provided must have positive variance across samples for a single variant. If this
+    is not the case, then errors like this are likely to be thrown: ``LinAlgError: SVD did not converge``.
+    To check this beforehand, try
+    ``assert (ds.call_alternate_allele_count.std(dim="samples") > 0).all().compute().item(0)``.
+
+    Returns
+    -------
+
+    Dataset containing (M = num variants, N = num samples, C = num principal components):
+
+    sample_pca_projection : [array-like, shape: (N, C)]
+        Projection of samples onto principal axes. This array is commonly
+        referred to as "scores" or simply "principal components (PCs)" for a set of samples.
+    sample_pca_component : [array-like, shape: (M, C)]
+        Principal axes defined as eigenvectors for sample covariance matrix.
+        In the context of SVD, these are equivalent to the right singular
+        vectors in the decomposition of a (N, M) matrix,
+        i.e. ``dask_ml.decomposition.TruncatedSVD.components_``.
+    sample_pca_loading : [array-like, shape: (M, C)]
+        Principal axes scaled by square root of eigenvalues.
+        These values can also be interpreted as the correlation between the
+        original variables and the unit-scaled principal axes.
+    sample_pca_explained_variance : [array-like, shape: (C,)]
+        Variance explained by each principal component. These values are equivalent
+        to eigenvalues that result from the eigendecomposition of a (N, M) matrix,
+        i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_``.
+    sample_pca_explained_variance_ratio : [array-like, shape: (C,)]
+        Ratio of variance explained to total variance for each principal component,
+        i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_ratio_``.
+
+    Examples
+    --------
+
+    >>> import xarray as xr
+    >>> import numpy as np
+    >>> import sgkit as sg
+
+    >>> # Set parameters for number of variants and number of samples per cohort
+    >>> n_variant, n_sample = 100, [25, 50, 75]
+
+    >>> # Simulate allele frequencies from 3 distinct ancestral populations
+    >>> rs = np.random.RandomState(0)
+    >>> af = np.concatenate([
+    ...     np.stack([rs.uniform(0.1, 0.9, size=n_variant)] * n_sample[i])
+    ...     for i in range(len(n_sample))
+    ... ])
+
+    >>>  # Run PCA on simulated dataset
+    >>> ds = (
+    ...     sg.simulate_genotype_call_dataset(n_variant=n_variant, n_sample=sum(n_sample), seed=0)
+    ...     .assign(call_alternate_allele_count=(("variants", "samples"), rs.binomial(2, af.T).astype("int8")))
+    ...     .pipe(sg.pca, n_components=2, merge=False)
+    ... )
+    >>> ds.compute() # doctest: +NORMALIZE_WHITESPACE
+    <xarray.Dataset>
+    Dimensions:                              (components: 2, samples: 150, variants: 100)
+    Dimensions without coordinates: components, samples, variants
+    Data variables:
+        sample_pca_projection                (samples, components) float32 0.0103...
+        sample_pca_component                 (variants, components) float32 0.096...
+        sample_pca_explained_variance        (components) float32 44.242146 23.49...
+        sample_pca_explained_variance_ratio  (components) float32 0.19153623 0.10...
+        sample_pca_loading                   (variants, components) float32 0.639...
+
+    >>> # Visualize first two PCs
+    >>> ax = (
+    ...     ds.sample_pca_projection
+    ...     .to_dataframe().unstack()
+    ...     .plot.scatter(x=("sample_pca_projection", 0), y=("sample_pca_projection", 1))
+    ... )
+    >>> ax
+    <AxesSubplot:xlabel='(sample_pca_projection, 0)', ylabel='(sample_pca_projection, 1)'>
+
+    References
+    ----------
+    [1] - A. Benson, D. Gleich, and J. Demmel.
+    Direct QR factorizations for tall-and-skinny matrices in MapReduce architectures.
+    IEEE International Conference on Big Data, 2013.
+    https://arxiv.org/abs/1301.1071
+
+    [2] - N. Halko, P. G. Martinsson, and J. A. Tropp.
+    Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions.
+    SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011
+    https://arxiv.org/abs/0909.4061
+    """
+    if variable not in ds:
+        ds = count_call_alternate_alleles(ds)
+    est = pca_est(
+        ds,
+        n_components=n_components,
+        ploidy=ploidy,
+        scaler=scaler,
+        algorithm=algorithm,
+        n_iter=n_iter,
+        random_state=random_state,
+        variable=variable,
+    )
+    est = pca_fit(
+        ds,
+        est,
+        variable=variable,
+        check_missing=check_missing,
+    )
+    new_ds = xr.merge(
+        [
+            pca_transform(
+                ds,
+                est,
+                variable=variable,
+                check_missing=check_missing,
+                merge=False,
+            ),
+            pca_stats(ds, est, merge=False),
+        ]
+    )
+    return conditional_merge_datasets(ds, new_ds, merge)
+
+
+def count_call_alternate_alleles(ds: Dataset, merge: bool = True) -> Dataset:
+    # TODO: Add to public API (https://github.com/pystatgen/sgkit/issues/282)
+    AC = count_call_alleles(ds, merge=False)["call_allele_count"]
+    AC = AC[..., 1:].sum(dim="alleles").astype("int16")
+    AC = AC.where(~ds.call_genotype_mask.any(dim="ploidy"), AC.dtype.type(-1))
+    new_ds = Dataset({"call_alternate_allele_count": AC})
+    return conditional_merge_datasets(ds, new_ds, merge)
+
+
+def _allele_counts(
+    ds: Dataset,
+    variable: str,
+    check_missing: bool = True,
+    dtype: DType = "float32",
+) -> DataArray:
+    if variable not in ds:
+        ds = count_call_alternate_alleles(ds)
+    AC = ds[variable]
+    if check_missing and ((AC < 0) | AC.isnull()).any().compute().item(0):
+        raise ValueError("Input data cannot contain missing values")
+    if AC.dtype.kind != "f":
+        AC = AC.astype(dtype)  # type: ignore[no-untyped-call]
+    return AC

--- a/sgkit/stats/preprocessing.py
+++ b/sgkit/stats/preprocessing.py
@@ -1,0 +1,104 @@
+from typing import Optional
+
+import dask.array as da
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
+
+from ..typing import ArrayLike
+
+
+class PattersonScaler(BaseEstimator, TransformerMixin):  # type: ignore[misc]
+    """Genotype scaling under HWE as described in Patterson, Price and Reich, 2006.
+
+    Scaling with this approach assumes that alternate alleles appear at a locus
+    on a chromosome following a Bernoulli(`p`) distribution.  Across some number of
+    samples `n` with ploidy `k`, the sampling distribution for the total number of
+    alternate alleles at a locus is Binomial(`kn`, `p`).  This scaler will estimate
+    `p` given fixed `k` and `n`.  Note that this model is invalid for variants that
+    are not in Hardy–Weinberg Equilibrium.
+
+    Simply put, this scaler does the following:
+
+    1. Estimate MAF (`p`) for each variant as the mean alternate
+        allele count divided by ploidy (`k`)
+    2. Estimate the bernoulli variance for each variant as
+        `scale` = sqrt(`p` * (1 - `p`))
+    3. Rescale inputs by subtracting `kp` and dividing by `scale`
+
+    Parameters
+    ----------
+    ploidy : int, optional, default 2
+        Sample ploidy, by default 2.
+
+    Attributes
+    ----------
+    mean_ : (n_variant,) array_like
+        Mean alternate allele count
+    scale_ : (n_variant,) array_like
+        Bernoulli standard deviation
+    """
+
+    def __init__(
+        self,
+        ploidy: int = 2,
+    ):
+        self.ploidy: int = ploidy
+
+    def fit(
+        self,
+        X: ArrayLike,
+        y: Optional[ArrayLike] = None,
+    ) -> "PattersonScaler":
+        """Fit scaler parameters
+
+        Parameters
+        ----------
+        X : (samples, variants) array_like
+            Alternate allele counts with missing values encoded as either nan
+            or negative numbers.
+        """
+        X = da.ma.masked_array(X, mask=da.isnan(X) | (X < 0))
+        self.mean_ = da.ma.filled(da.mean(X, axis=0), fill_value=np.nan)
+        p = self.mean_ / self.ploidy
+        self.scale_ = da.sqrt(p * (1 - p))
+        self.n_features_in_ = X.shape[1]
+        return self
+
+    def partial_fit(
+        self,
+        X: ArrayLike,
+        y: Optional[ArrayLike] = None,
+    ) -> None:
+        raise NotImplementedError()
+
+    def transform(
+        self,
+        X: ArrayLike,
+        y: Optional[ArrayLike] = None,
+        copy: Optional[bool] = None,
+    ) -> ArrayLike:
+        """Apply transform
+
+        Parameters
+        ----------
+        X : (samples, variants) array_like
+            Alternate allele counts with missing values encoded as either nan
+            or negative numbers.
+        """
+        X = da.ma.masked_array(X, mask=da.isnan(X) | (X < 0))
+        X -= self.mean_
+        X /= self.scale_
+        return da.ma.filled(X, fill_value=np.nan)
+
+    def inverse_transform(self, X: ArrayLike, copy: Optional[bool] = None) -> ArrayLike:
+        """Invert transform
+
+        Parameters
+        ----------
+        X : (samples, variants) array_like
+           Alternate allele counts with missing values encoded as either nan
+           or negative numbers.
+        """
+        X *= self.scale_
+        X += self.mean_
+        return X

--- a/sgkit/tests/test_pca.py
+++ b/sgkit/tests/test_pca.py
@@ -1,0 +1,282 @@
+from typing import Any, Optional
+
+import allel
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from xarray import Dataset
+
+from sgkit.stats import pca
+from sgkit.stats.pca import count_call_alternate_alleles
+from sgkit.testing import simulate_genotype_call_dataset
+from sgkit.typing import ArrayLike
+
+
+def simulate_cohort_genotypes(
+    n_variant: int, n_sample: int, n_cohort: int, seed: int = 0
+) -> np.ndarray:
+    """ Sample genotypes from distinct ancestral populations """
+    rs = np.random.RandomState(seed)
+    # Determine size of each cohort (which will be roughly equal)
+    cohort_sizes = list(map(len, np.array_split(np.arange(n_sample), n_cohort)))
+    # Set allele frequencies for each cohort as independent uniform
+    # draws, one for each cohort
+    af = np.concatenate(
+        [
+            np.stack([rs.uniform(0.1, 0.9, size=n_variant)] * cohort_sizes[i])
+            for i in range(n_cohort)
+        ]
+    )
+    # Sample allele counts in [0, 1, 2]
+    return rs.binomial(2, af.T).astype("int8")
+
+
+def simulate_dataset(
+    n_variant: int = 100,
+    n_sample: int = 50,
+    n_cohort: Optional[int] = None,
+    chunks: Any = (None, None),
+) -> Dataset:
+    """ Simulate dataset with optional population structure """
+    ds = simulate_genotype_call_dataset(n_variant, n_sample, seed=0)
+    if n_cohort:
+        ac = simulate_cohort_genotypes(
+            ds.dims["variants"], ds.dims["samples"], n_cohort
+        )
+        ds["call_alternate_allele_count"] = xr.DataArray(
+            ac, dims=("variants", "samples")
+        )
+    else:
+        ds = count_call_alternate_alleles(ds)
+    ds["call_alternate_allele_count"] = ds["call_alternate_allele_count"].chunk(chunks)
+    return ds
+
+
+def allel_pca(gn: ArrayLike, randomized: bool = False, **kwargs: Any) -> Dataset:
+    fn = allel.randomized_pca if randomized else allel.pca
+    pcs, est = fn(gn, **kwargs)
+    return xr.Dataset(
+        dict(
+            sample_pca_projection=(("samples", "components"), pcs),
+            sample_pca_component=(("variants", "components"), est.components_.T),
+            sample_pca_explained_variance=("components", est.explained_variance_),
+            sample_pca_explained_variance_ratio=(
+                "components",
+                est.explained_variance_ratio_,
+            ),
+        )
+    )
+
+
+@pytest.mark.parametrize("shape", [(100, 50), (50, 100), (50, 50)])
+@pytest.mark.parametrize("chunks", [(10, -1), (-1, 10), (-1, -1), (10, 10)])
+@pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
+def test_pca__lazy_evaluation(shape, chunks, algorithm):
+    # Ensure that all new variables are backed by lazy arrays
+    if algorithm == "tsqr" and all(c > 0 for c in chunks):
+        return
+    ds = simulate_dataset(*shape, chunks=chunks)  # type: ignore[misc]
+    ds = pca.pca(ds, n_components=2, algorithm=algorithm, merge=False)
+    for v in ds:
+        assert isinstance(ds[v].data, da.Array)
+
+
+@pytest.mark.parametrize("backend", [np, da])
+@pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
+def test_pca__array_backend(backend, algorithm):
+    # Ensure that calculation succeeds regardless of array input backend
+    ds = simulate_dataset(25, 5)
+    ds["call_alternate_allele_count"] = ds["call_alternate_allele_count"].copy(
+        data=backend.asarray(ds["call_alternate_allele_count"])
+    )
+    ds = pca.pca(ds, n_components=2, algorithm=algorithm, merge=False)
+    for v in ds:
+        ds[v].compute()
+
+
+@pytest.fixture(scope="module")
+def sample_dataset():
+    return simulate_dataset(10, 10)
+
+
+def test_pca__default_allele_counts(sample_dataset):
+    pca.pca(
+        sample_dataset.drop_vars("call_alternate_allele_count"),
+        n_components=2,
+        merge=False,
+    ).compute()
+
+
+def test_pca__raise_on_no_ploidy(sample_dataset):
+    with pytest.raises(ValueError, match="`ploidy` must be specified explicitly"):
+        pca.pca_est(sample_dataset.drop_dims("ploidy"), n_components=2, ploidy=None)
+
+
+def test_pca__raise_on_invalid_scaler(sample_dataset):
+    with pytest.raises(ValueError, match="Only 'patterson' scaler currently supported"):
+        pca.pca_est(sample_dataset, n_components=2, scaler="unknown")
+
+
+def test_pca__raise_on_invalid_algorithm(sample_dataset):
+    with pytest.raises(
+        ValueError, match=r"`algorithm` must be one of \['tsqr', 'randomized'\]"
+    ):
+        pca.pca_est(sample_dataset, n_components=2, algorithm="unknown")  # type: ignore[arg-type]
+
+
+def test_pca__raise_on_incompatible_chunking(sample_dataset):
+    ds = sample_dataset.assign(
+        call_alternate_allele_count=lambda ds: ds["call_alternate_allele_count"].chunk(
+            (2, 2)
+        )
+    )
+    with pytest.raises(
+        ValueError,
+        match="PCA can only be performed on arrays chunked in 2 dimensions if algorithm='randomized'",
+    ):
+        pca.pca_est(ds, n_components=2, algorithm="tsqr")
+
+
+@pytest.mark.parametrize("sentinel", [np.nan, -1])
+def test_pca__raise_on_missing_data(sample_dataset, sentinel):
+    ac = sample_dataset["call_alternate_allele_count"]
+    ac = ac.where(sample_dataset["call_alternate_allele_count"] == 1, sentinel)
+    ds = sample_dataset.assign(call_alternate_allele_count=ac)
+    with pytest.raises(ValueError, match="Input data cannot contain missing values"):
+        pca.pca(ds, n_components=2)
+
+
+def test_pca__fit(sample_dataset):
+    est = pca.TruncatedSVD(compute=False)
+    est = pca.pca_fit(sample_dataset, est)
+    assert hasattr(est, "components_")
+    est = pca.TruncatedSVD(compute=False)
+    est = pca.pca_fit(sample_dataset.drop_vars("call_alternate_allele_count"), est)
+    assert hasattr(est, "components_")
+
+
+def test_pca__transform(sample_dataset):
+    est = pca.TruncatedSVD()
+    est = pca.pca_fit(sample_dataset, est)
+    pca.pca_transform(sample_dataset, est).compute()
+    pca.pca_transform(
+        sample_dataset.drop_vars("call_alternate_allele_count"), est
+    ).compute()
+
+
+def test_pca__stats(sample_dataset):
+    # Test estimator with absent properties
+    est = pca.TruncatedSVD()
+    est = pca.pca_fit(sample_dataset, est)
+    del est.explained_variance_ratio_
+    ds = pca.pca_stats(xr.Dataset(), est)
+    assert "sample_pca_explained_variance_ratio" not in ds
+    assert "sample_pca_explained_variance" in ds
+    # Validate loadings by ensuring that the sum of squares
+    # across variants is equal to the eigenvalues (which are
+    # equal to the explained variance)
+    np.testing.assert_almost_equal(
+        (ds["sample_pca_loading"] ** 2).sum(dim="variants").values,
+        ds["sample_pca_explained_variance"].values,
+        decimal=3,
+    )
+
+
+@pytest.fixture(scope="module", params=[(100, 50), (50, 100)])
+def stability_test_result(request):
+    shape = request.param
+    ds = simulate_dataset(*shape, chunks=(-1, -1), n_cohort=3)  # type: ignore[misc]
+    res = pca.pca(ds, n_components=2, algorithm="tsqr", merge=False)
+    return shape, res
+
+
+@pytest.mark.parametrize("chunks", [(-1, -1), (25, 25)])
+@pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
+def test_pca__stability(stability_test_result, chunks, algorithm):
+    # Ensure that results are stable across algorithms and that sign flips
+    # do not occur when chunking changes
+    if algorithm == "tsqr" and all(c > 0 for c in chunks):
+        return
+    shape, expected = stability_test_result
+    ds = simulate_dataset(*shape, chunks=chunks, n_cohort=3)  # type: ignore[misc]
+    actual = pca.pca(
+        ds, n_components=2, algorithm=algorithm, n_iter=6, random_state=0, merge=False
+    )
+    # Results are expected to change slightly with chunking, but they
+    # will change drastically (far more than 1e-5) if a sign flip occurs
+    xr.testing.assert_allclose(expected, actual, atol=1e-5)  # type: ignore[no-untyped-call]
+
+
+@pytest.mark.parametrize("shape", [(80, 30), (30, 80)])
+@pytest.mark.parametrize("chunks", [(10, -1), (-1, 10), (-1, -1)])
+@pytest.mark.parametrize("n_components", [1, 2, 29])
+def test_pca__tsqr_allel_comparison(shape, chunks, n_components):
+    # Validate chunked, non-random implementation vs scikit-allel single chunk results
+    ds = simulate_dataset(*shape, chunks=chunks)  # type: ignore[misc]
+    ds_sg = pca.pca(ds, n_components=n_components, algorithm="tsqr")
+    ds_sk = allel_pca(
+        ds["call_alternate_allele_count"].values.astype("float32"),
+        n_components=n_components,
+        scaler="patterson",
+        randomized=False,
+    )
+    assert ds_sg["sample_pca_projection"].values.dtype == np.float32
+    assert ds_sk["sample_pca_projection"].values.dtype == np.float32
+    validate_allel_comparison(ds_sg, ds_sk)
+
+
+@pytest.mark.parametrize("shape", [(300, 200), (200, 300)])
+@pytest.mark.parametrize("chunks", [(50, 50)])
+@pytest.mark.parametrize("n_components", [1, 2])
+def test_pca__randomized_allel_comparison(shape, chunks, n_components):
+    # Validate chunked, randomized implementation vs scikit-allel single chunk results --
+    # randomized validation requires more data, more structure, and fewer components in
+    # order for results to be equal within the same tolerance as deterministic svd.
+    ds = simulate_dataset(*shape, chunks=chunks, n_cohort=3)  # type: ignore[misc]
+    ds_sg = pca.pca(
+        ds, n_components=n_components, algorithm="randomized", n_iter=5, random_state=0
+    )
+    ds_sk = allel_pca(
+        ds["call_alternate_allele_count"].values.astype("float32"),
+        n_components=n_components,
+        scaler="patterson",
+        randomized=True,
+        iterated_power=5,
+        random_state=0,
+    )
+    assert ds_sg["sample_pca_projection"].values.dtype == np.float64
+    assert ds_sk["sample_pca_projection"].values.dtype == np.float32
+    validate_allel_comparison(ds_sg, ds_sk)
+
+
+def validate_allel_comparison(ds_sg: Dataset, ds_sk: Dataset) -> None:
+    np.testing.assert_almost_equal(
+        _align_vectors(ds_sg["sample_pca_projection"].values, 0),
+        _align_vectors(ds_sk["sample_pca_projection"].values, 0),
+        decimal=3,
+    )
+    np.testing.assert_almost_equal(
+        _align_vectors(ds_sg["sample_pca_component"].values, 0),
+        _align_vectors(ds_sk["sample_pca_component"].values, 0),
+        decimal=2,
+    )
+    np.testing.assert_almost_equal(
+        ds_sg["sample_pca_explained_variance"].values,
+        ds_sk["sample_pca_explained_variance"].values,
+        decimal=2,
+    )
+    np.testing.assert_almost_equal(
+        ds_sg["sample_pca_explained_variance_ratio"].values,
+        ds_sk["sample_pca_explained_variance_ratio"].values,
+        decimal=2,
+    )
+
+
+def _align_vectors(x: ArrayLike, axis: int) -> ArrayLike:
+    """ Align vectors to common, arbitrary half-space """
+    assert x.ndim == 2
+    v = np.random.RandomState(1).rand(x.shape[axis])
+    signs = np.dot(x, v)[:, np.newaxis] if axis == 1 else np.dot(v[np.newaxis], x)
+    signs = signs.dtype.type(2) * ((signs >= 0) - signs.dtype.type(0.5))
+    return x * signs

--- a/sgkit/tests/test_preprocessing.py
+++ b/sgkit/tests/test_preprocessing.py
@@ -1,0 +1,100 @@
+from typing import Any
+
+import allel.stats.preprocessing
+import dask.array as da
+import numpy as np
+import pytest
+
+import sgkit.stats.preprocessing
+from sgkit.typing import ArrayLike, DType
+
+
+def simulate_alternate_allele_counts(
+    n_variant: int,
+    n_sample: int,
+    ploidy: int,
+    chunks: Any = (10, 10),
+    dtype: DType = "i",
+    seed: int = 0,
+) -> ArrayLike:
+    rs = da.random.RandomState(seed)
+    return rs.randint(
+        0, ploidy + 1, size=(n_variant, n_sample), chunks=chunks, dtype=dtype
+    )
+
+
+@pytest.mark.parametrize("shape", [(100, 50), (50, 100), (50, 50)])
+@pytest.mark.parametrize("ploidy", [2, 4])
+def test_patterson_scaler__allel_comparison(shape, ploidy):
+    ac = simulate_alternate_allele_counts(*shape, ploidy=ploidy)  # type: ignore[misc]
+    expected = sgkit.stats.preprocessing.PattersonScaler(ploidy=ploidy).fit_transform(
+        ac
+    )
+    actual = (
+        allel.stats.preprocessing.PattersonScaler(ploidy=ploidy)
+        .fit_transform(np.asarray(ac).T)
+        .T
+    )
+    np.testing.assert_array_almost_equal(expected, actual, decimal=2)
+
+
+@pytest.fixture(scope="module")
+def allele_counts():
+    return simulate_alternate_allele_counts(100, 50, ploidy=2)
+
+
+def test_patterson_scaler__lazy_evaluation(allele_counts):
+    scaler = sgkit.stats.preprocessing.PattersonScaler()
+    assert isinstance(scaler.fit_transform(allele_counts), da.Array)
+    assert isinstance(scaler.transform(allele_counts), da.Array)
+    assert isinstance(scaler.inverse_transform(allele_counts), da.Array)
+    assert isinstance(scaler.mean_, da.Array)
+    assert isinstance(scaler.scale_, da.Array)
+
+
+@pytest.mark.parametrize(
+    "dtype,expected_dtype",
+    [("f2", "f2"), ("f4", "f4"), ("f8", "f8"), ("i1", "f8"), ("u1", "f8")],
+)
+def test_patterson_scaler__dtype(allele_counts, dtype, expected_dtype):
+    scaler = sgkit.stats.preprocessing.PattersonScaler()
+    expected_dtype = np.dtype(expected_dtype)
+    assert scaler.fit_transform(allele_counts.astype(dtype)).dtype == expected_dtype
+    assert scaler.transform(allele_counts.astype(dtype)).dtype == expected_dtype
+    assert scaler.inverse_transform(allele_counts.astype(dtype)).dtype == expected_dtype
+    assert scaler.mean_.dtype == expected_dtype
+    assert scaler.scale_.dtype == expected_dtype
+
+
+def test_patterson_scaler__raise_on_partial_fit(allele_counts):
+    scaler = sgkit.stats.preprocessing.PattersonScaler()
+    with pytest.raises(NotImplementedError):
+        scaler.partial_fit(allele_counts)
+
+
+@pytest.mark.parametrize("dtype", ["i1", "i2", "f2", "f4", "f8"])
+@pytest.mark.parametrize("use_nan", [True, False])
+def test_patterson_scaler__missing_data(dtype, use_nan):
+    ac = np.array([[0, -1, -1, -1], [1, 0, -1, -1], [2, 2, 1, -1]], dtype=dtype)
+    if use_nan and ac.dtype.kind != "f":
+        return
+    if use_nan:
+        # Verify that nan and negative sentinel values are interchangeable
+        ac = np.where(ac < 0, np.nan, ac)
+    scaler = sgkit.stats.preprocessing.PattersonScaler().fit(ac)
+    # Read means from columns of array; scale = sqrt(mean/2 * (1 - mean/2))
+    np.testing.assert_equal(scaler.mean_, np.array([1] * 3 + [np.nan]))
+    np.testing.assert_equal(scaler.scale_, np.array([0.5] * 3 + [np.nan]))
+    np.testing.assert_equal(
+        scaler.transform(ac),
+        np.array(
+            [
+                [-2.0, np.nan, np.nan, np.nan],
+                [0.0, -2.0, np.nan, np.nan],
+                [2.0, 2.0, 0.0, np.nan],
+            ]
+        ),
+    )
+    # Test inversion to original array
+    acr = scaler.inverse_transform(scaler.transform(ac))
+    np.testing.assert_equal(np.where(np.isnan(acr), np.nan if use_nan else -1, acr), ac)

--- a/sgkit/typing.py
+++ b/sgkit/typing.py
@@ -7,3 +7,4 @@ import numpy as np
 ArrayLike = Union[np.ndarray, da.Array]
 DType = Any
 PathType = Union[str, Path]
+RandomStateType = Union[np.random.RandomState, da.random.RandomState, int]

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -247,6 +247,41 @@ sample_pcs, sample_pcs_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("sample_pcs", ndim=2, kind="f")
 )
 """Sample PCs (PCxS)."""
+sample_pca_component, sample_pca_component_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("sample_pca_component", ndim=2, kind="f")
+)
+"""Principal axes defined as eigenvectors for sample covariance matrix.
+In the context of SVD, these are equivalent to the right singular vectors in
+the decomposition of a (N, M) matrix., i.e. ``dask_ml.decomposition.TruncatedSVD.components_``."""
+(
+    sample_pca_explained_variance,
+    sample_pca_explained_variance_spec,
+) = SgkitVariables.register_variable(
+    ArrayLikeSpec("sample_pca_explained_variance", ndim=1, kind="f")
+)
+"""Variance explained by each principal component. These values are equivalent
+to eigenvalues that result from the eigendecomposition of a (N, M) matrix,
+i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_``."""
+(
+    sample_pca_explained_variance_ratio,
+    sample_pca_explained_variance_ratio_spec,
+) = SgkitVariables.register_variable(
+    ArrayLikeSpec("sample_pca_explained_variance_ratio", ndim=1, kind="f")
+)
+"""Ratio of variance explained to total variance for each principal component,
+i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_ratio_``."""
+sample_pca_loading, sample_pca_loading_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("sample_pca_loading", ndim=2, kind="f")
+)
+"""PCA loadings defined as principal axes scaled by square root of eigenvalues.
+These values  can also be interpreted  as the correlation between the original variables
+and unit-scaled principal axes."""
+sample_pca_projection, sample_pca_projection_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("sample_pca_projection", ndim=2, kind="f")
+)
+"""Projection of samples onto principal axes. This array is commonly
+referred to as "scores" or simply "principal components (PCs)" for a set of samples."""
+
 stat_Fst, stat_Fst_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("stat_Fst", ndim=2, kind="f")
 )


### PR DESCRIPTION
Implementation for https://github.com/pystatgen/sgkit/issues/95.

Notes:

### Upstream Fixes

Some upstream fixes necessary for this were:

- Dask SVD broken for short-fat arrays (https://github.com/dask/dask/pull/6591)
- Dask SVD had poor performance on certain in-memory arrays (https://github.com/dask/dask/pull/6616)
- The svd_flip function in dask-ml (used by PCA/TruncatedSVD) would have forced in-memory evaluation, but it doesn't anymore (https://github.com/dask/dask/pull/6613)
  - The fix for this also makes da.linalg.svd results consistent across platforms and input array chunkings 
- Dask-ml PCA classes force eager evaluation (https://github.com/dask/dask-ml/issues/740)
- Randomized SVD broken for small arrays (https://github.com/dask/dask/pull/6622)

### Discussion

- I added https://github.com/pystatgen/sgkit/issues/285 to track adding more extensive examples
- This contains a temporary workaround for https://github.com/pystatgen/sgkit/issues/282 that should eventually be removed
- Dependencies added:
  - matplotlib and scikit-allel as dev dependencies
  - dask-ml as a core dependency
- I opened https://github.com/pystatgen/sgkit/issues/286 to discuss how to handle required variables in a calculation like this (I don't particularly like how it works in this PR at the moment)

### TODO

- [x] More tests
  - [x] f4/f8 dtype preservation
  - [x] More complex chunking tests (this is the source of many problems)
  - [x] Add randomized/deterministic comparison 
  - [x] Ensure lazy evaluation
  - [x] Validate sign stability across random states and chunkings
  - [x] Add missing data warning
  - [x] Test for inputs on different array backends
  - [x] Patterson scaler
    - [x] test vs skallel
    - [x] test with missing data
    - [x] test dtype preservation
- [x] Add return_estimator option (or save scaler properties in dataset)
- [X] Throw informative errors when chunking not compatible with algorithm
- [x] Decide whether or not randomized pca should be a separate function since it is the only option for fully-chunked arrays
- [x] Lift `count_call_alternate_alleles` into issue
- [x] Improve test speed
- [x] Add docs