### PR TITLE
Filter partial calls

### DIFF
--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -14,6 +14,7 @@ from .stats.hwe import hardy_weinberg_test
 from .stats.pc_relate import pc_relate
 from .stats.pca import pca
 from .stats.popgen import Fst, Tajimas_D, divergence, diversity
+from .stats.preprocessing import filter_partial_calls
 from .stats.regenie import regenie
 from .testing import simulate_genotype_call_dataset
 
@@ -27,6 +28,7 @@ __all__ = [
     "count_call_alleles",
     "create_genotype_dosage_dataset",
     "display_genotypes",
+    "filter_partial_calls",
     "gwas_linear_regression",
     "read_vcfzarr",
     "regenie",

--- a/sgkit/stats/preprocessing.py
+++ b/sgkit/stats/preprocessing.py
@@ -1,10 +1,15 @@
-from typing import Optional
+from typing import Hashable, Optional
 
 import dask.array as da
 import numpy as np
+import xarray as xr
 from sklearn.base import BaseEstimator, TransformerMixin
+from xarray import Dataset
+
+from sgkit import variables
 
 from ..typing import ArrayLike
+from ..utils import conditional_merge_datasets
 
 
 class PattersonScaler(BaseEstimator, TransformerMixin):  # type: ignore[misc]
@@ -102,3 +107,77 @@ class PattersonScaler(BaseEstimator, TransformerMixin):  # type: ignore[misc]
         X *= self.scale_
         X += self.mean_
         return X
+
+
+def filter_partial_calls(
+    ds: Dataset,
+    *,
+    call_genotype: Hashable = variables.call_genotype,
+    merge: bool = True,
+) -> Dataset:
+    """Replace partial genotype calls with missing values.
+
+    Parameters
+    ----------
+    ds
+        Genotype call dataset such as from
+        :func:`sgkit.create_genotype_call_dataset`.
+    call_genotype
+        Input variable name holding call_genotype as defined by
+        :data:`sgkit.variables.call_genotype_spec`
+    merge
+        If True (the default), merge the input dataset and the computed
+        output variables into a single dataset, otherwise return only
+        the computed output variables.
+        See :ref:`dataset_merge` for more details.
+
+    Returns
+    -------
+    Dataset containing `call_genotype_complete` and
+    `call_genotype_complete_mask` in which partial genotype calls are
+    replaced with completely missing genotype calls.
+
+    Examples
+    --------
+    >>> import sgkit as sg
+    >>> from sgkit.testing import simulate_genotype_call_dataset
+    >>> ds = simulate_genotype_call_dataset(n_variant=4, n_sample=2, seed=1, missing_pct=0.3)
+    >>> sg.display_genotypes(ds) # doctest: +NORMALIZE_WHITESPACE
+    samples    S0   S1
+    variants
+    0         ./0  ./.
+    1         ./0  1/1
+    2         0/1  ./0
+    3         ./0  0/0
+    >>> ds2 = filter_partial_calls(ds)
+    >>> ds2['call_genotype'] = ds2['call_genotype_complete']
+    >>> ds2['call_genotype_mask'] = ds2['call_genotype_complete_mask']
+    >>> sg.display_genotypes(ds2) # doctest: +NORMALIZE_WHITESPACE
+    samples    S0   S1
+    variants
+    0         ./.  ./.
+    1         ./.  1/1
+    2         0/1  ./.
+    3         ./.  0/0
+
+
+    Notes
+    -----
+    The returned dataset will still contain the initial `call_genotype` and
+    `call_genotype_mask` variables. Many sgkit functions will default to
+    using `call_genotype` and/or `call_genotype_mask`, hence it is necessary
+    to overwrite these variables (see the example) or explicitly pass the new
+    variables as function arguments in order to remove partial calls from
+    futher analysis.
+    """
+    variables.validate(ds, {call_genotype: variables.call_genotype_spec})
+    G = ds[call_genotype]
+    P = (G < 0).any(axis=-1)
+    F = xr.where(P, -1, G)  # type: ignore[no-untyped-call]
+    new_ds = Dataset(
+        {
+            variables.call_genotype_complete: F,
+            variables.call_genotype_complete_mask: F < 0,
+        }
+    )
+    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)

--- a/sgkit/tests/test_preprocessing.py
+++ b/sgkit/tests/test_preprocessing.py
@@ -4,8 +4,10 @@ import allel.stats.preprocessing
 import dask.array as da
 import numpy as np
 import pytest
+import xarray as xr
 
 import sgkit.stats.preprocessing
+from sgkit import simulate_genotype_call_dataset
 from sgkit.typing import ArrayLike, DType
 
 
@@ -98,3 +100,26 @@ def test_patterson_scaler__missing_data(dtype, use_nan):
     # Test inversion to original array
     acr = scaler.inverse_transform(scaler.transform(ac))
     np.testing.assert_equal(np.where(np.isnan(acr), np.nan if use_nan else -1, acr), ac)
+
+
+def test_filter_partial_calls():
+    calls = np.array([[[0, 0], [0, 1], [1, 0]], [[-1, 0], [0, -1], [-1, -1]]])
+    ds = simulate_genotype_call_dataset(*calls.shape)
+    dims = ds["call_genotype"].dims
+    ds["call_genotype"] = xr.DataArray(calls, dims=dims)
+    ds["call_genotype_mask"] = xr.DataArray(calls < 0, dims=dims)
+
+    ds2 = sgkit.stats.preprocessing.filter_partial_calls(ds)
+
+    calls_filtered = ds2["call_genotype_complete"]
+    mask_filtered = ds2["call_genotype_complete_mask"]
+
+    np.testing.assert_array_equal(
+        calls_filtered,
+        np.array([[[0, 0], [0, 1], [1, 0]], [[-1, -1], [-1, -1], [-1, -1]]]),
+    )
+
+    np.testing.assert_array_equal(
+        mask_filtered,
+        np.array([[[0, 0], [0, 0], [0, 0]], [[1, 1], [1, 1], [1, 1]]], dtype=np.bool),
+    )

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -176,6 +176,20 @@ call_genotype_phased, call_genotype_phased_spec = SgkitVariables.register_variab
 A flag for each call indicating if it is phased or not. If omitted
 all calls are unphased.
 """
+call_genotype_complete, call_genotype_complete_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("call_genotype_complete", kind="i", ndim=3)
+)
+"""
+Call genotypes in which partial genotype calls are replaced with
+completely missing genotype calls.
+"""
+(
+    call_genotype_complete_mask,
+    call_genotype_complete_mask_spec,
+) = SgkitVariables.register_variable(
+    ArrayLikeSpec("call_genotype_complete_mask", kind="b", ndim=3)
+)
+"""TODO"""
 (
     call_genotype_probability,
     call_genotype_probability_spec,


### PR DESCRIPTION
Issue #223 

Some notes:

- Adding a new top-level sub-module might be OTT but this doesn't really fit in `stats` or `model`.
- Currently this will always throw a merge warning which is a safe default but may be inconvenient. Is an argument to optionally silence merge warnings a good idea?
- This implementation will require some minor changes if/when #243 is resolved.
- Some discussion in issue #282 on handling partial genotypes in other functions.
