### PR TITLE
Publish docs at https://pystatgen.github.io/sgkit/latest/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,12 +31,13 @@ jobs:
     - name: Commit documentation changes to gh-pages branch
       run: |
         git clone https://github.com/pystatgen/sgkit.git --branch gh-pages --single-branch gh-pages
-        cp -r docs/_build/html/* gh-pages/
+        mkdir -p gh-pages/latest
+        cp -r docs/_build/html/* gh-pages/latest
         cd gh-pages
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add .
-        git commit -m "Update documentation" -a || true # Ignore error if no changes present
+        git commit -m "Update latest documentation" -a || true # Ignore error if no changes present
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -14,7 +14,6 @@ Sgkit itself contains only Python code but many of the required dependencies use
 package dependencies. For this reason, conda is the preferred installation method.  There is no sgkit conda
 package yet though so the recommended setup instructions are::
 
-    $ conda install -c conda-forge --file requirements.txt
     $ pip install --pre sgkit
 
 ..


### PR DESCRIPTION
This is a follow on to #367. After this goes in I will make a few manual changes to the gh-pages branch to remove old top-level files, and add an HTML redirect from https://pystatgen.github.io/sgkit/.