### PR TITLE
Change count_variant_alleles to not reconstruct DataArray.

### DIFF
--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -208,12 +208,9 @@ def count_variant_alleles(
     """
     new_ds = Dataset(
         {
-            variables.variant_allele_count: (
-                ("variants", "alleles"),
-                count_call_alleles(ds, call_genotype=call_genotype)[
-                    variables.call_allele_count
-                ].sum(dim="samples"),
-            )
+            variables.variant_allele_count: count_call_alleles(
+                ds, call_genotype=call_genotype
+            )[variables.call_allele_count].sum(dim="samples")
         }
     )
     return conditional_merge_datasets(ds, variables.validate(new_ds), merge)

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -406,7 +406,7 @@ def Tajimas_D(
     S = ((ac > 0).sum(axis=1) > 1).sum()
 
     # assume number of chromosomes sampled is constant for all variants
-    n = ac.sum(axis=1).max()
+    n = ac.sum(axis=1).max().compute()
 
     # (n-1)th harmonic number
     a1 = (1 / da.arange(1, n)).sum()


### PR DESCRIPTION
Test that all allele counting functions are lazy.

Note that `test_count_variant_alleles__chunked` fails without the change in `count_variant_alleles`. 

Fixes #305.