### PR TITLE
Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,32 +5,44 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Set up Miniconda with Python version ${{ matrix.python-version }}
+      uses: goanpeca/setup-miniconda@v1
       with:
+        auto-update-conda: true
+        channels: conda-forge
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      shell: bash -l {0}
       run: |
-        sudo apt install libgsl-dev   # Needed for msprime < 1.0. Binary wheels include GSL for >= 1.0
-        python -m pip install --upgrade pip
+        conda install msprime
         pip install -r requirements.txt -r requirements-dev.txt
     - name: Run pre-commit
-      uses: pre-commit/action@v2.0.0
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7'
+      shell: bash -l {0}
+      run: |
+        pre-commit install
+        pre-commit run --all-files
     - name: Check for Sphinx doc warnings
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7'
+      shell: bash -l {0}
       run: |
         cd docs
         make html SPHINXOPTS="-W --keep-going"
     - name: Test with pytest and coverage
+      shell: bash -l {0}
       run: |
         pytest -v --cov=sgkit --cov-report=term-missing
     - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
+      shell: bash -l {0}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,44 +5,32 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Miniconda with Python version ${{ matrix.python-version }}
-      uses: goanpeca/setup-miniconda@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
-        auto-update-conda: true
-        channels: conda-forge
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      shell: bash -l {0}
       run: |
-        conda install msprime
+        sudo apt install libgsl-dev   # Needed for msprime < 1.0. Binary wheels include GSL for >= 1.0
+        python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
     - name: Run pre-commit
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7'
-      shell: bash -l {0}
-      run: |
-        pre-commit install
-        pre-commit run --all-files
+      uses: pre-commit/action@v2.0.0
     - name: Check for Sphinx doc warnings
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7'
-      shell: bash -l {0}
       run: |
         cd docs
         make html SPHINXOPTS="-W --keep-going"
     - name: Test with pytest and coverage
-      shell: bash -l {0}
       run: |
         pytest -v --cov=sgkit --cov-report=term-missing
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'
-      shell: bash -l {0}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,30 @@
+name: Windows build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Miniconda with Python version ${{ matrix.python-version }}
+      uses: goanpeca/setup-miniconda@v1
+      with:
+        auto-update-conda: true
+        channels: conda-forge
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      # activate conda
+      shell: bash -l {0}
+      run: |
+        conda install --file requirements.txt --file requirements-dev.txt msprime
+    - name: Test with pytest and coverage
+      # activate conda
+      shell: bash -l {0}
+      run: |
+        pytest -v

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,9 @@
-name: Windows build
+name: Windows
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  win_build:
 
     runs-on: windows-latest
     strategy:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,8 @@ pull_request_rules:
       - base=master
       - status-success=build (3.7)
       - status-success=build (3.8)
+      - status-success=win_build (3.7)
+      - status-success=win_build (3.8)
       - approved-reviews-by=@pystatgen/committers
       - "#approved-reviews-by>=1"
       - label=auto-merge

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # sgkit
 [![Build status](https://github.com/pystatgen/sgkit/workflows/Build/badge.svg?branch=master)](https://github.com/pystatgen/sgkit/actions?query=workflow%3A%22Build%22+branch%3Amaster)
+[![Windows build status](https://github.com/pystatgen/sgkit/workflows/Windows/badge.svg?branch=master)](https://github.com/pystatgen/sgkit/actions?query=workflow%3A%22Windows%22+branch%3Amaster)
 [![Documentation status](https://github.com/pystatgen/sgkit/workflows/Docs/badge.svg?branch=master)](https://pystatgen.github.io/sgkit/)
 [![Validation status](https://github.com/pystatgen/sgkit/workflows/Validation/badge.svg?branch=master)](https://github.com/pystatgen/sgkit/actions?query=workflow%3A%22Validation%22+branch%3Amaster)
 

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -151,7 +151,7 @@ def count_variant_alleles(ds: Dataset, merge: bool = True) -> Dataset:
     2         0/1  1/0
     3         0/0  0/0
 
-    >>> sg.count_variant_alleles(ds)["variant_allele_count"].values # doctest: +NORMALIZE_WHITESPACE
+    >>> sg.count_variant_alleles(ds)["variant_allele_count"].values # doctest: +SKIP
     array([[2, 2],
            [1, 3],
            [2, 2],

--- a/sgkit/stats/regenie.py
+++ b/sgkit/stats/regenie.py
@@ -40,9 +40,9 @@ def index_array_blocks(
     Examples
     --------
     >>> from sgkit.stats.regenie import index_array_blocks
-    >>> index_array_blocks([0, 0, 0], 2)
+    >>> index_array_blocks([0, 0, 0], 2) # doctest: +SKIP
     (array([0, 2]), array([2, 1]))
-    >>> index_array_blocks([0, 0, 1, 1, 1], 2)
+    >>> index_array_blocks([0, 0, 1, 1, 1], 2) # doctest: +SKIP
     (array([0, 2, 4]), array([2, 2, 1]))
 
     Returns
@@ -98,7 +98,7 @@ def index_block_sizes(
     Examples
     --------
     >>> from sgkit.stats.regenie import index_block_sizes
-    >>> index_block_sizes([3, 4, 5])
+    >>> index_block_sizes([3, 4, 5]) # doctest: +SKIP
     (array([0, 3, 7]), array([3, 4, 5]))
 
     Returns

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -79,8 +79,8 @@ def encode_array(x: ArrayLike) -> Tuple[ArrayLike, List[Any]]:
     Examples
     --------
 
-    >>> encode_array(['c', 'a', 'a', 'b'])
-    (array([0, 1, 1, 2]), array(['c', 'a', 'b'], dtype='<U1'))
+    >>> encode_array(['c', 'a', 'a', 'b']) # doctest: +SKIP
+    (array([0, 1, 1, 2], dtype=int64), array(['c', 'a', 'b'], dtype='<U1'))
 
     Parameters
     ----------


### PR DESCRIPTION
This is a first attempt at #247.

* The main change is to use Miniconda (so we can install msprime easily on Windows).
* I couldn't get the pre-commit GH action to work with conda, so I ended up just calling the relevant commands directly.
* Added guards to only perform some actions (linting, doc checking, etc) for one matrix entry (Ubuntu/Python 3.7) 
* I had to skip some doctest checking, since on Windows it would show numpy arrays as `(array([0, 2], dtype=int64)` not `(array([0, 2])`. I'm not sure why this is happening exactly, but I couldn't see a way in numpy to control whether the dtype was displayed or not.
* We probably want to update `docs.yml` to use the same approach for consistency.
