### PR TITLE
Standardize intermediate variables

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,7 @@ Methods
    :toctree: generated/
 
    count_call_alleles
+   count_cohort_alleles
    count_variant_alleles
    divergence
    diversity

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -8,7 +8,12 @@ from .model import (  # noqa: F401
     create_genotype_call_dataset,
     create_genotype_dosage_dataset,
 )
-from .stats.aggregation import count_call_alleles, count_variant_alleles, variant_stats
+from .stats.aggregation import (
+    count_call_alleles,
+    count_cohort_alleles,
+    count_variant_alleles,
+    variant_stats,
+)
 from .stats.association import gwas_linear_regression
 from .stats.hwe import hardy_weinberg_test
 from .stats.pc_relate import pc_relate
@@ -26,6 +31,7 @@ __all__ = [
     "create_genotype_call_dataset",
     "count_variant_alleles",
     "count_call_alleles",
+    "count_cohort_alleles",
     "create_genotype_dosage_dataset",
     "display_genotypes",
     "filter_partial_calls",

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Hashable, Optional
+from typing import Any, Dict, Hashable
 
 import dask.array as da
 import numpy as np
@@ -10,7 +10,7 @@ from xarray import Dataset
 from sgkit import variables
 from sgkit.stats.utils import assert_array_shape
 from sgkit.typing import ArrayLike
-from sgkit.utils import conditional_merge_datasets
+from sgkit.utils import conditional_merge_datasets, define_variable_if_absent
 
 Dimension = Literal["samples", "variants"]
 
@@ -101,7 +101,8 @@ def count_call_alleles(
         Dataset containing genotype calls.
     call_genotype
         Input variable name holding call_genotype as defined by
-        :data:`sgkit.variables.call_genotype_spec`
+        :data:`sgkit.variables.call_genotype_spec`.
+        Must be present in ``ds``.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -110,8 +111,8 @@ def count_call_alleles(
 
     Returns
     -------
-    Array `call_allele_count` of allele counts with
-    shape (variants, samples, alleles) and values corresponding to
+    A dataset containing :data:`sgkit.variables.call_allele_count_spec`
+    of allele counts with shape (variants, samples, alleles) and values corresponding to
     the number of non-missing occurrences of each allele.
 
     Examples
@@ -162,18 +163,20 @@ def count_call_alleles(
 def count_variant_alleles(
     ds: Dataset,
     *,
-    call_genotype: Hashable = variables.call_genotype,
+    call_allele_count: Hashable = variables.call_allele_count,
     merge: bool = True,
 ) -> Dataset:
-    """Compute allele count from genotype calls.
+    """Compute allele count from per-sample allele counts, or genotype calls.
 
     Parameters
     ----------
     ds
         Dataset containing genotype calls.
-    call_genotype
-        Input variable name holding call_genotype as defined by
-        :data:`sgkit.variables.call_genotype_spec`
+    call_allele_count
+        Input variable name holding call_allele_count as defined by
+        :data:`sgkit.variables.call_allele_count_spec`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`count_call_alleles`.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -182,8 +185,8 @@ def count_variant_alleles(
 
     Returns
     -------
-    Array `variant_allele_count` of allele counts with
-    shape (variants, alleles) and values corresponding to
+    A dataset containing :data:`sgkit.variables.variant_allele_count_spec`
+    of allele counts with shape (variants, alleles) and values corresponding to
     the number of non-missing occurrences of each allele.
 
     Examples
@@ -206,12 +209,13 @@ def count_variant_alleles(
            [2, 2],
            [4, 0]], dtype=uint64)
     """
+    ds = define_variable_if_absent(
+        ds, variables.call_allele_count, call_allele_count, count_call_alleles
+    )
+    variables.validate(ds, {call_allele_count: variables.call_allele_count_spec})
+
     new_ds = Dataset(
-        {
-            variables.variant_allele_count: count_call_alleles(
-                ds, call_genotype=call_genotype
-            )[variables.call_allele_count].sum(dim="samples")
-        }
+        {variables.variant_allele_count: ds[call_allele_count].sum(dim="samples")}
     )
     return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
 
@@ -219,18 +223,20 @@ def count_variant_alleles(
 def count_cohort_alleles(
     ds: Dataset,
     *,
-    call_genotype: Hashable = variables.call_genotype,
+    call_allele_count: Hashable = variables.call_allele_count,
     merge: bool = True,
 ) -> Dataset:
-    """Compute per cohort allele counts from genotype calls.
+    """Compute per cohort allele counts from per-sample allele counts, or genotype calls.
 
     Parameters
     ----------
     ds
         Dataset containing genotype calls.
-    call_genotype
-        Input variable name holding call_genotype as defined by
-        :data:`sgkit.variables.call_genotype_spec`
+    call_allele_count
+        Input variable name holding call_allele_count as defined by
+        :data:`sgkit.variables.call_allele_count_spec`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`count_call_alleles`.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -239,15 +245,18 @@ def count_cohort_alleles(
 
     Returns
     -------
-    Dataset containing variable `call_allele_count` of allele counts with
-    shape (variants, cohorts, alleles) and values corresponding to
+    A dataset containing :data:`sgkit.variables.cohort_allele_count_spec`
+    of allele counts with shape (variants, cohorts, alleles) and values corresponding to
     the number of non-missing occurrences of each allele.
     """
+    ds = define_variable_if_absent(
+        ds, variables.call_allele_count, call_allele_count, count_call_alleles
+    )
+    variables.validate(ds, {call_allele_count: variables.call_allele_count_spec})
 
     n_variants = ds.dims["variants"]
     n_alleles = ds.dims["alleles"]
 
-    ds = count_call_alleles(ds, call_genotype=call_genotype)
     AC, SC = da.asarray(ds.call_allele_count), da.asarray(ds.sample_cohort)
     n_cohorts = SC.max().compute() + 1  # 0-based indexing
     C = da.empty(n_cohorts, dtype=np.uint8)
@@ -306,21 +315,18 @@ def genotype_count(
 
 def allele_frequency(
     ds: Dataset,
-    call_genotype: Hashable,
     call_genotype_mask: Hashable,
-    variant_allele_count: Optional[Hashable],
+    variant_allele_count: Hashable,
 ) -> Dataset:
     data_vars: Dict[Hashable, Any] = {}
     # only compute variant allele count if not already in dataset
-    if variant_allele_count is not None:
+    if variant_allele_count in ds:
         variables.validate(
             ds, {variant_allele_count: variables.variant_allele_count_spec}
         )
         AC = ds[variant_allele_count]
     else:
-        AC = count_variant_alleles(ds, merge=False, call_genotype=call_genotype)[
-            variables.variant_allele_count
-        ]
+        AC = count_variant_alleles(ds, merge=False)[variables.variant_allele_count]
         data_vars[variables.variant_allele_count] = AC
 
     M = ds[call_genotype_mask].stack(calls=("samples", "ploidy"))
@@ -337,7 +343,7 @@ def variant_stats(
     *,
     call_genotype_mask: Hashable = variables.call_genotype_mask,
     call_genotype: Hashable = variables.call_genotype,
-    variant_allele_count: Optional[Hashable] = None,
+    variant_allele_count: Hashable = variables.variant_allele_count,
     merge: bool = True,
 ) -> Dataset:
     """Compute quality control variant statistics from genotype calls.
@@ -349,12 +355,16 @@ def variant_stats(
     call_genotype
         Input variable name holding call_genotype.
         Defined by :data:`sgkit.variables.call_genotype_spec`.
+        Must be present in ``ds``.
     call_genotype_mask
         Input variable name holding call_genotype_mask.
         Defined by :data:`sgkit.variables.call_genotype_mask_spec`
+        Must be present in ``ds``.
     variant_allele_count
-        Optional name of the input variable holding variant_allele_count,
+        Input variable name holding variant_allele_count,
         as defined by :data:`sgkit.variables.variant_allele_count_spec`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`count_variant_alleles`.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -402,7 +412,6 @@ def variant_stats(
             ),
             allele_frequency(
                 ds,
-                call_genotype=call_genotype,
                 call_genotype_mask=call_genotype_mask,
                 variant_allele_count=variant_allele_count,
             ),

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -395,7 +395,7 @@ def Tajimas_D(
     samples dimension.
     """
     if variant_allele_counts not in ds:
-        ds = count_variant_alleles(ds, call_genotype=call_genotype)
+        ds = count_variant_alleles(ds)
     else:
         variables.validate(
             ds, {variant_allele_counts: variables.variant_allele_count_spec}

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -7,7 +7,7 @@ from xarray import Dataset
 
 from sgkit.stats.utils import assert_array_shape
 from sgkit.typing import ArrayLike
-from sgkit.utils import conditional_merge_datasets
+from sgkit.utils import conditional_merge_datasets, define_variable_if_absent
 from sgkit.window import has_windows, window_statistic
 
 from .. import variables
@@ -17,8 +17,7 @@ from .aggregation import count_cohort_alleles, count_variant_alleles
 def diversity(
     ds: Dataset,
     *,
-    allele_counts: Hashable = variables.cohort_allele_count,
-    call_genotype: Hashable = variables.call_genotype,
+    cohort_allele_count: Hashable = variables.cohort_allele_count,
     merge: bool = True,
 ) -> Dataset:
     """Compute diversity from cohort allele counts.
@@ -36,12 +35,11 @@ def diversity(
     ----------
     ds
         Genotype call dataset.
-    allele_counts
-        cohort allele counts to use or calculate. Defined by
-        :data:`sgkit.variables.cohort_allele_count_spec`
-    call_genotype
-        Input variable name holding call_genotype as defined by
-        :data:`sgkit.variables.call_genotype_spec`
+    cohort_allele_count
+        Cohort allele count variable to use or calculate. Defined by
+        :data:`sgkit.variables.cohort_allele_count_spec`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`count_cohort_alleles`.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -50,18 +48,19 @@ def diversity(
 
     Returns
     -------
-    diversity value, as defined by :data:`sgkit.variables.stat_diversity_spec`.
+    A dataset containing the diversity value, as defined by :data:`sgkit.variables.stat_diversity_spec`.
 
     Warnings
     --------
     This method does not currently support datasets that are chunked along the
     samples dimension.
     """
-    if allele_counts not in ds:
-        ds = count_cohort_alleles(ds, call_genotype=call_genotype)
-    else:
-        variables.validate(ds, {allele_counts: variables.cohort_allele_count_spec})
-    ac = ds[allele_counts]
+    ds = define_variable_if_absent(
+        ds, variables.cohort_allele_count, cohort_allele_count, count_cohort_alleles
+    )
+    variables.validate(ds, {cohort_allele_count: variables.cohort_allele_count_spec})
+
+    ac = ds[cohort_allele_count]
     an = ac.sum(axis=2)
     n_pairs = an * (an - 1) / 2
     n_same = (ac * (ac - 1) / 2).sum(axis=2)
@@ -147,8 +146,7 @@ def _divergence(ac: ArrayLike, out: ArrayLike) -> None:
 def divergence(
     ds: Dataset,
     *,
-    call_genotype: Hashable = variables.call_genotype,
-    allele_counts: Hashable = variables.cohort_allele_count,
+    cohort_allele_count: Hashable = variables.cohort_allele_count,
     merge: bool = True,
 ) -> Dataset:
     """Compute divergence between pairs of cohorts.
@@ -161,12 +159,11 @@ def divergence(
     ----------
     ds
         Genotype call dataset.
-    allele_counts
-        cohort allele counts to use or calculate. Defined by
-        :data:`sgkit.variables.cohort_allele_count_spec`
-    call_genotype
-        Input variable name holding call_genotype as defined by
-        :data:`sgkit.variables.call_genotype_spec`
+    cohort_allele_count
+        Cohort allele count variable to use or calculate. Defined by
+        :data:`sgkit.variables.cohort_allele_count_spec`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`count_cohort_alleles`.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -175,7 +172,7 @@ def divergence(
 
     Returns
     -------
-    divergence value between pairs of cohorts, as defined by
+    A dataset containing the divergence value between pairs of cohorts, as defined by
     :data:`sgkit.variables.stat_divergence_spec`.
 
     Warnings
@@ -184,11 +181,11 @@ def divergence(
     samples dimension.
     """
 
-    if allele_counts not in ds:
-        ds = count_cohort_alleles(ds, call_genotype=call_genotype)
-    else:
-        variables.validate(ds, {allele_counts: variables.cohort_allele_count_spec})
-    ac = ds[allele_counts]
+    ds = define_variable_if_absent(
+        ds, variables.cohort_allele_count, cohort_allele_count, count_cohort_alleles
+    )
+    variables.validate(ds, {cohort_allele_count: variables.cohort_allele_count_spec})
+    ac = ds[cohort_allele_count]
 
     n_variants = ds.dims["variants"]
     n_cohorts = ds.dims["cohorts"]
@@ -293,8 +290,7 @@ def Fst(
     ds: Dataset,
     *,
     estimator: Optional[str] = None,
-    call_genotype: Hashable = variables.call_genotype,
-    allele_counts: Hashable = variables.cohort_allele_count,
+    stat_divergence: Hashable = variables.stat_divergence,
     merge: bool = True,
 ) -> Dataset:
     """Compute Fst between pairs of cohorts.
@@ -310,12 +306,11 @@ def Fst(
         (the same estimator as scikit-allel).
         Other supported estimators include ``Nei`` (1986), (the same estimator
         as tskit).
-    allele_counts
-        cohort allele counts to use or calculate. Defined by
-        :data:`sgkit.variables.cohort_allele_count_spec`
-    call_genotype
-        Input variable name holding call_genotype as defined by
-        :data:`sgkit.variables.call_genotype_spec`
+    stat_divergence
+        Divergence variable to use or calculate. Defined by
+        :data:`sgkit.variables.stat_divergence_spec`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`divergence`.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -324,7 +319,7 @@ def Fst(
 
     Returns
     -------
-    Fst value between pairs of cohorts, as defined by
+    A dataset containing the Fst value between pairs of cohorts, as defined by
     :data:`sgkit.variables.stat_Fst_spec`.
 
     Warnings
@@ -338,16 +333,13 @@ def Fst(
             f"Estimator '{estimator}' is not a known estimator: {known_estimators.keys()}"
         )
     estimator = estimator or "Hudson"
-    if allele_counts not in ds:
-        ds = count_cohort_alleles(ds, call_genotype=call_genotype)
-    else:
-        variables.validate(ds, {allele_counts: variables.cohort_allele_count_spec})
+    ds = define_variable_if_absent(
+        ds, variables.stat_divergence, stat_divergence, divergence
+    )
+    variables.validate(ds, {stat_divergence: variables.stat_divergence_spec})
 
     n_cohorts = ds.dims["cohorts"]
-    gs = divergence(
-        ds, allele_counts=allele_counts, call_genotype=call_genotype, merge=False
-    ).stat_divergence
-    gs = da.asarray(gs)
+    gs = da.asarray(ds.stat_divergence)
     shape = (gs.chunks[0], n_cohorts, n_cohorts)
     fst = da.map_blocks(known_estimators[estimator], gs, chunks=shape, dtype=np.float64)
     # TODO: reinstate assert (first dim could be either variants or windows)
@@ -359,9 +351,8 @@ def Fst(
 def Tajimas_D(
     ds: Dataset,
     *,
-    call_genotype: Hashable = variables.call_genotype,
-    variant_allele_counts: Hashable = variables.variant_allele_count,
-    allele_counts: Hashable = variables.cohort_allele_count,
+    variant_allele_count: Hashable = variables.variant_allele_count,
+    stat_diversity: Hashable = variables.stat_diversity,
     merge: bool = True,
 ) -> Dataset:
     """Compute Tajimas' D for a genotype call dataset.
@@ -370,15 +361,16 @@ def Tajimas_D(
     ----------
     ds
         Genotype call dataset.
-    variant_allele_counts
-        variant allele counts to use or calculate. Defined by
-        :data:`sgkit.variables.variant_allele_counts_spec`
-    allele_counts
-        cohort allele counts to use or calculate. Defined by
-        :data:`sgkit.variables.cohort_allele_count_spec`
-    call_genotype
-        Input variable name holding call_genotype as defined by
-        :data:`sgkit.variables.call_genotype_spec`
+    variant_allele_count
+        Variant allele count variable to use or calculate. Defined by
+        :data:`sgkit.variables.variant_allele_count`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`count_variant_alleles`.
+    stat_diversity
+        Diversity variable to use or calculate. Defined by
+        :data:`sgkit.variables.stat_diversity_spec`.
+        If the variable is not present in ``ds``, it will be computed
+        using :func:`diversity`.
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -387,20 +379,28 @@ def Tajimas_D(
 
     Returns
     -------
-    Tajimas' D value, as defined by :data:`sgkit.variables.stat_Tajimas_D_spec`.
+    A dataset containing the Tajimas' D value, as defined by :data:`sgkit.variables.stat_Tajimas_D_spec`.
 
     Warnings
     --------
     This method does not currently support datasets that are chunked along the
     samples dimension.
     """
-    if variant_allele_counts not in ds:
-        ds = count_variant_alleles(ds)
-    else:
-        variables.validate(
-            ds, {variant_allele_counts: variables.variant_allele_count_spec}
-        )
-    ac = ds[variant_allele_counts]
+    ds = define_variable_if_absent(
+        ds, variables.variant_allele_count, variant_allele_count, count_variant_alleles
+    )
+    ds = define_variable_if_absent(
+        ds, variables.stat_diversity, stat_diversity, diversity
+    )
+    variables.validate(
+        ds,
+        {
+            variant_allele_count: variables.variant_allele_count_spec,
+            stat_diversity: variables.stat_diversity_spec,
+        },
+    )
+
+    ac = ds[variant_allele_count]
 
     # count segregating
     S = ((ac > 0).sum(axis=1) > 1).sum()
@@ -414,10 +414,8 @@ def Tajimas_D(
     # calculate Watterson's theta (absolute value)
     theta = S / a1
 
-    # calculate diversity
-    div = diversity(
-        ds, allele_counts=allele_counts, call_genotype=call_genotype, merge=False
-    ).stat_diversity
+    # get diversity
+    div = ds[stat_diversity]
 
     # N.B., both theta estimates are usually divided by the number of
     # (accessible) bases but here we want the absolute difference

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -254,9 +254,7 @@ def test_variant_stats(precompute_variant_allele_count):
     )
     if precompute_variant_allele_count:
         ds = count_variant_alleles(ds)
-        vs = variant_stats(ds, variant_allele_count="variant_allele_count")
-    else:
-        vs = variant_stats(ds)
+    vs = variant_stats(ds)
 
     np.testing.assert_equal(vs["variant_n_called"], np.array([1, 2, 2, 1]))
     np.testing.assert_equal(vs["variant_call_rate"], np.array([0.5, 1.0, 1.0, 0.5]))

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -92,6 +92,12 @@ def test_diversity__windowed(sample_size):
     )  # scikit-allel has final window missing
 
 
+def test_diversity__missing_call_genotype():
+    ds = xr.Dataset()
+    with pytest.raises(ValueError, match="call_genotype not present"):
+        diversity(ds)
+
+
 @pytest.mark.parametrize(
     "sample_size, n_cohorts",
     [(2, 2), (3, 2), (3, 3), (10, 2), (10, 3), (10, 4), (100, 2), (100, 3), (100, 4)],

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -10,6 +10,7 @@ from allel import hudson_fst
 from sgkit import (
     Fst,
     Tajimas_D,
+    count_cohort_alleles,
     count_variant_alleles,
     create_genotype_call_dataset,
     divergence,
@@ -50,13 +51,17 @@ def ts_to_dataset(ts, chunks=None, samples=None):
 
 @pytest.mark.parametrize("sample_size", [2, 3, 10, 100])
 @pytest.mark.parametrize("chunks", [(-1, -1), (10, -1)])
-def test_diversity(sample_size, chunks):
+@pytest.mark.parametrize("precompute_cohort_allele_count", [False, True])
+def test_diversity(sample_size, chunks, precompute_cohort_allele_count):
     ts = msprime.simulate(sample_size, length=100, mutation_rate=0.05, random_seed=42)
     ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
     ds = ds.chunk(dict(zip(["variants", "samples"], chunks)))
     sample_cohorts = np.full_like(ts.samples(), 0)
     ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
+    if precompute_cohort_allele_count:
+        ds = count_cohort_alleles(ds, merge=False)
     ds = ds.assign_coords({"cohorts": ["co_0"]})
+
     ds = diversity(ds)
     div = ds.stat_diversity.sum(axis=0, skipna=False).sel(cohorts="co_0").values
     ts_div = ts.diversity(span_normalise=False)


### PR DESCRIPTION
This addresses #286.

This is what I've implemented:

1. Methods declare only the variables that they use directly.
2. If the variable of the given name exists in the dataset it will be used for the computation.
3. If the variable doesn't exist then it will be computed if the variable name is the default, and added to the dataset.
4. An error is raised if the variable doesn't exist and it has a non-default name or it can't be computed (e.g. `call_genotype`).

These rules mean you can always call a method and it will compute (and retain) all intermediate variables:

```python
ds = pbs(ds)
# ds now has variables stat_divergence, stat_Fst, stat_pbs
```

To use non-default parameters for an intermediate step, you can do something like this:

```python
ds = Fst(ds, estimator="Nei")
# ds now has variables stat_divergence, stat_Fst

ds = pbs(ds) # uses existing stat_Fst
# ds now has variables stat_divergence, stat_Fst, stat_pbs
```

This approach should also play well with being able to persist intermediate steps that are computationally expensive (for #347):

```python
ds = count_cohort_alleles(ds)
ds.to_zarr(...) # compute and persist to disk

ds = xr.open_zarr(...) # reload from disk

ds = pbs(ds) # doesn't need to run any count alleles functions
```

(Note that `pbs` isn't done yet, so these examples won't work.)

This is based on #349, which should be merged first.