### PR TITLE
Add to_haplotype_calls function

### DIFF
--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -7,6 +7,7 @@ from .model import (
     DIM_VARIANT,
     create_genotype_call_dataset,
     create_genotype_dosage_dataset,
+    to_haplotype_calls,
 )
 from .stats.aggregation import (
     count_call_alleles,
@@ -48,6 +49,7 @@ __all__ = [
     "pbs",
     "pc_relate",
     "simulate_genotype_call_dataset",
+    "to_haplotype_calls",
     "variables",
     "pca",
     "window",

--- a/sgkit/tests/test_model.py
+++ b/sgkit/tests/test_model.py
@@ -9,7 +9,9 @@ from sgkit import (
     create_genotype_call_dataset,
     create_genotype_dosage_dataset,
     display_genotypes,
+    to_haplotype_calls,
 )
+from sgkit.testing import simulate_genotype_call_dataset
 
 
 def test_create_genotype_call_dataset():
@@ -103,4 +105,36 @@ def test_create_genotype_dosage_dataset():
     assert_array_equal(ds["call_genotype_probability"], call_genotype_probability)
     assert_array_equal(
         ds["call_genotype_probability_mask"], np.isnan(call_genotype_probability)
+    )
+
+
+def test_to_haplotype_calls():
+    ds = simulate_genotype_call_dataset(
+        n_variant=4, n_sample=3, n_ploidy=2, missing_pct=0.1
+    )
+    assert_array_equal(
+        ds["call_genotype"],
+        np.array(
+            [
+                [[0, 0], [1, 0], [1, 0]],
+                [[0, 1], [1, 0], [0, -1]],
+                [[-1, -1], [1, 0], [1, 1]],
+                [[0, 0], [1, 0], [0, 1]],
+            ],
+            dtype="i1",
+        ),
+    )
+
+    ds = to_haplotype_calls(ds)
+    assert_array_equal(
+        ds["call_haplotype"],
+        np.array(
+            [
+                [0, 0, 1, 0, 1, 0],
+                [0, 1, 1, 0, 0, -1],
+                [-1, -1, 1, 0, 1, 1],
+                [0, 0, 1, 0, 0, 1],
+            ],
+            dtype="i1",
+        ),
     )

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -204,6 +204,11 @@ completely missing genotype calls.
     ArrayLikeSpec("call_genotype_probability_mask", kind="b", ndim=3)
 )
 """TODO"""
+call_haplotype, call_haplotype_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("call_haplotype", kind="i", ndim=2)
+)
+"""Call haplotype. With shape (variants, haplotypes). Encoded
+in the same way as call genotype."""
 cohort_allele_count, cohort_allele_count_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("cohort_allele_count", kind="i", ndim=3)
 )


### PR DESCRIPTION
This is needed for #231, which works on haplotypes.

I'm open to suggestions for a different name (`to_haplotype_calls`), or where it lives (`model.py` at the moment).
