### PR TITLE
Remove deadline and improve speed of max_str_len test

### DIFF
--- a/sgkit/stats/hwe.py
+++ b/sgkit/stats/hwe.py
@@ -154,7 +154,6 @@ def hardy_weinberg_test(
         Input variable name holding call_genotype_mask.
         Defined by :data:`sgkit.variables.call_genotype_mask_spec`
     ploidy
-<<<<<<< HEAD
         Genotype ploidy, defaults to ``ploidy`` dimension of provided dataset.
         If the `ploidy` dimension is not present, then this value must be set explicitly.
         Currently HWE calculations are only supported for diploid datasets,
@@ -164,13 +163,6 @@ def hardy_weinberg_test(
         If the `alleles` dimension is not present, then this value must be set explicitly.
         Currently HWE calculations are only supported for biallelic datasets,
         i.e. ``alleles`` must equal 2.
-=======
-        Genotype ploidy, defaults to ``ploidy`` dimension of genotype
-        call array (:data:`sgkit.variables.call_genotype_spec`) if present.
-        If that variable is not present, then this value must be set.
-        Currently HWE calculations are only supported for diploid datasets,
-        i.e. ``ploidy`` must equal 2.
->>>>>>> Rework HWE inputs
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only

--- a/sgkit/stats/hwe.py
+++ b/sgkit/stats/hwe.py
@@ -154,6 +154,7 @@ def hardy_weinberg_test(
         Input variable name holding call_genotype_mask.
         Defined by :data:`sgkit.variables.call_genotype_mask_spec`
     ploidy
+<<<<<<< HEAD
         Genotype ploidy, defaults to ``ploidy`` dimension of provided dataset.
         If the `ploidy` dimension is not present, then this value must be set explicitly.
         Currently HWE calculations are only supported for diploid datasets,
@@ -163,6 +164,13 @@ def hardy_weinberg_test(
         If the `alleles` dimension is not present, then this value must be set explicitly.
         Currently HWE calculations are only supported for biallelic datasets,
         i.e. ``alleles`` must equal 2.
+=======
+        Genotype ploidy, defaults to ``ploidy`` dimension of genotype
+        call array (:data:`sgkit.variables.call_genotype_spec`) if present.
+        If that variable is not present, then this value must be set.
+        Currently HWE calculations are only supported for diploid datasets,
+        i.e. ``ploidy`` must equal 2.
+>>>>>>> Rework HWE inputs
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only

--- a/sgkit/tests/test_utils.py
+++ b/sgkit/tests/test_utils.py
@@ -122,9 +122,9 @@ def test_split_array_chunks__size(a: int, b: int) -> None:
 @pytest.mark.parametrize("chunks", [None, -1, 5])
 @pytest.mark.parametrize("backend", [xr.DataArray, np.array, da.array])
 @given(st.data())
-@settings(max_examples=25)
+@settings(max_examples=10, deadline=None)
 def test_max_str_len(dtype, chunks, backend, data):
-    shape = data.draw(st.lists(st.integers(0, 15), min_size=0, max_size=3))
+    shape = data.draw(st.lists(st.integers(0, 8), min_size=0, max_size=3))
     ndim = len(shape)
     x = data.draw(arrays(dtype=dtype if dtype != "O" else "U", shape=shape))
     x = backend(x)


### PR DESCRIPTION
These are small changes for https://github.com/pystatgen/sgkit/issues/336.

They improve the running time of a single test modestly and make it impossible for the test to fail the build again due to sporadic latencies.

I'm not sure what to do about deadlines in general (as mentioned in the issue), but perhaps disabling them when they become problematic is the best approach.

FYI these changes bring the total time for this test to run across all parameterizations down to ~1.5s (from ~6s), which is still annoyingly slow but a bit more palatable.