### PR TITLE
Remove duplicate scikit-allel from dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,6 @@ statsmodels
 zarr
 msprime
 scikit-learn
-scikit-allel
 partd
 fsspec
 bed-reader


### PR DESCRIPTION
It seems there are multiple mentions of `scikit-allel` in the dev `requirements.txt`.