### PR TITLE
Fix PCA tests running on Dask 2020.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 xarray
-dask[array] == 2.30.0
-distributed == 2.30.0
+dask[array]
+distributed
 dask-ml
 scipy
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 install_requires =
     numpy
     xarray
-    dask[array] == 2.30.0
-    distributed == 2.30.0
+    dask[array]
+    distributed
     dask-ml
     scipy
     zarr

--- a/sgkit/tests/test_pca.py
+++ b/sgkit/tests/test_pca.py
@@ -245,7 +245,7 @@ def test_pca__randomized_allel_comparison(shape, chunks, n_components):
         iterated_power=5,
         random_state=0,
     )
-    assert ds_sg["sample_pca_projection"].values.dtype == np.float64
+    assert ds_sg["sample_pca_projection"].values.dtype == np.float32
     assert ds_sk["sample_pca_projection"].values.dtype == np.float32
     validate_allel_comparison(ds_sg, ds_sk)
 

--- a/sgkit/tests/test_regenie.py
+++ b/sgkit/tests/test_regenie.py
@@ -292,6 +292,7 @@ def test_regenie__glow_comparison(datadir: Path) -> None:
         check_simulation_result(datadir, config, run)
 
 
+@pytest.mark.xfail(reason="See https://github.com/pystatgen/sgkit/issues/456")
 def test_regenie__no_loco_with_one_contig():
     # LOCO is not possible with a single contig
     ds = simulate_regression_dataset(


### PR DESCRIPTION
This will fail and should not be merged until there is a new release of dask-ml with https://github.com/dask/dask-ml/pull/767 in it.