### PR TITLE
Fix docs build after VCF merger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,8 @@ jobs:
         python-version: '3.8'
     - name: Install dependencies
       run: |
+        sudo apt update -y
+        sudo apt install -y libcurl4-openssl-dev  # Needed for htslib (via cyvcf2)
         sudo apt install libgsl-dev   # Needed for msprime < 1.0. Binary wheels include GSL for >= 1.0
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt -r requirements-doc.txt


### PR DESCRIPTION
The docs build only gets run on push to master, so I missed this in #289.