### PR TITLE
Garud H statistics

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,6 +48,7 @@ Methods
    divergence
    diversity
    Fst
+   Garud_h
    gwas_linear_regression
    hardy_weinberg_test
    regenie
@@ -88,6 +89,10 @@ Variables
     variables.pc_relate_phi_spec
     variables.sample_id_spec
     variables.sample_pcs_spec
+    variables.stat_Garud_h1_spec
+    variables.stat_Garud_h12_spec
+    variables.stat_Garud_h123_spec
+    variables.stat_Garud_h2_h1_spec
     variables.traits_spec
     variables.variant_allele_spec
     variables.variant_allele_count_spec

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -18,7 +18,7 @@ from .stats.association import gwas_linear_regression
 from .stats.hwe import hardy_weinberg_test
 from .stats.pc_relate import pc_relate
 from .stats.pca import pca
-from .stats.popgen import Fst, Tajimas_D, divergence, diversity, pbs
+from .stats.popgen import Fst, Garud_h, Tajimas_D, divergence, diversity, pbs
 from .stats.preprocessing import filter_partial_calls
 from .stats.regenie import regenie
 from .testing import simulate_genotype_call_dataset
@@ -44,6 +44,7 @@ __all__ = [
     "diversity",
     "divergence",
     "Fst",
+    "Garud_h",
     "Tajimas_D",
     "pbs",
     "pc_relate",

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -405,38 +405,21 @@ def test_pbs__windowed(sample_size, n_cohorts, chunks):
 
 @pytest.mark.parametrize(
     "n_variants, n_samples, n_contigs, n_cohorts",
-    [(3, 5, 1, 1), (3, 5, 1, 2)],
+    [(3, 5, 1, 1)],
 )
-@pytest.mark.parametrize("chunks", [(-1, -1), (2, -1)])
-def test_Garud_h(n_variants, n_samples, n_contigs, n_cohorts, chunks):
+def test_Garud_h__no_windows(n_variants, n_samples, n_contigs, n_cohorts):
     # We can't use msprime since it doesn't generate diploid data, and Garud uses phased data
     ds = simulate_genotype_call_dataset(
         n_variant=n_variants, n_sample=n_samples, n_contig=n_contigs
     )
-    ds = ds.chunk(dict(zip(["variants", "samples"], chunks)))
     subsets = np.array_split(ds.samples.values, n_cohorts)
     sample_cohorts = np.concatenate(
         [np.full_like(subset, i) for i, subset in enumerate(subsets)]
     )
     ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
 
-    gh = Garud_h(ds)
-    h1 = gh.stat_Garud_h1.values
-    h12 = gh.stat_Garud_h12.values
-    h123 = gh.stat_Garud_h123.values
-    h2_h1 = gh.stat_Garud_h2_h1.values
-
-    # scikit-allel
-    for c in range(n_cohorts):
-        gt = ds.call_genotype.values[:, sample_cohorts == c, :]
-        ska_gt = allel.GenotypeArray(gt)
-        ska_ha = ska_gt.to_haplotypes()
-        ska_h = allel.garud_h(ska_ha)
-
-        np.testing.assert_allclose(h1[c], ska_h[0])
-        np.testing.assert_allclose(h12[c], ska_h[1])
-        np.testing.assert_allclose(h123[c], ska_h[2])
-        np.testing.assert_allclose(h2_h1[c], ska_h[3])
+    with pytest.raises(ValueError, match="Dataset must be windowed for Garud_h"):
+        Garud_h(ds)
 
 
 @pytest.mark.parametrize(
@@ -444,7 +427,7 @@ def test_Garud_h(n_variants, n_samples, n_contigs, n_cohorts, chunks):
     [(9, 5, 1, 1), (9, 5, 1, 2)],
 )
 @pytest.mark.parametrize("chunks", [(-1, -1), (5, -1)])
-def test_Garud_h__windowed(n_variants, n_samples, n_contigs, n_cohorts, chunks):
+def test_Garud_h(n_variants, n_samples, n_contigs, n_cohorts, chunks):
     ds = simulate_genotype_call_dataset(
         n_variant=n_variants, n_sample=n_samples, n_contig=n_contigs
     )

--- a/sgkit/tests/test_utils.py
+++ b/sgkit/tests/test_utils.py
@@ -13,6 +13,7 @@ from sgkit.utils import (
     check_array_like,
     define_variable_if_absent,
     encode_array,
+    hash_columns,
     max_str_len,
     merge_datasets,
     split_array_chunks,
@@ -208,3 +209,25 @@ def test_split_array_chunks__raise_on_blocks_lte_0():
 def test_split_array_chunks__raise_on_n_lte_0():
     with pytest.raises(ValueError, match=r"Number of elements .* must be >= 0"):
         split_array_chunks(0, 0)
+
+
+@given(st.integers(1, 50), st.integers(2, 50))
+@settings(deadline=None)  # avoid problem with numba jit compilation
+def test_hash_columns(n_rows, n_cols):
+    # construct an array with random repeated columns
+    x = np.random.randint(-2, 10, size=(n_rows, n_cols // 2))
+    cols = np.random.choice(x.shape[1], n_cols, replace=True)
+    x = x[:, cols]
+
+    # find unique column counts (exact method)
+    _, expected_inverse, expected_counts = np.unique(
+        x, axis=1, return_inverse=True, return_counts=True
+    )
+
+    # hash columns, then find unique column counts using the hash values
+    h = hash_columns(x)
+    _, inverse, counts = np.unique(h, return_inverse=True, return_counts=True)
+
+    # counts[inverse] gives the count for each column in x
+    # these should be the same for both ways of counting
+    np.testing.assert_equal(counts[inverse], expected_counts[expected_inverse])

--- a/sgkit/tests/test_utils.py
+++ b/sgkit/tests/test_utils.py
@@ -13,7 +13,7 @@ from sgkit.utils import (
     check_array_like,
     define_variable_if_absent,
     encode_array,
-    hash_columns,
+    hash_array,
     max_str_len,
     merge_datasets,
     split_array_chunks,
@@ -211,21 +211,21 @@ def test_split_array_chunks__raise_on_n_lte_0():
         split_array_chunks(0, 0)
 
 
-@given(st.integers(1, 50), st.integers(2, 50))
+@given(st.integers(2, 50), st.integers(1, 50))
 @settings(deadline=None)  # avoid problem with numba jit compilation
-def test_hash_columns(n_rows, n_cols):
-    # construct an array with random repeated columns
-    x = np.random.randint(-2, 10, size=(n_rows, n_cols // 2))
-    cols = np.random.choice(x.shape[1], n_cols, replace=True)
-    x = x[:, cols]
+def test_hash_array(n_rows, n_cols):
+    # construct an array with random repeated rows
+    x = np.random.randint(-2, 10, size=(n_rows // 2, n_cols))
+    rows = np.random.choice(x.shape[0], n_rows, replace=True)
+    x = x[rows, :]
 
     # find unique column counts (exact method)
     _, expected_inverse, expected_counts = np.unique(
-        x, axis=1, return_inverse=True, return_counts=True
+        x, axis=0, return_inverse=True, return_counts=True
     )
 
     # hash columns, then find unique column counts using the hash values
-    h = hash_columns(x)
+    h = hash_array(x)
     _, inverse, counts = np.unique(h, return_inverse=True, return_counts=True)
 
     # counts[inverse] gives the count for each column in x

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -318,6 +318,22 @@ stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("stat_diversity", ndim=2, kind="f")
 )
 """Genetic diversity (also known as "Tajima’s pi") for cohorts."""
+stat_Garud_h1, stat_Garud_h1_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("stat_Garud_h1", ndim={1, 2}, kind="f")
+)
+"""Garud H1 statistic for cohorts."""
+stat_Garud_h12, stat_Garud_h12_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("stat_Garud_h12", ndim={1, 2}, kind="f")
+)
+"""Garud H12 statistic for cohorts."""
+stat_Garud_h123, stat_Garud_h123_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("stat_Garud_h123", ndim={1, 2}, kind="f")
+)
+"""Garud H123 statistic for cohorts."""
+stat_Garud_h2_h1, stat_Garud_h2_h1_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("stat_Garud_h2_h1", ndim={1, 2}, kind="f")
+)
+"""Garud H2/H1 statistic for cohorts."""
 stat_pbs, stat_pbs_spec = SgkitVariables.register_variable(
     ArrayLikeSpec("stat_pbs", ndim=4, kind="f")
 )

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, Iterable, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -134,10 +134,13 @@ def window_statistic(
     window_starts: ArrayLike,
     window_stops: ArrayLike,
     dtype: DType,
+    chunks: Any = None,
+    new_axis: Union[None, int, Iterable[int]] = None,
     **kwargs: Any,
 ) -> da.Array:
 
     values = da.asarray(values)
+    desired_chunks = chunks or values.chunks
 
     window_lengths = window_stops - window_starts
     depth = np.max(window_lengths)
@@ -184,7 +187,7 @@ def window_statistic(
         # depth is 0 except in first axis
         depth = {0: depth}
         # new chunks are same except in first axis
-        new_chunks = tuple([tuple(windows_per_chunk)] + list(values.chunks[1:]))  # type: ignore
+        new_chunks = tuple([tuple(windows_per_chunk)] + list(desired_chunks[1:]))  # type: ignore
     return values.map_overlap(
         blockwise_moving_stat,
         dtype=dtype,
@@ -192,6 +195,7 @@ def window_statistic(
         depth=depth,
         boundary=0,
         trim=False,
+        new_axis=new_axis,
     )
 
 


### PR DESCRIPTION
This fixes #231.

* This PR depends on #377 for getting a haplotype representation of calls, so that should be merged first. The function there takes genotype calls of shape (variants, samples, ploidy) to (variants, haplotypes), where haplotypes=samples * ploidy.
* If the dataset is not windowed, the variants are assumed to be in a single window. This won't work for large numbers of variants (see discussion about hashing below), so we could choose not to support this and say that the input must be windowed. Would be good to hear thoughts about this @alimanfoo, @jeromekelleher.
* All of the H statistics work by computing statistics on the frequency of occurrences of each haplotype in a cohort. In scikit-allel, the haplotypes (columns of calls) are [hashed](https://github.com/cggh/scikit-allel/blob/5f2f73ff926e105e5a65cacfc28f2928aba70f69/allel/model/ndarray.py#L2507) by calling `hash(x.tobytes())` on the numpy array column `x`. When I tried this on MalariaGEN-scale data using Dask the computation ground to a halt, which I think was due to issues with the GIL. To avoid this, I have written a `hash_columns` function that is Numba-jit compiled, and outperforms the Python hash method by a factor of 5 in a single thread.
* I've used this code in a [notebook](https://nbviewer.jupyter.org/github/tomwhite/shiny-train/blob/sgkit/notebooks/gwss/sgkit_h12.ipynb) to compare with scikit-allel on MalariaGEN. The results for a single cohort and statistic (H12) are concordant (for the first 1000 windows at least), which is promising.
* The H stats notebook that uses scikit-allel has [different window sizes for different cohorts](https://github.com/alimanfoo/shiny-train/blob/master/notebooks/gwss/pop_defs.yml), which is not possible in sgkit easily at the moment (see https://github.com/pystatgen/sgkit/issues/232#issuecomment-722377847 for the same problem with PBS). The most pragmatic way to fix this will probably be to specify the subset of cohorts to calculate the statistic for.