### PR TITLE
Split out docs requirements so they don't need to be installed on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sudo apt install libgsl-dev   # Needed for msprime < 1.0. Binary wheels include GSL for >= 1.0
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
+        pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt
     - name: Run pre-commit
       uses: pre-commit/action@v2.0.0
     - name: Check for Sphinx doc warnings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sudo apt install libgsl-dev   # Needed for msprime < 1.0. Binary wheels include GSL for >= 1.0
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt
+        pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt
     - name: Build Sphinx documentation
       run: |
         cd docs

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -92,7 +92,7 @@ To build the library you can install the necessary requirements using
 pip::
 
   cd sgkit
-  pip install -r requirements.txt -r requirements-dev.txt
+  pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt
 
 Also install pre-commit, which is used to enforce coding standards::
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,3 @@ hypothesis
 statsmodels
 zarr
 msprime
-sphinx
-sphinx_rtd_theme
-scikit-learn
-sphinx_autodoc_typehints
-scanpydoc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ hypothesis
 statsmodels
 zarr
 msprime
+scikit-learn

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx
+sphinx_rtd_theme
+scikit-learn
+sphinx_autodoc_typehints
+scanpydoc

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,4 @@
 sphinx
 sphinx_rtd_theme
-scikit-learn
 sphinx_autodoc_typehints
 scanpydoc


### PR DESCRIPTION
The Windows CI build is [failing](https://github.com/pystatgen/sgkit/runs/1143067740) because it crossed with #261 which introduced dependencies that are not available in conda (for Windows). These are `scanpydoc` and `sphinx_autodoc_typehints`.

Since we don't build docs on Windows, I've split out the docs requirements, and not included them for the Windows build.

Fixes #247