### PR TITLE
Add popgen examples to docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,6 +63,7 @@ Utilities
 
    display_genotypes
    simulate_genotype_call_dataset
+   window
 
 Variables
 =========
@@ -105,3 +106,5 @@ Variables
     variables.variant_p_value_spec
     variables.variant_position_spec
     variables.variant_t_value_spec
+    variables.window_start_spec
+    variables.window_stop_spec

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -22,6 +22,7 @@ from .stats.popgen import Fst, Tajimas_D, divergence, diversity
 from .stats.preprocessing import filter_partial_calls
 from .stats.regenie import regenie
 from .testing import simulate_genotype_call_dataset
+from .window import window
 
 __all__ = [
     "DIM_ALLELE",
@@ -48,4 +49,5 @@ __all__ = [
     "simulate_genotype_call_dataset",
     "variables",
     "pca",
+    "window",
 ]

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -119,8 +119,7 @@ def count_call_alleles(
     --------
 
     >>> import sgkit as sg
-    >>> from sgkit.testing import simulate_genotype_call_dataset
-    >>> ds = simulate_genotype_call_dataset(n_variant=4, n_sample=2, seed=1)
+    >>> ds = sg.simulate_genotype_call_dataset(n_variant=4, n_sample=2, seed=1)
     >>> sg.display_genotypes(ds) # doctest: +NORMALIZE_WHITESPACE
     samples    S0   S1
     variants
@@ -193,8 +192,7 @@ def count_variant_alleles(
     --------
 
     >>> import sgkit as sg
-    >>> from sgkit.testing import simulate_genotype_call_dataset
-    >>> ds = simulate_genotype_call_dataset(n_variant=4, n_sample=2, seed=1)
+    >>> ds = sg.simulate_genotype_call_dataset(n_variant=4, n_sample=2, seed=1)
     >>> sg.display_genotypes(ds) # doctest: +NORMALIZE_WHITESPACE
     samples    S0   S1
     variants
@@ -248,6 +246,41 @@ def count_cohort_alleles(
     A dataset containing :data:`sgkit.variables.cohort_allele_count_spec`
     of allele counts with shape (variants, cohorts, alleles) and values corresponding to
     the number of non-missing occurrences of each allele.
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> import sgkit as sg
+    >>> import xarray as xr
+    >>> ds = sg.simulate_genotype_call_dataset(n_variant=5, n_sample=4)
+
+    >>> # Divide samples into two cohorts
+    >>> ds["sample_cohort"] = xr.DataArray(np.repeat([0, 1], ds.dims["samples"] // 2), dims="samples")
+    >>> sg.display_genotypes(ds) # doctest: +NORMALIZE_WHITESPACE
+    samples    S0   S1   S2   S3
+    variants
+    0         0/0  1/0  1/0  0/1
+    1         1/0  0/1  0/0  1/0
+    2         1/1  0/0  1/0  0/1
+    3         1/0  1/1  1/1  1/0
+    4         1/0  0/0  1/0  1/1
+
+    >>> sg.count_cohort_alleles(ds)["cohort_allele_count"].values # doctest: +NORMALIZE_WHITESPACE
+    array([[[3, 1],
+            [2, 2]],
+    <BLANKLINE>
+            [[2, 2],
+            [3, 1]],
+    <BLANKLINE>
+            [[2, 2],
+            [2, 2]],
+    <BLANKLINE>
+            [[1, 3],
+            [1, 3]],
+    <BLANKLINE>
+            [[3, 1],
+            [1, 3]]])
     """
     ds = define_variable_if_absent(
         ds, variables.call_allele_count, call_allele_count, count_call_alleles

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -299,19 +299,19 @@ referred to as "scores" or simply "principal components (PCs)" for a set of samp
 stat_Fst, stat_Fst_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("stat_Fst", ndim=3, kind="f")
 )
-"""TODO"""
+"""Fixation index (Fst) between pairs of cohorts."""
 stat_divergence, stat_divergence_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("stat_divergence", ndim=3, kind="f")
 )
-"""TODO"""
+"""Genetic divergence between pairs of cohorts."""
 stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("stat_diversity", ndim=2, kind="f")
 )
-"""TODO"""
+"""Genetic diversity (also known as "Tajima’s pi") for cohorts."""
 stat_Tajimas_D, stat_Tajimas_D_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("stat_Tajimas_D", ndim={0, 2}, kind="f")
 )
-"""TODO"""
+"""Tajima’s D for cohorts."""
 traits, traits_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("traits", ndim={1, 2})
 )


### PR DESCRIPTION
This is a documentation update to add some simple examples for popgen functions, and `count_cohort_alleles`. Also fixes some of the TODOs for #295.

