### PR TITLE
Use fsspec in load_dataset and save_dataset #395

### DIFF
--- a/sgkit/tests/io/test_dataset.py
+++ b/sgkit/tests/io/test_dataset.py
@@ -1,3 +1,5 @@
+from typing import MutableMapping
+
 import pytest
 import xarray as xr
 from xarray import Dataset
@@ -31,3 +33,16 @@ def test_save_and_load_dataset(tmp_path, is_path):
         path2 = str(path2)
     save_dataset(ds2, path2)
     assert_identical(ds, load_dataset(path2))
+
+
+def test_save_and_load_dataset__mutable_mapping():
+    store: MutableMapping[str, bytes] = {}
+    ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10)
+    save_dataset(ds, store)
+    ds2 = load_dataset(store)
+    assert_identical(ds, ds2)
+
+    # save and load again to test https://github.com/pydata/xarray/issues/4386
+    store2: MutableMapping[str, bytes] = {}
+    save_dataset(ds2, store2)
+    assert_identical(ds, load_dataset(store2))

--- a/sgkit/tests/io/test_dataset.py
+++ b/sgkit/tests/io/test_dataset.py
@@ -1,3 +1,4 @@
+import pytest
 import xarray as xr
 from xarray import Dataset
 
@@ -11,14 +12,22 @@ def assert_identical(ds1: Dataset, ds2: Dataset) -> None:
     assert all([ds1[v].dtype == ds2[v].dtype for v in ds1.data_vars])
 
 
-def test_save_and_load_dataset(tmp_path):
-    path = str(tmp_path / "ds.zarr")
+@pytest.mark.parametrize(
+    "is_path",
+    [True, False],
+)
+def test_save_and_load_dataset(tmp_path, is_path):
+    path = tmp_path / "ds.zarr"
+    if not is_path:
+        path = str(path)
     ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10)
     save_dataset(ds, path)
     ds2 = load_dataset(path)
     assert_identical(ds, ds2)
 
     # save and load again to test https://github.com/pydata/xarray/issues/4386
-    path2 = str(tmp_path / "ds2.zarr")
+    path2 = tmp_path / "ds2.zarr"
+    if not is_path:
+        path2 = str(path2)
     save_dataset(ds2, path2)
     assert_identical(ds, load_dataset(path2))


### PR DESCRIPTION
Fixes #395.

The problem with warnings about files not being closed was fixed in https://github.com/intake/filesystem_spec/pull/463. There hasn't been an `fsspec` release with that fix in yet, but I think we can merge this PR anyway, since I haven't seen it cause any problems (and @eric-czech has been using something equivalent in https://github.com/related-sciences/ukb-gwas-pipeline-nealelab/blob/4f862e31b8093d25fdaa8da7f841b9be8583cda4/scripts/gwas.py#L53-L71).