### PR TITLE
Add docs for variables to xarray attributes #393

### DIFF
--- a/sgkit/model.py
+++ b/sgkit/model.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, Hashable, List, Optional
 import numpy as np
 import xarray as xr
 
-from . import variables
 from .typing import ArrayLike
+from .utils import create_dataset
 
 DIM_VARIANT = "variants"
 DIM_SAMPLE = "samples"
@@ -89,7 +89,7 @@ def create_genotype_call_dataset(
     if variant_id is not None:
         data_vars["variant_id"] = ([DIM_VARIANT], variant_id)
     attrs: Dict[Hashable, Any] = {"contigs": variant_contig_names}
-    return variables.validate(xr.Dataset(data_vars=data_vars, attrs=attrs))
+    return create_dataset(data_vars=data_vars, attrs=attrs)
 
 
 def create_genotype_dosage_dataset(
@@ -157,4 +157,4 @@ def create_genotype_dosage_dataset(
     if variant_id is not None:
         data_vars["variant_id"] = ([DIM_VARIANT], variant_id)
     attrs: Dict[Hashable, Any] = {"contigs": variant_contig_names}
-    return variables.validate(xr.Dataset(data_vars=data_vars, attrs=attrs))
+    return create_dataset(data_vars=data_vars, attrs=attrs)

--- a/sgkit/stats/association.py
+++ b/sgkit/stats/association.py
@@ -3,13 +3,12 @@ from typing import Hashable, Optional, Sequence, Union
 
 import dask.array as da
 import numpy as np
-import xarray as xr
 from dask.array import Array, stats
 from xarray import Dataset
 
 from .. import variables
 from ..typing import ArrayLike
-from ..utils import conditional_merge_datasets
+from ..utils import conditional_merge_datasets, create_dataset
 from .utils import concat_2d
 
 
@@ -222,11 +221,11 @@ def gwas_linear_regression(
     Y = Y.rechunk((None, -1))
 
     res = linear_regression(G.T, X, Y)
-    new_ds = xr.Dataset(
+    new_ds = create_dataset(
         {
             variables.variant_beta: (("variants", "traits"), res.beta),
             variables.variant_t_value: (("variants", "traits"), res.t_value),
             variables.variant_p_value: (("variants", "traits"), res.p_value),
         }
     )
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/stats/conversion.py
+++ b/sgkit/stats/conversion.py
@@ -5,7 +5,7 @@ from xarray import Dataset
 
 from sgkit import variables
 from sgkit.typing import ArrayLike
-from sgkit.utils import conditional_merge_datasets
+from sgkit.utils import conditional_merge_datasets, create_dataset
 
 
 @guvectorize(  # type: ignore
@@ -119,10 +119,10 @@ def convert_probability_to_call(
         GP = GP.rechunk((None, None, -1))
     K = da.empty(2, dtype=np.uint8)
     GT = _convert_probability_to_call(GP, K, threshold)
-    new_ds = Dataset(
+    new_ds = create_dataset(
         {
             variables.call_genotype: (("variants", "samples", "ploidy"), GT),
             variables.call_genotype_mask: (("variants", "samples", "ploidy"), GT < 0),
         }
     )
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/stats/hwe.py
+++ b/sgkit/stats/hwe.py
@@ -2,14 +2,13 @@ from typing import Hashable, Optional
 
 import dask.array as da
 import numpy as np
-import xarray as xr
 from numba import njit
 from numpy import ndarray
 from xarray import Dataset
 
 from sgkit import variables
 from sgkit.stats.aggregation import count_genotypes
-from sgkit.utils import conditional_merge_datasets
+from sgkit.utils import conditional_merge_datasets, create_dataset
 
 
 def hardy_weinberg_p_value(obs_hets: int, obs_hom1: int, obs_hom2: int) -> float:
@@ -213,5 +212,5 @@ def hardy_weinberg_test(
             for v in ["variant_n_het", "variant_n_hom_ref", "variant_n_hom_alt"]
         ]
     p = da.map_blocks(hardy_weinberg_p_value_vec_jit, *obs)
-    new_ds = xr.Dataset({variables.variant_hwe_p_value: ("variants", p)})
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    new_ds = create_dataset({variables.variant_hwe_p_value: ("variants", p)})
+    return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/stats/pc_relate.py
+++ b/sgkit/stats/pc_relate.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 from sgkit import variables
 from sgkit.typing import ArrayLike
-from sgkit.utils import conditional_merge_datasets
+from sgkit.utils import conditional_merge_datasets, create_dataset
 
 
 def gramian(a: ArrayLike) -> ArrayLike:
@@ -173,5 +173,5 @@ def pc_relate(
     phi = gramian(centered_af) / gramian(stddev)
     # NOTE: phi is of shape (S x S), S = num samples
     assert phi.shape == (call_g.shape[1],) * 2
-    new_ds = xr.Dataset({variables.pc_relate_phi: (("sample_x", "sample_y"), phi)})
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    new_ds = create_dataset({variables.pc_relate_phi: (("sample_x", "sample_y"), phi)})
+    return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -12,6 +12,7 @@ from sgkit.stats.utils import assert_array_shape
 from sgkit.typing import ArrayLike
 from sgkit.utils import (
     conditional_merge_datasets,
+    create_dataset,
     define_variable_if_absent,
     hash_array,
 )
@@ -106,7 +107,7 @@ def diversity(
             dtype=pi.dtype,
             axis=0,
         )
-        new_ds = Dataset(
+        new_ds = create_dataset(
             {
                 variables.stat_diversity: (
                     ("windows", "cohorts"),
@@ -115,7 +116,7 @@ def diversity(
             }
         )
     else:
-        new_ds = Dataset(
+        new_ds = create_dataset(
             {
                 variables.stat_diversity: (
                     ("variants", "cohorts"),
@@ -123,7 +124,7 @@ def diversity(
                 )
             }
         )
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)
 
 
 # c = cohorts, k = alleles
@@ -273,7 +274,7 @@ def divergence(
             dtype=d.dtype,
             axis=0,
         )
-        new_ds = Dataset(
+        new_ds = create_dataset(
             {
                 variables.stat_divergence: (
                     ("windows", "cohorts_0", "cohorts_1"),
@@ -282,7 +283,7 @@ def divergence(
             }
         )
     else:
-        new_ds = Dataset(
+        new_ds = create_dataset(
             {
                 variables.stat_divergence: (
                     ("variants", "cohorts_0", "cohorts_1"),
@@ -290,7 +291,7 @@ def divergence(
                 )
             }
         )
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)
 
 
 # c = cohorts
@@ -459,8 +460,10 @@ def Fst(
     fst = da.map_blocks(known_estimators[estimator], gs, chunks=shape, dtype=np.float64)
     # TODO: reinstate assert (first dim could be either variants or windows)
     # assert_array_shape(fst, n_windows, n_cohorts, n_cohorts)
-    new_ds = Dataset({variables.stat_Fst: (("windows", "cohorts_0", "cohorts_1"), fst)})
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    new_ds = create_dataset(
+        {variables.stat_Fst: (("windows", "cohorts_0", "cohorts_1"), fst)}
+    )
+    return conditional_merge_datasets(ds, new_ds, merge)
 
 
 def Tajimas_D(
@@ -584,8 +587,8 @@ def Tajimas_D(
         # finally calculate Tajima's D
         D = d / d_stdev
 
-    new_ds = Dataset({variables.stat_Tajimas_D: D})
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    new_ds = create_dataset({variables.stat_Tajimas_D: D})
+    return conditional_merge_datasets(ds, new_ds, merge)
 
 
 # c = cohorts
@@ -725,10 +728,10 @@ def pbs(
     )
     assert_array_shape(p, n_windows, n_cohorts, n_cohorts, n_cohorts)
 
-    new_ds = Dataset(
+    new_ds = create_dataset(
         {variables.stat_pbs: (["windows", "cohorts_0", "cohorts_1", "cohorts_2"], p)}
     )
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)
 
 
 N_GARUD_H_STATS = 4  # H1, H12, H123, H2/H1
@@ -885,7 +888,7 @@ def Garud_H(
     )
     n_windows = ds.window_start.shape[0]
     assert_array_shape(gh, n_windows, n_cohorts, N_GARUD_H_STATS)
-    new_ds = Dataset(
+    new_ds = create_dataset(
         {
             variables.stat_Garud_h1: (
                 ("windows", "cohorts"),
@@ -906,4 +909,4 @@ def Garud_H(
         }
     )
 
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/stats/preprocessing.py
+++ b/sgkit/stats/preprocessing.py
@@ -9,7 +9,7 @@ from xarray import Dataset
 from sgkit import variables
 
 from ..typing import ArrayLike
-from ..utils import conditional_merge_datasets
+from ..utils import conditional_merge_datasets, create_dataset
 
 
 class PattersonScaler(BaseEstimator, TransformerMixin):  # type: ignore[misc]
@@ -178,11 +178,11 @@ def filter_partial_calls(
     else:
         P = (G < 0).any(axis=-1)
     F = xr.where(P, -1, G)  # type: ignore[no-untyped-call]
-    new_ds = Dataset(
+    new_ds = create_dataset(
         {
             variables.call_genotype_complete: F,
             variables.call_genotype_complete_mask: F < 0,
         }
     )
     new_ds[variables.call_genotype_complete].attrs["mixed_ploidy"] = mixed_ploidy
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/stats/regenie.py
+++ b/sgkit/stats/regenie.py
@@ -9,7 +9,7 @@ from xarray import Dataset
 
 from .. import variables
 from ..typing import ArrayLike
-from ..utils import conditional_merge_datasets, split_array_chunks
+from ..utils import conditional_merge_datasets, create_dataset, split_array_chunks
 from .utils import (
     assert_array_shape,
     assert_block_shape,
@@ -722,7 +722,7 @@ def regenie_transform(
             dims=("contigs", "samples", "outcomes"),
             attrs={"description": DESC_LOCO_PRED},
         )
-    return xr.Dataset(data_vars)
+    return create_dataset(data_vars)
 
 
 def regenie(
@@ -886,4 +886,4 @@ def regenie(
         orthogonalize=orthogonalize,
         **kwargs,
     )
-    return conditional_merge_datasets(ds, variables.validate(new_ds), merge)
+    return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -1,10 +1,11 @@
 import warnings
-from typing import Any, Callable, Hashable, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Hashable, List, Mapping, Optional, Set, Tuple, Union
 
 import numpy as np
 from numba import guvectorize
 from xarray import Dataset
 
+from . import variables
 from .typing import ArrayLike, DType
 
 
@@ -192,6 +193,36 @@ def define_variable_if_absent(
             f"Variable '{variable_name}' with non-default name is missing and will not be automatically defined."
         )
     return func(ds)
+
+
+def create_dataset(
+    data_vars: Mapping[Hashable, Any] = None,  # type: ignore[assignment]
+    coords: Mapping[Hashable, Any] = None,  # type: ignore[assignment]
+    attrs: Mapping[Hashable, Any] = None,  # type: ignore[assignment]
+) -> Dataset:
+    """Create an Xarray dataset and validate its variables.
+
+    This is a wrapper around `xarray.Dataset`, with the additional
+    convenience of validating variables against the ones defined by sgkit,
+    and annotating these variables with a `comment` attribute containing
+    their doc comments.
+
+    Parameters
+    ----------
+    data_vars
+        A mapping defining data variables.
+    coords
+        A mapping defining coordinates.
+    attrs
+        Global attributes.
+
+    Returns
+    -------
+    A new dataset.
+    """
+    ds = Dataset(data_vars, coords, attrs)
+    ds = variables.annotate(ds)
+    return ds
 
 
 def split_array_chunks(n: int, blocks: int) -> Tuple[int, ...]:

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -1,6 +1,7 @@
+import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import Dict, Hashable, Mapping, Set, Tuple, Union, overload
+from typing import Dict, Hashable, Mapping, Optional, Set, Tuple, Union, overload
 
 import xarray as xr
 
@@ -12,6 +13,7 @@ class Spec:
     """Root type Spec"""
 
     default_name: str
+    __doc__: Optional[str] = dataclasses.field(default=None, repr=False)
 
     # Note: we want to prevent dev/users from mistakenly
     #       using Spec as a hashable obj in dict, xr.Dataset
@@ -110,6 +112,8 @@ class SgkitVariables:
             check_array_like(
                 xr_dataset[field], kind=field_spec.kind, ndim=field_spec.ndim
             )
+            if field_spec.__doc__ is not None:
+                xr_dataset[field].attrs["comment"] = field_spec.__doc__.strip()
         except (TypeError, ValueError) as e:
             raise ValueError(
                 f"{field} does not match the spec, see the error above for more detail"
@@ -136,332 +140,592 @@ specific page.
 """
 
 base_prediction, base_prediction_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("base_prediction", ndim=4, kind="f")
-)
-"""
+    ArrayLikeSpec(
+        "base_prediction",
+        ndim=4,
+        kind="f",
+        __doc__="""
 REGENIE's base prediction (blocks, alphas, samples, outcomes). Stage 1
 predictions from ridge regression reduction.
-"""
-call_allele_count, call_allele_count_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_allele_count", ndim=3, kind="u")
+""",
+    )
 )
-"""
+
+call_allele_count, call_allele_count_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "call_allele_count",
+        ndim=3,
+        kind="u",
+        __doc__="""
 Allele counts. With shape (variants, samples, alleles) and values
 corresponding to the number of non-missing occurrences of each allele.
-"""
+""",
+    )
+)
+
 call_dosage, call_dosage_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_dosage", kind="f", ndim=2)
+    ArrayLikeSpec(
+        "call_dosage",
+        kind="f",
+        ndim=2,
+        __doc__="""Dosages, encoded as floats, with NaN indicating a missing value.""",
+    )
 )
-"""Dosages, encoded as floats, with NaN indicating a missing value."""
+
 call_dosage_mask, call_dosage_mask_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_dosage_mask", kind="b", ndim=2)
+    ArrayLikeSpec("call_dosage_mask", kind="b", ndim=2, __doc__="""TODO""")
 )
-"""TODO"""
+
 call_genotype, call_genotype_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype", kind="i", ndim=3)
-)
-"""
+    ArrayLikeSpec(
+        "call_genotype",
+        kind="i",
+        ndim=3,
+        __doc__="""
 Call genotype. Encoded as allele values (0 for the reference, 1 for
 the first allele, 2 for the second allele), -1 to indicate a
 missing value, or -2 to indicate a non allele in mixed ploidy datasets.
-"""
-call_genotype_mask, call_genotype_mask_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype_mask", kind="b", ndim=3)
+""",
+    )
 )
-"""TODO"""
+
+call_genotype_mask, call_genotype_mask_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("call_genotype_mask", kind="b", ndim=3, __doc__="""TODO""")
+)
+
 (
     call_genotype_non_allele,
     call_genotype_non_allele_spec,
 ) = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype_non_allele", kind="b", ndim=3)
-)
-"""
+    ArrayLikeSpec(
+        "call_genotype_non_allele",
+        kind="b",
+        ndim=3,
+        __doc__="""
 A flag for each allele position within mixed ploidy call genotypes
 indicating non-allele values of lower ploidy calls.
-"""
-call_genotype_phased, call_genotype_phased_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype_phased", kind="b", ndim=2)
+""",
+    )
 )
-"""
+
+call_genotype_phased, call_genotype_phased_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "call_genotype_phased",
+        kind="b",
+        ndim=2,
+        __doc__="""
 A flag for each call indicating if it is phased or not. If omitted
 all calls are unphased.
-"""
-call_genotype_complete, call_genotype_complete_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype_complete", kind="i", ndim=3)
+""",
+    )
 )
-"""
+
+call_genotype_complete, call_genotype_complete_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "call_genotype_complete",
+        kind="i",
+        ndim=3,
+        __doc__="""
 Call genotypes in which partial genotype calls are replaced with
 completely missing genotype calls.
-"""
+""",
+    )
+)
+
 (
     call_genotype_complete_mask,
     call_genotype_complete_mask_spec,
 ) = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype_complete_mask", kind="b", ndim=3)
+    ArrayLikeSpec("call_genotype_complete_mask", kind="b", ndim=3, __doc__="""TODO""")
 )
-"""TODO"""
+
 (
     call_genotype_probability,
     call_genotype_probability_spec,
 ) = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype_probability", kind="f", ndim=3)
+    ArrayLikeSpec("call_genotype_probability", kind="f", ndim=3, __doc__="""TODO""")
 )
-"""TODO"""
+
 (
     call_genotype_probability_mask,
     call_genotype_probability_mask_spec,
 ) = SgkitVariables.register_variable(
-    ArrayLikeSpec("call_genotype_probability_mask", kind="b", ndim=3)
+    ArrayLikeSpec(
+        "call_genotype_probability_mask", kind="b", ndim=3, __doc__="""TODO"""
+    )
 )
-"""TODO"""
+
 cohort_allele_count, cohort_allele_count_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("cohort_allele_count", kind="i", ndim=3)
+    ArrayLikeSpec("cohort_allele_count", kind="i", ndim=3, __doc__="""TODO""")
 )
+
 covariates, covariates_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("covariates", ndim={1, 2})
-)
-"""
+    ArrayLikeSpec(
+        "covariates",
+        ndim={1, 2},
+        __doc__="""
 Covariate variable names. Must correspond to 1 or 2D dataset
 variables of shape (samples[, covariates]). All covariate arrays
 will be concatenated along the second axis (columns).
-"""
-dosage, dosage_spec = SgkitVariables.register_variable(ArrayLikeSpec("dosage"))
-"""
+""",
+    )
+)
+
+dosage, dosage_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "dosage",
+        __doc__="""
 Dosage variable name. Where "dosage" array can contain represent
 one of several possible quantities, e.g.:
 - Alternate allele counts
 - Recessive or dominant allele encodings
 - True dosages as computed from imputed or probabilistic variant calls
 - Any other custom encoding in a user-defined variable
-"""
-genotype_counts, genotype_counts_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("genotype_counts", ndim=2, kind="i")
+""",
+    )
 )
-"""
+
+genotype_counts, genotype_counts_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "genotype_counts",
+        ndim=2,
+        kind="i",
+        __doc__="""
 Genotype counts. Must correspond to an (`N`, 3) array where `N` is equal
 to the number of variants and the 3 columns contain heterozygous,
 homozygous reference, and homozygous alternate counts (in that order)
 across all samples for a variant.
-"""
-loco_prediction, loco_prediction_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("loco_prediction", ndim=3, kind="f")
+""",
+    )
 )
-"""
+
+loco_prediction, loco_prediction_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "loco_prediction",
+        ndim=3,
+        kind="f",
+        __doc__="""
 REGENIE's loco_prediction (contigs, samples, outcomes). LOCO predictions
 resulting from Stage 2 predictions ignoring effects for variant blocks on
 held out contigs. This will be absent if the data provided does not contain
 at least 2 contigs.
-"""
-meta_prediction, meta_prediction_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("meta_prediction", ndim=2, kind="f")
+""",
+    )
 )
-"""
+
+meta_prediction, meta_prediction_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "meta_prediction",
+        ndim=2,
+        kind="f",
+        __doc__="""
 REGENIE's meta_prediction (samples, outcomes). Stage 2 predictions from
 the best meta estimator trained on the out-of-sample Stage 1 predictions.
-"""
+""",
+    )
+)
+
 pc_relate_phi, pc_relate_phi_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("pc_relate_phi", ndim=2, kind="f")
+    ArrayLikeSpec(
+        "pc_relate_phi",
+        ndim=2,
+        kind="f",
+        __doc__="""PC Relate kinship coefficient matrix.""",
+    )
 )
-"""PC Relate kinship coefficient matrix."""
+
 sample_call_rate, sample_call_rate_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_call_rate", ndim=1, kind="f")
+    ArrayLikeSpec(
+        "sample_call_rate",
+        ndim=1,
+        kind="f",
+        __doc__="""The fraction of variants with called genotypes.""",
+    )
 )
-"""The fraction of variants with called genotypes."""
+
 sample_id, sample_id_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_id", kind={"S", "U", "O"}, ndim=1)
+    ArrayLikeSpec(
+        "sample_id",
+        kind={"S", "U", "O"},
+        ndim=1,
+        __doc__="""The unique identifier of the sample.""",
+    )
 )
-"""The unique identifier of the sample."""
+
 sample_n_called, sample_n_called_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_n_called", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "sample_n_called",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of variants with called genotypes.""",
+    )
 )
-"""The number of variants with called genotypes."""
+
 sample_n_het, sample_n_het_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_n_het", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "sample_n_het",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of variants with heterozygous calls.""",
+    )
 )
-"""The number of variants with heterozygous calls."""
+
 sample_n_hom_alt, sample_n_hom_alt_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_n_hom_alt", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "sample_n_hom_alt",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of variants with homozygous alternate calls.""",
+    )
 )
-"""The number of variants with homozygous alternate calls."""
+
 sample_n_hom_ref, sample_n_hom_ref_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_n_hom_ref", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "sample_n_hom_ref",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of variants with homozygous reference calls.""",
+    )
 )
-"""The number of variants with homozygous reference calls."""
+
 sample_n_non_ref, sample_n_non_ref_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_n_non_ref", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "sample_n_non_ref",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of variants that are not homozygous reference calls.""",
+    )
 )
-"""The number of variants that are not homozygous reference calls."""
+
 sample_pcs, sample_pcs_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_pcs", ndim=2, kind="f")
+    ArrayLikeSpec("sample_pcs", ndim=2, kind="f", __doc__="""Sample PCs (PCxS).""")
 )
-"""Sample PCs (PCxS)."""
+
 sample_pca_component, sample_pca_component_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_pca_component", ndim=2, kind="f")
-)
-"""Principal axes defined as eigenvectors for sample covariance matrix.
+    ArrayLikeSpec(
+        "sample_pca_component",
+        ndim=2,
+        kind="f",
+        __doc__="""Principal axes defined as eigenvectors for sample covariance matrix.
 In the context of SVD, these are equivalent to the right singular vectors in
-the decomposition of a (N, M) matrix., i.e. ``dask_ml.decomposition.TruncatedSVD.components_``."""
+the decomposition of a (N, M) matrix., i.e. ``dask_ml.decomposition.TruncatedSVD.components_``.""",
+    )
+)
+
 (
     sample_pca_explained_variance,
     sample_pca_explained_variance_spec,
 ) = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_pca_explained_variance", ndim=1, kind="f")
-)
-"""Variance explained by each principal component. These values are equivalent
+    ArrayLikeSpec(
+        "sample_pca_explained_variance",
+        ndim=1,
+        kind="f",
+        __doc__="""Variance explained by each principal component. These values are equivalent
 to eigenvalues that result from the eigendecomposition of a (N, M) matrix,
-i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_``."""
+i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_``.""",
+    )
+)
+
 (
     sample_pca_explained_variance_ratio,
     sample_pca_explained_variance_ratio_spec,
 ) = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_pca_explained_variance_ratio", ndim=1, kind="f")
+    ArrayLikeSpec(
+        "sample_pca_explained_variance_ratio",
+        ndim=1,
+        kind="f",
+        __doc__="""Ratio of variance explained to total variance for each principal component,
+i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_ratio_``.""",
+    )
 )
-"""Ratio of variance explained to total variance for each principal component,
-i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_ratio_``."""
+
 sample_pca_loading, sample_pca_loading_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_pca_loading", ndim=2, kind="f")
-)
-"""PCA loadings defined as principal axes scaled by square root of eigenvalues.
+    ArrayLikeSpec(
+        "sample_pca_loading",
+        ndim=2,
+        kind="f",
+        __doc__="""PCA loadings defined as principal axes scaled by square root of eigenvalues.
 These values  can also be interpreted  as the correlation between the original variables
-and unit-scaled principal axes."""
-sample_pca_projection, sample_pca_projection_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_pca_projection", ndim=2, kind="f")
+and unit-scaled principal axes.""",
+    )
 )
-"""Projection of samples onto principal axes. This array is commonly
-referred to as "scores" or simply "principal components (PCs)" for a set of samples."""
+
+sample_pca_projection, sample_pca_projection_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "sample_pca_projection",
+        ndim=2,
+        kind="f",
+        __doc__="""Projection of samples onto principal axes. This array is commonly
+referred to as "scores" or simply "principal components (PCs)" for a set of samples.""",
+    )
+)
+
 
 stat_Fst, stat_Fst_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Fst", ndim=3, kind="f")
+    ArrayLikeSpec(
+        "stat_Fst",
+        ndim=3,
+        kind="f",
+        __doc__="""Fixation index (Fst) between pairs of cohorts.""",
+    )
 )
-"""Fixation index (Fst) between pairs of cohorts."""
+
 stat_divergence, stat_divergence_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_divergence", ndim=3, kind="f")
+    ArrayLikeSpec(
+        "stat_divergence",
+        ndim=3,
+        kind="f",
+        __doc__="""Genetic divergence between pairs of cohorts.""",
+    )
 )
-"""Genetic divergence between pairs of cohorts."""
+
 stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_diversity", ndim=2, kind="f")
+    ArrayLikeSpec(
+        "stat_diversity",
+        ndim=2,
+        kind="f",
+        __doc__="""Genetic diversity (also known as "Tajima’s pi") for cohorts.""",
+    )
 )
-"""Genetic diversity (also known as "Tajima’s pi") for cohorts."""
+
 stat_Garud_h1, stat_Garud_h1_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Garud_h1", ndim={1, 2}, kind="f")
+    ArrayLikeSpec(
+        "stat_Garud_h1",
+        ndim={1, 2},
+        kind="f",
+        __doc__="""Garud H1 statistic for cohorts.""",
+    )
 )
-"""Garud H1 statistic for cohorts."""
+
 stat_Garud_h12, stat_Garud_h12_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Garud_h12", ndim={1, 2}, kind="f")
+    ArrayLikeSpec(
+        "stat_Garud_h12",
+        ndim={1, 2},
+        kind="f",
+        __doc__="""Garud H12 statistic for cohorts.""",
+    )
 )
-"""Garud H12 statistic for cohorts."""
+
 stat_Garud_h123, stat_Garud_h123_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Garud_h123", ndim={1, 2}, kind="f")
+    ArrayLikeSpec(
+        "stat_Garud_h123",
+        ndim={1, 2},
+        kind="f",
+        __doc__="""Garud H123 statistic for cohorts.""",
+    )
 )
-"""Garud H123 statistic for cohorts."""
+
 stat_Garud_h2_h1, stat_Garud_h2_h1_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Garud_h2_h1", ndim={1, 2}, kind="f")
+    ArrayLikeSpec(
+        "stat_Garud_h2_h1",
+        ndim={1, 2},
+        kind="f",
+        __doc__="""Garud H2/H1 statistic for cohorts.""",
+    )
 )
-"""Garud H2/H1 statistic for cohorts."""
+
 stat_pbs, stat_pbs_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_pbs", ndim=4, kind="f")
+    ArrayLikeSpec(
+        "stat_pbs",
+        ndim=4,
+        kind="f",
+        __doc__="""Population branching statistic for cohort triples.""",
+    )
 )
-"""Population branching statistic for cohort triples."""
+
 stat_Tajimas_D, stat_Tajimas_D_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("stat_Tajimas_D", ndim={0, 2}, kind="f")
+    ArrayLikeSpec(
+        "stat_Tajimas_D", ndim={0, 2}, kind="f", __doc__="""Tajima’s D for cohorts."""
+    )
 )
-"""Tajima’s D for cohorts."""
+
 traits, traits_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("traits", ndim={1, 2})
-)
-"""
+    ArrayLikeSpec(
+        "traits",
+        ndim={1, 2},
+        __doc__="""
 Trait (for example phenotype) variable names. Must all be continuous and
 correspond to 1 or 2D dataset variables of shape (samples[, traits]).
 2D trait arrays will be assumed to contain separate traits within columns
 and concatenated to any 1D traits along the second axis (columns).
-"""
+""",
+    )
+)
+
 variant_allele, variant_allele_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_allele", kind={"S", "O"}, ndim=2)
+    ArrayLikeSpec(
+        "variant_allele",
+        kind={"S", "O"},
+        ndim=2,
+        __doc__="""The possible alleles for the variant.""",
+    )
 )
-"""The possible alleles for the variant."""
+
 variant_allele_count, variant_allele_count_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_allele_count", ndim=2, kind="u")
-)
-"""
+    ArrayLikeSpec(
+        "variant_allele_count",
+        ndim=2,
+        kind="u",
+        __doc__="""
 Variant allele counts. With shape (variants, alleles) and values
 corresponding to the number of non-missing occurrences of each allele.
-"""
+""",
+    )
+)
+
 (
     variant_allele_frequency,
     variant_allele_frequency_spec,
 ) = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_allele_frequency", ndim=2, kind="f")
+    ArrayLikeSpec(
+        "variant_allele_frequency",
+        ndim=2,
+        kind="f",
+        __doc__="""The frequency of the occurrence of each allele.""",
+    )
 )
-"""The frequency of the occurrence of each allele."""
+
 variant_allele_total, variant_allele_total_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_allele_total", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "variant_allele_total",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of occurrences of all alleles.""",
+    )
 )
-"""The number of occurrences of all alleles."""
+
 variant_beta, variant_beta_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_beta")
+    ArrayLikeSpec(
+        "variant_beta",
+        __doc__="""Beta values associated with each variant and trait.""",
+    )
 )
-"""Beta values associated with each variant and trait."""
+
 variant_call_rate, variant_call_rate_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_call_rate", ndim=1, kind="f")
+    ArrayLikeSpec(
+        "variant_call_rate",
+        ndim=1,
+        kind="f",
+        __doc__="""The fraction of samples with called genotypes.""",
+    )
 )
-"""The number of samples with heterozygous calls."""
+
 variant_contig, variant_contig_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_contig", kind={"i", "u"}, ndim=1)
+    ArrayLikeSpec(
+        "variant_contig",
+        kind={"i", "u"},
+        ndim=1,
+        __doc__="""
+Index corresponding to contig name for each variant. In some less common
+scenarios, this may also be equivalent to the contig names if the data
+generating process used contig names that were also integers.
+""",
+    )
 )
-"""
-Index corresponding to contig name for each variant. In some less common scenarios,
-this may also be equivalent to the contig names if the data generating process used
-contig names that were also integers.
-"""
+
 variant_hwe_p_value, variant_hwe_p_value_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_hwe_p_value", kind="f")
+    ArrayLikeSpec(
+        "variant_hwe_p_value",
+        kind="f",
+        __doc__="""P values from HWE test for each variant as float in [0, 1].""",
+    )
 )
-"""P values from HWE test for each variant as float in [0, 1]."""
+
 variant_id, variant_id_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_id", kind={"S", "U", "O"}, ndim=1)
+    ArrayLikeSpec(
+        "variant_id",
+        kind={"S", "U", "O"},
+        ndim=1,
+        __doc__="""The unique identifier of the variant.""",
+    )
 )
-"""The unique identifier of the variant."""
+
 variant_n_called, variant_n_called_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_n_called", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "variant_n_called",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of samples with called genotypes.""",
+    )
 )
-"""The number of samples with called genotypes."""
+
 variant_n_het, variant_n_het_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_n_het", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "variant_n_het",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of samples with heterozygous calls.""",
+    )
 )
-"""The number of samples with heterozygous calls."""
+
 variant_n_hom_alt, variant_n_hom_alt_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_n_hom_alt", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "variant_n_hom_alt",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of samples with homozygous alternate calls.""",
+    )
 )
-"""The number of samples with homozygous alternate calls."""
+
 variant_n_hom_ref, variant_n_hom_ref_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_n_hom_ref", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "variant_n_hom_ref",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of samples with homozygous reference calls.""",
+    )
 )
-"""The number of samples with homozygous reference calls."""
+
 variant_n_non_ref, variant_n_non_ref_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_n_non_ref", ndim=1, kind="i")
+    ArrayLikeSpec(
+        "variant_n_non_ref",
+        ndim=1,
+        kind="i",
+        __doc__="""The number of samples that are not homozygous reference calls.""",
+    )
 )
-"""The number of samples that are not homozygous reference calls."""
+
 variant_p_value, variant_p_value_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_p_value", kind="f")
+    ArrayLikeSpec(
+        "variant_p_value", kind="f", __doc__="""P values as float in [0, 1]."""
+    )
 )
-"""P values as float in [0, 1]."""
+
 variant_position, variant_position_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_position", kind="i", ndim=1)
+    ArrayLikeSpec(
+        "variant_position",
+        kind="i",
+        ndim=1,
+        __doc__="""The reference position of the variant.""",
+    )
 )
-"""The reference position of the variant."""
 variant_t_value, variant_t_value_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_t_value")
+    ArrayLikeSpec("variant_t_value", __doc__="""T statistics for each beta.""")
 )
-"""T statistics for each beta."""
+
 window_contig, window_contig_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("window_contig", kind="i", ndim=1)
+    ArrayLikeSpec(
+        "window_contig",
+        kind="i",
+        ndim=1,
+        __doc__="""The contig index of each window.""",
+    )
 )
-"""The contig index of each window."""
+
 window_start, window_start_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("window_start", kind="i", ndim=1)
+    ArrayLikeSpec(
+        "window_start",
+        kind="i",
+        ndim=1,
+        __doc__="""The index values of window start positions along the ``variants`` dimension.""",
+    )
 )
-"""The index values of window start positions along the ``variants`` dimension."""
+
 window_stop, window_stop_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("window_stop", kind="i", ndim=1)
+    ArrayLikeSpec(
+        "window_stop",
+        kind="i",
+        ndim=1,
+        __doc__="""The index values of window stop positions along the ``variants`` dimension.""",
+    )
 )
-"""The index values of window stop positions along the ``variants`` dimension."""

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -4,7 +4,7 @@ import dask.array as da
 import numpy as np
 from xarray import Dataset
 
-from sgkit.utils import conditional_merge_datasets
+from sgkit.utils import conditional_merge_datasets, create_dataset
 from sgkit.variables import window_contig, window_start, window_stop
 
 from .typing import ArrayLike, DType
@@ -69,7 +69,7 @@ def window(
     window_starts = np.concatenate(contig_window_starts)
     window_stops = np.concatenate(contig_window_stops)
 
-    new_ds = Dataset(
+    new_ds = create_dataset(
         {
             window_contig: (
                 "windows",


### PR DESCRIPTION
This is a draft to show how it might work. I haven't converted all the docstrings yet, but will do if this looks OK.

Here is an example rendered dataset - note the `comment` attributes (they are hidden by default and can be viewed by clicking on the file icon):

![ds](https://user-images.githubusercontent.com/85085/102084467-1acbe880-3e0d-11eb-90ec-2686d1aebff6.png)

I also checked that the Sphinx generated documentation is the same (note use of `dataclasses.field(repr=False)` so that the docstring does not show up as an attribute in the string representation of `ArrayLikeSpec`).

Fixes #393