### PR TITLE
Fix Returns spacing in documentation #339

### DIFF
--- a/sgkit/stats/pc_relate.py
+++ b/sgkit/stats/pc_relate.py
@@ -104,6 +104,7 @@ def pc_relate(
     Returns
     -------
     Dataset containing (S = num samples):
+
     :data:`sgkit.variables.pc_relate_phi_spec`: (S,S) ArrayLike
     pairwise recent kinship coefficient matrix as float in [-0.5, 0.5].
 


### PR DESCRIPTION
I checked and this seemed to be the only one missing the space.

Fixes #339 