### PR TITLE
Post 0.1.0a1 release doc fixes

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -121,12 +121,6 @@ Contributing to code
 *sgkit* maintains development standards that are similar to most PyData projects.  These standards include
 language support, testing, documentation, and style.
 
-Python versions
-~~~~~~~~~~~~~~~
-
-*sgkit* supports Python versions 3.7 and 3.8.
-
-
 Continuous Integration
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -10,11 +10,9 @@ Getting Started
 Installation
 ------------
 
-Sgkit itself contains only Python code but many of the required dependencies use compiled code or have system
-package dependencies. For this reason, conda is the preferred installation method.  There is no sgkit conda
-package yet though so the recommended setup instructions are::
+You can install sgkit with `pip` - there is no conda package yet. Python 3.7 or 3.8 is required.
 
-    $ pip install --pre sgkit
+    $ pip install sgkit
 
 ..
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -19,7 +19,7 @@ arrays within an :class:`xarray.Dataset` from ``bed``, ``bim``, and ``fam`` file
 PLINK IO support is an "extra" feature within sgkit and requires additional
 dependencies. To install sgkit with PLINK support using pip::
 
-    $ pip install --pre 'sgkit[plink]'
+    $ pip install 'sgkit[plink]'
 
 VCF
 ---

--- a/docs/vcf.rst
+++ b/docs/vcf.rst
@@ -32,7 +32,7 @@ have, at a minimum, ``libcurl`` installed on your machine (you can check by typi
 
 To install sgkit with VCF support using pip::
 
-    $ pip install --pre 'sgkit[vcf]'
+    $ pip install 'sgkit[vcf]'
 
 There are `installation instructions for cyvcf2 <https://github.com/brentp/cyvcf2#installation>`_,
 which may be helpful if you encounter errors during installation.

--- a/sgkit/io/bgen/__init__.py
+++ b/sgkit/io/bgen/__init__.py
@@ -6,6 +6,6 @@ except ImportError as e:  # pragma: no cover
     msg = (
         "sgkit bgen requirements are not installed.\n\n"
         "Please install them via pip :\n\n"
-        "  pip install --pre 'sgkit[bgen]'"
+        "  pip install 'sgkit[bgen]'"
     )
     raise ImportError(str(e) + "\n\n" + msg) from e

--- a/sgkit/io/plink/__init__.py
+++ b/sgkit/io/plink/__init__.py
@@ -6,6 +6,6 @@ except ImportError as e:  # pragma: no cover
     msg = (
         "sgkit plink requirements are not installed.\n\n"
         "Please install them via pip :\n\n"
-        "  pip install --pre 'sgkit[plink]'"
+        "  pip install 'sgkit[plink]'"
     )
     raise ImportError(str(e) + "\n\n" + msg) from e

--- a/sgkit/io/vcf/__init__.py
+++ b/sgkit/io/vcf/__init__.py
@@ -21,6 +21,6 @@ except ImportError as e:  # pragma: no cover
         msg = (
             "sgkit-vcf requirements are not installed.\n\n"
             "Please install them via pip :\n\n"
-            "  pip install --pre 'sgkit[vcf]'"
+            "  pip install 'sgkit[vcf]'"
         )
     raise ImportError(str(e) + "\n\n" + msg) from e


### PR DESCRIPTION
This moves the required Python versions to a more prominent position following https://github.com/pystatgen/sgkit/issues/367#issuecomment-728056891.

I have also removed the `--pre` option from the `pip install` commands. I misunderstood the meaning of this flag - I assumed that you had to include it to install *any* pre-release version, but that's not quite correct - if there are *only* pre-release versions available then pip will install the latest one of those, but if a stable version is available pip will favour that, even if it is older. This is discussed a bit more here: https://github.com/pypa/pip/issues/5503

So for example, at the moment users will get version 0.1.0a1 (whether they use `--pre` or not), but once we have released 0.1.0 and 0.2.0a1 (say), then users will get 0.1.0, unless they use `--pre` in which case they will get 0.2.0a1.