### PR TITLE
Revert "Workaround dask#6631 (#246)"

### DIFF
--- a/sgkit/io/vcfzarr_reader.py
+++ b/sgkit/io/vcfzarr_reader.py
@@ -60,11 +60,9 @@ def read_vcfzarr(path: PathType) -> xr.Dataset:
     )
 
     # Add a mask for variant ID
-    # Note: we wrap the "." inside a list to workaround https://github.com/dask/dask/issues/6631,
-    #       and therefor force dask array's eq
     ds["variant_id_mask"] = (
         [DIM_VARIANT],
-        variants_id == ["."],
+        variants_id == ".",
     )
 
     return ds


### PR DESCRIPTION
Dask 2.18.0 has the fix included via https://github.com/dask/dask/pull/6632

This reverts commit ffd85e0e1f27478f550b188a53b597b71338d364.