### PR TITLE
Fst windowing

### DIFF
--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -348,10 +348,11 @@ def Fst(
         ds, allele_counts=allele_counts, call_genotype=call_genotype, merge=False
     ).stat_divergence
     gs = da.asarray(gs)
-    shape = (n_cohorts, n_cohorts)
+    shape = (gs.chunks[0], n_cohorts, n_cohorts)
     fst = da.map_blocks(known_estimators[estimator], gs, chunks=shape, dtype=np.float64)
-    assert_array_shape(fst, n_cohorts, n_cohorts)
-    new_ds = Dataset({variables.stat_Fst: (("cohorts_0", "cohorts_1"), fst)})
+    # TODO: reinstate assert (first dim could be either variants or windows)
+    # assert_array_shape(fst, n_windows, n_cohorts, n_cohorts)
+    new_ds = Dataset({variables.stat_Fst: (("windows", "cohorts_0", "cohorts_1"), fst)})
     return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
 
 

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -48,10 +48,10 @@ def ts_to_dataset(ts, chunks=None, samples=None):
     return ds
 
 
-@pytest.mark.parametrize("size", [2, 3, 10, 100])
+@pytest.mark.parametrize("sample_size", [2, 3, 10, 100])
 @pytest.mark.parametrize("chunks", [(-1, -1), (10, -1)])
-def test_diversity(size, chunks):
-    ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
+def test_diversity(sample_size, chunks):
+    ts = msprime.simulate(sample_size, length=100, mutation_rate=0.05, random_seed=42)
     ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     ds = ds.chunk(dict(zip(["variants", "samples"], chunks)))
     sample_cohorts = np.full_like(ts.samples(), 0)
@@ -63,9 +63,9 @@ def test_diversity(size, chunks):
     np.testing.assert_allclose(div, ts_div)
 
 
-@pytest.mark.parametrize("size", [10])
-def test_diversity__windowed(size):
-    ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
+@pytest.mark.parametrize("sample_size", [10])
+def test_diversity__windowed(sample_size):
+    ts = msprime.simulate(sample_size, length=200, mutation_rate=0.05, random_seed=42)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.full_like(ts.samples(), 0)
     ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
@@ -93,12 +93,12 @@ def test_diversity__windowed(size):
 
 
 @pytest.mark.parametrize(
-    "size, n_cohorts",
+    "sample_size, n_cohorts",
     [(2, 2), (3, 2), (3, 3), (10, 2), (10, 3), (10, 4), (100, 2), (100, 3), (100, 4)],
 )
 @pytest.mark.parametrize("chunks", [(-1, -1), (10, -1)])
-def test_divergence(size, n_cohorts, chunks):
-    ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
+def test_divergence(sample_size, n_cohorts, chunks):
+    ts = msprime.simulate(sample_size, length=100, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
     ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
@@ -124,10 +124,10 @@ def test_divergence(size, n_cohorts, chunks):
     np.testing.assert_allclose(div, ts_div)
 
 
-@pytest.mark.parametrize("size, n_cohorts", [(10, 2)])
+@pytest.mark.parametrize("sample_size, n_cohorts", [(10, 2)])
 @pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
-def test_divergence__windowed(size, n_cohorts, chunks):
-    ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
+def test_divergence__windowed(sample_size, n_cohorts, chunks):
+    ts = msprime.simulate(sample_size, length=200, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
     ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
@@ -167,11 +167,11 @@ def test_divergence__windowed(size, n_cohorts, chunks):
     # np.testing.assert_allclose(div[:-1], ska_div)  # scikit-allel has final window missing
 
 
-@pytest.mark.parametrize("size", [2, 3, 10, 100])
-def test_Fst__Hudson(size):
+@pytest.mark.parametrize("sample_size", [2, 3, 10, 100])
+def test_Fst__Hudson(sample_size):
     # scikit-allel can only calculate Fst for pairs of cohorts (populations)
     n_cohorts = 2
-    ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
+    ts = msprime.simulate(sample_size, length=100, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
@@ -195,11 +195,11 @@ def test_Fst__Hudson(size):
 
 
 @pytest.mark.parametrize(
-    "size, n_cohorts",
+    "sample_size, n_cohorts",
     [(2, 2), (3, 2), (3, 3), (10, 2), (10, 3), (10, 4), (100, 2), (100, 3), (100, 4)],
 )
-def test_Fst__Nei(size, n_cohorts):
-    ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
+def test_Fst__Nei(sample_size, n_cohorts):
+    ts = msprime.simulate(sample_size, length=100, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
@@ -230,12 +230,12 @@ def test_Fst__unknown_estimator():
 
 
 @pytest.mark.parametrize(
-    "size, n_cohorts",
+    "sample_size, n_cohorts",
     [(10, 2)],
 )
 @pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
-def test_Fst__windowed(size, n_cohorts, chunks):
-    ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
+def test_Fst__windowed(sample_size, n_cohorts, chunks):
+    ts = msprime.simulate(sample_size, length=200, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
     ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
@@ -274,9 +274,9 @@ def test_Fst__windowed(size, n_cohorts, chunks):
     )  # scikit-allel has final window missing
 
 
-@pytest.mark.parametrize("size", [2, 3, 10, 100])
-def test_Tajimas_D(size):
-    ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
+@pytest.mark.parametrize("sample_size", [2, 3, 10, 100])
+def test_Tajimas_D(sample_size):
+    ts = msprime.simulate(sample_size, length=100, mutation_rate=0.05, random_seed=42)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.full_like(ts.samples(), 0)
     ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -125,10 +125,11 @@ def test_divergence(size, n_cohorts, chunks):
 
 
 @pytest.mark.parametrize("size, n_cohorts", [(10, 2)])
-def test_divergence__windowed(size, n_cohorts):
+@pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
+def test_divergence__windowed(size, n_cohorts, chunks):
     ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
         [np.full_like(subset, i) for i, subset in enumerate(subsets)]
     )
@@ -167,13 +168,12 @@ def test_divergence__windowed(size, n_cohorts):
 
 
 @pytest.mark.parametrize("size", [2, 3, 10, 100])
-@pytest.mark.parametrize("chunks", [(-1, -1), (10, -1)])
-def test_Fst__Hudson(size, chunks):
+def test_Fst__Hudson(size):
     # scikit-allel can only calculate Fst for pairs of cohorts (populations)
     n_cohorts = 2
     ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
         [np.full_like(subset, i) for i, subset in enumerate(subsets)]
     )
@@ -198,11 +198,10 @@ def test_Fst__Hudson(size, chunks):
     "size, n_cohorts",
     [(2, 2), (3, 2), (3, 3), (10, 2), (10, 3), (10, 4), (100, 2), (100, 3), (100, 4)],
 )
-@pytest.mark.parametrize("chunks", [(-1, -1), (10, -1)])
-def test_Fst__Nei(size, n_cohorts, chunks):
+def test_Fst__Nei(size, n_cohorts):
     ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
         [np.full_like(subset, i) for i, subset in enumerate(subsets)]
     )
@@ -234,10 +233,11 @@ def test_Fst__unknown_estimator():
     "size, n_cohorts",
     [(10, 2)],
 )
-def test_Fst__windowed(size, n_cohorts):
+@pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
+def test_Fst__windowed(size, n_cohorts, chunks):
     ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     sample_cohorts = np.concatenate(
         [np.full_like(subset, i) for i, subset in enumerate(subsets)]
     )
@@ -275,10 +275,9 @@ def test_Fst__windowed(size, n_cohorts):
 
 
 @pytest.mark.parametrize("size", [2, 3, 10, 100])
-@pytest.mark.parametrize("chunks", [(-1, -1), (10, -1)])
-def test_Tajimas_D(size, chunks):
+def test_Tajimas_D(size):
     ts = msprime.simulate(size, length=100, mutation_rate=0.05, random_seed=42)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.full_like(ts.samples(), 0)
     ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
     n_variants = ds.dims["variants"]

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -281,6 +281,8 @@ def test_Tajimas_D(size, chunks):
     ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     sample_cohorts = np.full_like(ts.samples(), 0)
     ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
+    n_variants = ds.dims["variants"]
+    ds = window(ds, size=n_variants, step=n_variants)  # single window
     ds = Tajimas_D(ds)
     d = ds.stat_Tajimas_D.compute()
     ts_d = ts.Tajimas_D()

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -76,8 +76,8 @@ def test_diversity__windowed(sample_size):
 
     # Calculate diversity using tskit windows
     # Find the variant positions so we can have windows with a fixed number of variants
-    positions = [variant.site.position for variant in ts.variants()]
-    windows = [0] + positions[::25][1:] + [ts.sequence_length]
+    positions = ts.tables.sites.position
+    windows = np.concatenate(([0], positions[::25][1:], [ts.sequence_length]))
     ts_div = ts.diversity(windows=windows, span_normalise=False)
     np.testing.assert_allclose(div, ts_div)
 
@@ -144,8 +144,8 @@ def test_divergence__windowed(sample_size, n_cohorts, chunks):
 
     # Calculate diversity using tskit windows
     # Find the variant positions so we can have windows with a fixed number of variants
-    positions = [variant.site.position for variant in ts.variants()]
-    windows = [0] + positions[::25][1:] + [ts.sequence_length]
+    positions = ts.tables.sites.position
+    windows = np.concatenate(([0], positions[::25][1:], [ts.sequence_length]))
     n_windows = len(windows) - 1
     ts_div = np.full([n_windows, n_cohorts, n_cohorts], np.nan)
     for i, j in itertools.combinations(range(n_cohorts), 2):
@@ -272,8 +272,8 @@ def test_Fst__windowed(sample_size, n_cohorts, chunks):
 
     # Calculate Fst using tskit windows
     # Find the variant positions so we can have windows with a fixed number of variants
-    positions = [variant.site.position for variant in ts.variants()]
-    windows = [0] + positions[::25][1:] + [ts.sequence_length]
+    positions = ts.tables.sites.position
+    windows = np.concatenate(([0], positions[::25][1:], [ts.sequence_length]))
     n_windows = len(windows) - 1
     ts_fst = np.full([n_windows, n_cohorts, n_cohorts], np.nan)
     for i, j in itertools.combinations(range(n_cohorts), 2):

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -64,7 +64,7 @@ def test_diversity(size, chunks):
 
 
 @pytest.mark.parametrize("size", [10])
-def test_windowed_diversity(size):
+def test_diversity__windowed(size):
     ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
     sample_cohorts = np.full_like(ts.samples(), 0)
@@ -86,9 +86,9 @@ def test_windowed_diversity(size):
     ds = count_variant_alleles(ts_to_dataset(ts))  # type: ignore[no-untyped-call]
     ac = ds["variant_allele_count"].values
     mpd = allel.mean_pairwise_difference(ac, fill=0)
-    sa_div = allel.moving_statistic(mpd, np.sum, size=25, step=25)
+    ska_div = allel.moving_statistic(mpd, np.sum, size=25, step=25)
     np.testing.assert_allclose(
-        div[:-1], sa_div
+        div[:-1], ska_div
     )  # scikit-allel has final window missing
 
 
@@ -125,7 +125,7 @@ def test_divergence(size, n_cohorts, chunks):
 
 
 @pytest.mark.parametrize("size, n_cohorts", [(10, 2)])
-def test_windowed_divergence(size, n_cohorts):
+def test_divergence__windowed(size, n_cohorts):
     ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
@@ -161,9 +161,9 @@ def test_windowed_divergence(size, n_cohorts):
     ac1 = ds1["variant_allele_count"].values
     ac2 = ds2["variant_allele_count"].values
     mpd = allel.mean_pairwise_difference_between(ac1, ac2, fill=0)
-    sa_div = allel.moving_statistic(mpd, np.sum, size=25, step=25)  # noqa: F841
+    ska_div = allel.moving_statistic(mpd, np.sum, size=25, step=25)  # noqa: F841
     # TODO: investigate why numbers are different
-    # np.testing.assert_allclose(div[:-1], sa_div)  # scikit-allel has final window missing
+    # np.testing.assert_allclose(div[:-1], ska_div)  # scikit-allel has final window missing
 
 
 @pytest.mark.parametrize("size", [2, 3, 10, 100])
@@ -234,7 +234,7 @@ def test_Fst__unknown_estimator():
     "size, n_cohorts",
     [(10, 2)],
 )
-def test_windowed_Fst(size, n_cohorts):
+def test_Fst__windowed(size, n_cohorts):
     ts = msprime.simulate(size, length=200, mutation_rate=0.05, random_seed=42)
     subsets = np.array_split(ts.samples(), n_cohorts)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -155,6 +155,26 @@ def test_divergence__windowed(sample_size, n_cohorts, chunks):
         ts_div[:, j, i] = ts_div[:, i, j]
     np.testing.assert_allclose(div, ts_div)
 
+
+@pytest.mark.parametrize("sample_size, n_cohorts", [(10, 2)])
+@pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
+@pytest.mark.xfail()  # combine with test_divergence__windowed when this is passing
+def test_divergence__windowed_scikit_allel_comparison(sample_size, n_cohorts, chunks):
+    ts = msprime.simulate(sample_size, length=200, mutation_rate=0.05, random_seed=42)
+    subsets = np.array_split(ts.samples(), n_cohorts)
+    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
+    sample_cohorts = np.concatenate(
+        [np.full_like(subset, i) for i, subset in enumerate(subsets)]
+    )
+    ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
+    cohort_names = [f"co_{i}" for i in range(n_cohorts)]
+    ds = ds.assign_coords({"cohorts_0": cohort_names, "cohorts_1": cohort_names})
+    ds = window(ds, size=25, step=25)
+    ds = divergence(ds)
+    div = ds["stat_divergence"].values
+    # test off-diagonal entries, by replacing diagonal with NaNs
+    div[:, np.arange(2), np.arange(2)] = np.nan
+
     # Calculate divergence using scikit-allel moving_statistic
     # (Don't use windowed_divergence, since it treats the last window differently)
     ds1 = count_variant_alleles(ts_to_dataset(ts, samples=ts.samples()[:1]))  # type: ignore[no-untyped-call]
@@ -164,7 +184,9 @@ def test_divergence__windowed(sample_size, n_cohorts, chunks):
     mpd = allel.mean_pairwise_difference_between(ac1, ac2, fill=0)
     ska_div = allel.moving_statistic(mpd, np.sum, size=25, step=25)  # noqa: F841
     # TODO: investigate why numbers are different
-    # np.testing.assert_allclose(div[:-1], ska_div)  # scikit-allel has final window missing
+    np.testing.assert_allclose(
+        div[:-1], ska_div
+    )  # scikit-allel has final window missing
 
 
 @pytest.mark.parametrize("sample_size", [2, 3, 10, 100])

--- a/sgkit/tests/test_window.py
+++ b/sgkit/tests/test_window.py
@@ -1,0 +1,46 @@
+import allel
+import dask.array as da
+import numpy as np
+import pytest
+
+from sgkit.window import moving_statistic
+
+
+@pytest.mark.parametrize(
+    "length, chunks, size, step", [(12, 6, 4, 4), (12, 6, 4, 2), (12, 5, 4, 4)]
+)
+def test_moving_statistic_1d(length, chunks, size, step):
+    values = da.from_array(np.arange(length), chunks=chunks)
+
+    stat = moving_statistic(values, np.sum, size=size, step=step, dtype=values.dtype)
+    stat = stat.compute()
+    if length % size != 0 or size != step:
+        # scikit-allel misses final window in this case
+        stat = stat[:-1]
+
+    values_sa = np.arange(length)
+    stat_sa = allel.moving_statistic(values_sa, np.sum, size=size, step=step)
+
+    np.testing.assert_equal(stat, stat_sa)
+
+
+@pytest.mark.parametrize(
+    "length, chunks, size, step", [(12, 6, 4, 4), (12, 6, 4, 2), (12, 5, 4, 4)]
+)
+def test_moving_statistic_2d(length, chunks, size, step):
+    arr = np.arange(length * 3).reshape(length, 3)
+
+    def sum_cols(x):
+        return np.sum(x, axis=0)
+
+    values = da.from_array(arr, chunks=chunks)
+    stat = moving_statistic(values, sum_cols, size=size, step=step, dtype=values.dtype)
+    stat = stat.compute()
+    if length % size != 0 or size != step:
+        # scikit-allel misses final window in this case
+        stat = stat[:-1]
+
+    values_sa = arr
+    stat_sa = allel.moving_statistic(values_sa, sum_cols, size=size, step=step)
+
+    np.testing.assert_equal(stat, stat_sa)

--- a/sgkit/tests/test_window.py
+++ b/sgkit/tests/test_window.py
@@ -9,14 +9,16 @@ from sgkit.window import moving_statistic
 @pytest.mark.parametrize(
     "length, chunks, size, step", [(12, 6, 4, 4), (12, 6, 4, 2), (12, 5, 4, 4)]
 )
-def test_moving_statistic_1d(length, chunks, size, step):
-    values = da.from_array(np.arange(length), chunks=chunks)
+@pytest.mark.parametrize("dtype", [np.int64, np.float32, np.float64])
+def test_moving_statistic_1d(length, chunks, size, step, dtype):
+    values = da.from_array(np.arange(length, dtype=dtype), chunks=chunks)
 
     stat = moving_statistic(values, np.sum, size=size, step=step, dtype=values.dtype)
     stat = stat.compute()
     if length % size != 0 or size != step:
         # scikit-allel misses final window in this case
         stat = stat[:-1]
+    assert stat.dtype == dtype
 
     values_sa = np.arange(length)
     stat_sa = allel.moving_statistic(values_sa, np.sum, size=size, step=step)
@@ -27,8 +29,9 @@ def test_moving_statistic_1d(length, chunks, size, step):
 @pytest.mark.parametrize(
     "length, chunks, size, step", [(12, 6, 4, 4), (12, 6, 4, 2), (12, 5, 4, 4)]
 )
-def test_moving_statistic_2d(length, chunks, size, step):
-    arr = np.arange(length * 3).reshape(length, 3)
+@pytest.mark.parametrize("dtype", [np.int64, np.float32, np.float64])
+def test_moving_statistic_2d(length, chunks, size, step, dtype):
+    arr = np.arange(length * 3, dtype=dtype).reshape(length, 3)
 
     def sum_cols(x):
         return np.sum(x, axis=0)
@@ -39,6 +42,7 @@ def test_moving_statistic_2d(length, chunks, size, step):
     if length % size != 0 or size != step:
         # scikit-allel misses final window in this case
         stat = stat[:-1]
+    assert stat.dtype == dtype
 
     values_sa = arr
     stat_sa = allel.moving_statistic(values_sa, sum_cols, size=size, step=step)

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -295,7 +295,7 @@ stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(
 )
 """TODO"""
 stat_Tajimas_D, stat_Tajimas_D_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Tajimas_D", ndim={0, 1}, kind="f")
+    ArrayLikeSpec("stat_Tajimas_D", ndim={0, 2}, kind="f")
 )
 """TODO"""
 traits, traits_spec = SgkitVariables.register_variable(

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -291,7 +291,7 @@ stat_divergence, stat_divergence_spec = SgkitVariables.register_variable(
 )
 """TODO"""
 stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_diversity", ndim=1, kind="f")
+    ArrayLikeSpec("stat_diversity", ndim=2, kind="f")
 )
 """TODO"""
 stat_Tajimas_D, stat_Tajimas_D_spec = SgkitVariables.register_variable(

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -385,3 +385,11 @@ variant_t_value, variant_t_value_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("variant_t_value")
 )
 """T statistics for each beta."""
+window_start, window_start_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("window_start", kind="i", ndim=1)
+)
+"""The index values of window start positions along the ``variants`` dimension."""
+window_stop, window_stop_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("window_stop", kind="i", ndim=1)
+)
+"""The index values of window stop positions along the ``variants`` dimension."""

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -287,7 +287,7 @@ stat_Fst, stat_Fst_spec = SgkitVariables.register_variable(
 )
 """TODO"""
 stat_divergence, stat_divergence_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_divergence", ndim=2, kind="f")
+    ArrayLikeSpec("stat_divergence", ndim=3, kind="f")
 )
 """TODO"""
 stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -283,7 +283,7 @@ sample_pca_projection, sample_pca_projection_spec = SgkitVariables.register_vari
 referred to as "scores" or simply "principal components (PCs)" for a set of samples."""
 
 stat_Fst, stat_Fst_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Fst", ndim=2, kind="f")
+    ArrayLikeSpec("stat_Fst", ndim=3, kind="f")
 )
 """TODO"""
 stat_divergence, stat_divergence_spec = SgkitVariables.register_variable(

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -5,6 +5,7 @@ import numpy as np
 from xarray import Dataset
 
 from sgkit.utils import conditional_merge_datasets
+from sgkit.variables import window_start, window_stop
 
 from .typing import ArrayLike, DType
 
@@ -53,11 +54,11 @@ def window(
 
     new_ds = Dataset(
         {
-            "window_start": (
+            window_start: (
                 "windows",
                 window_starts,
             ),
-            "window_stop": (
+            window_stop: (
                 "windows",
                 window_stops,
             ),
@@ -81,7 +82,7 @@ def _get_windows(
 
 def has_windows(ds: Dataset) -> bool:
     """Test if a dataset has windowing information."""
-    return "window_start" in ds and "window_stop" in ds
+    return window_start in ds and window_stop in ds
 
 
 def moving_statistic(

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -70,7 +70,7 @@ def _get_windows(
     start: int, stop: int, size: int, step: int
 ) -> Tuple[ArrayLike, ArrayLike]:
     # Find the indexes for the start positions of all windows
-    # TODO: take contigs into account
+    # TODO: take contigs into account https://github.com/pystatgen/sgkit/issues/335
     window_starts = np.arange(start, stop, step)
     window_stops = np.clip(window_starts + size, start, stop)
     return window_starts, window_stops

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -121,7 +121,6 @@ def window_statistic(
 
     values = da.asarray(values)
 
-    length = values.shape[0]
     window_lengths = window_stops - window_starts
     depth = np.max(window_lengths)
 
@@ -136,7 +135,7 @@ def window_statistic(
     chunks = values.chunks[0]
 
     rel_window_starts, windows_per_chunk = _get_chunked_windows(
-        chunks, length, window_starts, window_stops
+        chunks, window_starts, window_stops
     )
 
     # Add depth for map_overlap
@@ -185,7 +184,6 @@ def _sizes_to_start_offsets(sizes: ArrayLike) -> ArrayLike:
 
 def _get_chunked_windows(
     chunks: ArrayLike,
-    length: int,
     window_starts: ArrayLike,
     window_stops: ArrayLike,
 ) -> Tuple[ArrayLike, ArrayLike]:
@@ -202,6 +200,10 @@ def _get_chunked_windows(
     rel_window_starts = window_starts - chunk_starts[chunk_numbers]
 
     # Find the number of windows in each chunk
-    _, windows_per_chunk = np.unique(chunk_numbers, return_counts=True)
+    unique_chunk_numbers, unique_chunk_counts = np.unique(
+        chunk_numbers, return_counts=True
+    )
+    windows_per_chunk = np.zeros_like(chunks)
+    windows_per_chunk[unique_chunk_numbers] = unique_chunk_counts  # set non-zero counts
 
     return rel_window_starts, windows_per_chunk

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -1,0 +1,174 @@
+from typing import Any, Callable
+
+import dask.array as da
+import numpy as np
+from xarray import Dataset
+
+from sgkit.utils import conditional_merge_datasets
+
+# Window definition (user code)
+
+
+def window(
+    ds: Dataset,
+    size: int,
+    step: int,
+    merge: bool = True,
+) -> Dataset:
+    """Add windowing information to a dataset."""
+
+    n_variants = ds.dims["variants"]
+
+    length = n_variants
+    window_starts, window_stops = _get_windows(0, length, size, step)
+
+    new_ds = Dataset(
+        {
+            "window_start": (
+                "windows",
+                window_starts,
+            ),
+            "window_stop": (
+                "windows",
+                window_stops,
+            ),
+        }
+    )
+    return conditional_merge_datasets(ds, new_ds, merge)
+
+
+def _get_windows(start: int, stop: int, size: int, step: int) -> Any:
+    # Find the indexes for the start positions of all windows
+    # TODO: take contigs into account
+    window_starts = np.arange(start, stop, step)
+    window_stops = np.clip(window_starts + size, start, stop)
+    return window_starts, window_stops
+
+
+# Computing statistics for windows (internal code)
+
+
+def has_windows(ds: Dataset) -> bool:
+    """Test if a dataset has windowing information."""
+    return "window_start" in ds and "window_stop" in ds
+
+
+def moving_statistic(
+    values: Any,
+    statistic: Callable[..., Any],
+    size: int,
+    step: int,
+    dtype: int,
+    **kwargs: Any,
+) -> Any:
+    """A Dask implementation of scikit-allel's moving_statistic function."""
+    length = values.shape[0]
+    chunks = values.chunks[0]
+    if len(chunks) > 1:
+        min_chunksize = np.min(chunks[:-1])  # ignore last chunk
+    else:
+        min_chunksize = np.min(chunks)
+    if min_chunksize < size:
+        raise ValueError(
+            f"Minimum chunk size ({min_chunksize}) must not be smaller than size ({size})."
+        )
+    window_starts, window_stops = _get_windows(0, length, size, step)
+    return window_statistic(
+        values, statistic, window_starts, window_stops, dtype, **kwargs
+    )
+
+
+def window_statistic(
+    values: Any,
+    statistic: Callable[..., Any],
+    window_starts: Any,
+    window_stops: Any,
+    dtype: int,
+    **kwargs: Any,
+) -> Any:
+
+    values = da.asarray(values)
+
+    length = values.shape[0]
+    window_lengths = window_stops - window_starts
+    depth = np.max(window_lengths)
+
+    # Dask will raise an error if the last chunk size is smaller than the depth
+    # Workaround by rechunking to combine the last two chunks in first axis
+    # See https://github.com/dask/dask/issues/6597
+    if depth > values.chunks[0][-1]:
+        chunk0 = values.chunks[0]
+        new_chunk0 = tuple(list(chunk0[:-2]) + [chunk0[-2] + chunk0[-1]])
+        # None means don't rechunk along that axis
+        new_chunks = tuple(list([new_chunk0] + ([None] * (len(chunk0) - 1))))  # type: ignore
+        values = values.rechunk(new_chunks)
+
+    chunks = values.chunks[0]
+
+    rel_window_starts, windows_per_chunk = _get_chunked_windows(
+        chunks, length, window_starts, window_stops
+    )
+
+    # Add depth for map_overlap
+    rel_window_starts = rel_window_starts + depth
+    rel_window_stops = rel_window_starts + window_lengths
+
+    chunk_offsets = _sizes_to_start_offsets(windows_per_chunk)
+
+    def blockwise_moving_stat(x: Any, block_info: Any = None) -> Any:
+        if block_info is None or len(block_info) == 0:
+            return np.array([])
+        chunk_number = block_info[0]["chunk-location"][0]
+        chunk_offset_start = chunk_offsets[chunk_number]
+        chunk_offset_stop = chunk_offsets[chunk_number + 1]
+        chunk_window_starts = rel_window_starts[chunk_offset_start:chunk_offset_stop]
+        chunk_window_stops = rel_window_stops[chunk_offset_start:chunk_offset_stop]
+        out = np.array(
+            [
+                statistic(x[i:j], **kwargs)
+                for i, j in zip(chunk_window_starts, chunk_window_stops)
+            ]
+        )
+        return out
+
+    if values.ndim == 1:
+        new_chunks = (tuple(windows_per_chunk),)
+    else:
+        # depth is 0 except in first axis
+        depth = tuple([depth] + ([0] * (values.ndim - 1)))
+        # new chunks are same except in first axis
+        new_chunks = tuple([tuple(windows_per_chunk)] + list(values.chunks[1:]))
+    return values.map_overlap(
+        blockwise_moving_stat,
+        dtype=dtype,
+        chunks=new_chunks,
+        depth=depth,
+        boundary=0,
+        trim=False,
+    )
+
+
+def _sizes_to_start_offsets(sizes: Any) -> Any:
+    """Convert an array of sizes, to cumulative offsets, starting with 0"""
+    return np.cumsum(np.insert(sizes, 0, 0, axis=0))
+
+
+def _get_chunked_windows(
+    chunks: Any, length: int, window_starts: Any, window_stops: Any
+) -> Any:
+    """Find the window start positions relative to the start of the chunk they are in,
+    and the number of windows in each chunk."""
+
+    # Find the indexes for the start positions of all chunks
+    chunk_starts = _sizes_to_start_offsets(chunks)
+
+    # Find which chunk each window falls in
+    chunk_numbers = np.searchsorted(chunk_starts, window_starts, side="right") - 1
+
+    # Find the start positions for each window relative to each chunk start
+    rel_window_starts = window_starts - chunk_starts[chunk_numbers]
+
+    # Find the number of windows in each chunk
+    _, windows_per_chunk = np.unique(chunk_numbers, return_counts=True)
+
+    return rel_window_starts, windows_per_chunk

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -164,7 +164,7 @@ def window_statistic(
         new_chunks = (tuple(windows_per_chunk),)
     else:
         # depth is 0 except in first axis
-        depth = tuple([depth] + ([0] * (values.ndim - 1)))
+        depth = {0: depth}
         # new chunks are same except in first axis
         new_chunks = tuple([tuple(windows_per_chunk)] + list(values.chunks[1:]))  # type: ignore
     return values.map_overlap(

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -103,9 +103,7 @@ def window_statistic(
     if depth > values.chunks[0][-1]:
         chunk0 = values.chunks[0]
         new_chunk0 = tuple(list(chunk0[:-2]) + [chunk0[-2] + chunk0[-1]])
-        # None means don't rechunk along that axis
-        new_chunks = tuple(list([new_chunk0] + ([None] * (len(chunk0) - 1))))  # type: ignore
-        values = values.rechunk(new_chunks)
+        values = values.rechunk({0: new_chunk0})
 
     chunks = values.chunks[0]
 
@@ -141,7 +139,7 @@ def window_statistic(
         # depth is 0 except in first axis
         depth = tuple([depth] + ([0] * (values.ndim - 1)))
         # new chunks are same except in first axis
-        new_chunks = tuple([tuple(windows_per_chunk)] + list(values.chunks[1:]))
+        new_chunks = tuple([tuple(windows_per_chunk)] + list(values.chunks[1:]))  # type: ignore
     return values.map_overlap(
         blockwise_moving_stat,
         dtype=dtype,

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -17,8 +17,35 @@ def window(
     step: int,
     merge: bool = True,
 ) -> Dataset:
-    """Add windowing information to a dataset."""
+    """Add fixed-size windowing information to a dataset.
 
+    Windows are defined over the ``variants`` dimension, and are
+    used by some downstream functions to calculate statistics for
+    each window.
+
+    Parameters
+    ----------
+    ds
+        Genotype call dataset.
+    size
+        The window size (number of variants).
+    step
+        The distance (number of variants) between start positions of windows.
+    merge
+        If True (the default), merge the input dataset and the computed
+        output variables into a single dataset, otherwise return only
+        the computed output variables.
+        See :ref:`dataset_merge` for more details.
+
+    Returns
+    -------
+    A dataset containing the following variables:
+
+    - :data:`sgkit.variables.window_start_spec` (windows):
+      The index values of window start positions.
+    - :data:`sgkit.variables.window_stop_spec` (windows):
+      The index values of window stop positions.
+    """
     n_variants = ds.dims["variants"]
 
     length = n_variants


### PR DESCRIPTION
This is a proposal for #229, and is also related to #281.

* Adds a new `window` function that adds windowing information to a dataset (a `windows` dimension). This just adds fixed-size windows at the moment, and doesn't take contigs into account - both could be improved in the future.
* Adds a `window_statistic` function (similar scikit-allel's `moving_statistic`) that computes a statistic for each window (using Dask's `map_overlap` function) for use by method functions (i.e. this is not a user-facing function).
* Updates `diversity`, `divergence`, and `Fst` to use windows if present.

Sample usage:

```python
>>> ds = window(ds, size=25, step=25)
>>> fst_ds = Fst(ds, estimator="Nei")
>>> fst_ds
<xarray.Dataset>
Dimensions:              (alleles: 2, cohorts: 2, cohorts_0: 2, cohorts_1: 2, ploidy: 1, samples: 10, variants: 98, windows: 4)
Coordinates:
  * cohorts_0            (cohorts_0) object 'co_0' 'co_1'
  * cohorts_1            (cohorts_1) object 'co_0' 'co_1'
Dimensions without coordinates: alleles, cohorts, ploidy, samples, variants, windows
Data variables:
    stat_Fst             (windows, cohorts_0, cohorts_1) float64 dask.array<chunksize=(4, 2, 2), meta=np.ndarray>
    cohort_allele_count  (variants, cohorts, alleles) int64 dask.array<chunksize=(98, 2, 2), meta=np.ndarray>
    call_allele_count    (variants, samples, alleles) uint8 dask.array<chunksize=(98, 10, 2), meta=np.ndarray>
    window_start         (windows) int64 0 25 50 75
    window_stop          (windows) int64 25 50 75 98
    variant_contig       (variants) int64 0 0 0 0 0 0 0 0 0 ... 0 0 0 0 0 0 0 0
    variant_position     (variants) int64 0 2 6 8 12 19 ... 193 193 194 196 197
    variant_allele       (variants, alleles) |S1 b'0' b'1' b'0' ... b'0' b'1'
    sample_id            (samples) <U5 'tsk_0' 'tsk_1' ... 'tsk_8' 'tsk_9'
    call_genotype        (variants, samples, ploidy) int8 0 0 0 1 1 ... 1 0 0 1
    call_genotype_mask   (variants, samples, ploidy) bool False False ... False
    sample_cohort        (samples) int32 0 0 0 0 0 1 1 1 1 1
>>> fst = fst_ds["stat_Fst"].values
>>> fst
[[[       nan 0.04802022]
  [0.04802022        nan]]

 [[       nan 0.05591201]
  [0.05591201        nan]]

 [[       nan 0.03881701]
  [0.03881701        nan]]

 [[       nan 0.02708124]
  [0.02708124        nan]]]
```

Note the `window_start` and `window_stop` variables of dimension `windows`, and the `stat_Fst` variable whose first dimension is `windows`.