### PR TITLE
Enable strict checking in Sphinx build #86

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check for Sphinx doc warnings
       run: |
         cd docs
-        make html SPHINXOPTS="-W --keep-going"
+        make html SPHINXOPTS="-W --keep-going -n"
     - name: Test with pytest and coverage
       run: |
         pytest -v --cov=sgkit --cov-report=term-missing

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build Sphinx documentation
       run: |
         cd docs
-        make html SPHINXOPTS="-W --keep-going"
+        make html SPHINXOPTS="-W --keep-going -n"
     - name: Commit documentation changes to gh-pages branch
       run: |
         git clone https://github.com/pystatgen/sgkit.git --branch gh-pages --single-branch gh-pages

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -81,6 +81,7 @@ Variables
     variables.call_genotype_phased_spec
     variables.call_genotype_probability_spec
     variables.call_genotype_probability_mask_spec
+    variables.cohort_allele_count_spec
     variables.covariates_spec
     variables.dosage_spec
     variables.genotype_counts_spec
@@ -89,10 +90,14 @@ Variables
     variables.pc_relate_phi_spec
     variables.sample_id_spec
     variables.sample_pcs_spec
+    variables.stat_divergence_spec
+    variables.stat_diversity_spec
+    variables.stat_Fst_spec
     variables.stat_Garud_h1_spec
     variables.stat_Garud_h12_spec
     variables.stat_Garud_h123_spec
     variables.stat_Garud_h2_h1_spec
+    variables.stat_Tajimas_D_spec
     variables.traits_spec
     variables.variant_allele_spec
     variables.variant_allele_count_spec

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autosummary_generate = True
 
+nitpick_ignore = [("py:class", "sgkit.display.GenotypeDisplay")]
+
 
 # FIXME: Workaround for linking xarray module
 # For some reason, intersphinx is not able to to link xarray objects.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -254,7 +254,7 @@ the affected pages.
 The documentation build is checked by CI to ensure that it builds
 without warnings. You can do that locally with::
 
-   make clean html SPHINXOPTS="-W --keep-going"
+   make clean html SPHINXOPTS="-W --keep-going -n"
 
 .. _Sphinx: https://www.sphinx-doc.org/
 

--- a/sgkit/io/plink/plink_reader.py
+++ b/sgkit/io/plink/plink_reader.py
@@ -142,38 +142,38 @@ def read_plink(
 
     Parameters
     ----------
-    path : Optional[PathType]
+    path
         Path to PLINK file set.
         This should not include a suffix, i.e. if the files are
         at `data.{bed,fam,bim}` then only 'data' should be
         provided (suffixes are added internally).
         Either this path must be provided or all 3 of
         `bed_path`, `bim_path` and `fam_path`.
-    bed_path: Optional[PathType]
+    bed_path
         Path to PLINK bed file.
         This should be a full path including the `.bed` extension
         and cannot be specified in conjunction with `path`.
-    bim_path: Optional[PathType]
+    bim_path
         Path to PLINK bim file.
         This should be a full path including the `.bim` extension
         and cannot be specified in conjunction with `path`.
-    fam_path: Optional[PathType]
+    fam_path
         Path to PLINK fam file.
         This should be a full path including the `.fam` extension
         and cannot be specified in conjunction with `path`.
-    chunks : Union[str, int, tuple], optional
+    chunks
         Chunk size for genotype (i.e. `.bed`) data, by default "auto"
-    fam_sep : str, optional
+    fam_sep
         Delimiter for `.fam` file, by default " "
-    bim_sep : str, optional
+    bim_sep
         Delimiter for `.bim` file, by default "\t"
-    bim_int_contig : bool, optional
+    bim_int_contig
         Whether or not the contig/chromosome name in the `.bim`
         file should be interpreted as an integer, by default False.
         If False, then the `variant/contig` field in the resulting
         dataset will contain the indexes of corresponding strings
         encountered in the first `.bim` field.
-    count_a1 : bool, optional
+    count_a1
         Whether or not allele counts should be for A1 or A2,
         by default True. Typically A1 is the minor allele
         and should be counted instead of A2. This is not enforced
@@ -181,11 +181,11 @@ def read_plink(
         to ensure that A1 is in fact an alternate/minor/effect
         allele. See https://www.cog-genomics.org/plink/1.9/formats
         for more details.
-    lock : bool, optional
+    lock
         Whether or not to synchronize concurrent reads of `.bed`
         file blocks, by default False. This is passed through to
         [dask.array.from_array](https://docs.dask.org/en/latest/array-api.html#dask.array.from_array).
-    persist : bool, optional
+    persist
         Whether or not to persist `.fam` and `.bim` information in
         memory, by default True. This is an important performance
         consideration as the plain text files for this data will

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -482,7 +482,7 @@ def Tajimas_D(
         Genotype call dataset.
     variant_allele_count
         Variant allele count variable to use or calculate. Defined by
-        :data:`sgkit.variables.variant_allele_count`.
+        :data:`sgkit.variables.variant_allele_count_spec`.
         If the variable is not present in ``ds``, it will be computed
         using :func:`count_variant_alleles`.
     stat_diversity


### PR DESCRIPTION
Enables nit picky mode when building Sphinx docs, which picks up some errors that were getting through before.

Fixes #86 