### PR TITLE
Better errors for VCF files with no genotype information, or with missing contigs in the header

### DIFF
--- a/sgkit/io/vcf/vcf_partition.py
+++ b/sgkit/io/vcf/vcf_partition.py
@@ -132,13 +132,6 @@ def partition_into_regions(
         if target_part_size_bytes < 1:
             raise ValueError("target_part_size must be positive")
 
-    if index_path is None:
-        index_path = get_tabix_path(vcf_path, storage_options=storage_options)
-        if index_path is None:
-            index_path = get_csi_path(vcf_path, storage_options=storage_options)
-            if index_path is None:
-                raise ValueError("Cannot find .tbi or .csi file.")
-
     # Calculate the desired part file boundaries
     file_length = get_file_length(vcf_path, storage_options=storage_options)
     if num_parts is not None:
@@ -148,6 +141,13 @@ def partition_into_regions(
     if num_parts == 1:
         return None
     part_lengths = np.array([i * target_part_size_bytes for i in range(num_parts)])
+
+    if index_path is None:
+        index_path = get_tabix_path(vcf_path, storage_options=storage_options)
+        if index_path is None:
+            index_path = get_csi_path(vcf_path, storage_options=storage_options)
+            if index_path is None:
+                raise ValueError("Cannot find .tbi or .csi file.")
 
     # Get the file offsets from .tbi/.csi
     index = read_index(index_path, storage_options=storage_options)

--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -93,10 +93,17 @@ def vcf_to_zarr_sequential(
             variant_allele = []
 
             for i, variant in enumerate(variants_chunk):
+                if variant.genotype is None:
+                    raise ValueError("Genotype information missing from VCF.")
                 variant_id = variant.ID if variant.ID is not None else "."
                 variant_ids.append(variant_id)
                 max_variant_id_length = max(max_variant_id_length, len(variant_id))
-                variant_contig[i] = variant_contig_names.index(variant.CHROM)
+                try:
+                    variant_contig[i] = variant_contig_names.index(variant.CHROM)
+                except ValueError:
+                    raise ValueError(
+                        f"Contig '{variant.CHROM}' is not defined in the header."
+                    )
                 variant_position[i] = variant.POS
 
                 alleles = [variant.REF] + variant.ALT

--- a/sgkit/tests/io/vcf/data/no_genotypes.vcf
+++ b/sgkit/tests/io/vcf/data/no_genotypes.vcf
@@ -1,0 +1,112 @@
+##fileformat=VCFv4.1
+##contig=<ID=1,length=249250621,assembly=b37>
+##contig=<ID=10,length=135534747,assembly=b37>
+##contig=<ID=11,length=135006516,assembly=b37>
+##contig=<ID=12,length=133851895,assembly=b37>
+##contig=<ID=13,length=115169878,assembly=b37>
+##contig=<ID=14,length=107349540,assembly=b37>
+##contig=<ID=15,length=102531392,assembly=b37>
+##contig=<ID=16,length=90354753,assembly=b37>
+##contig=<ID=17,length=81195210,assembly=b37>
+##contig=<ID=18,length=78077248,assembly=b37>
+##contig=<ID=19,length=59128983,assembly=b37>
+##contig=<ID=2,length=243199373,assembly=b37>
+##contig=<ID=20,length=63025520,assembly=b37>
+##contig=<ID=21,length=48129895,assembly=b37>
+##contig=<ID=22,length=51304566,assembly=b37>
+##contig=<ID=3,length=198022430,assembly=b37>
+##contig=<ID=4,length=191154276,assembly=b37>
+##contig=<ID=5,length=180915260,assembly=b37>
+##contig=<ID=6,length=171115067,assembly=b37>
+##contig=<ID=7,length=159138663,assembly=b37>
+##contig=<ID=8,length=146364022,assembly=b37>
+##contig=<ID=9,length=141213431,assembly=b37>
+##contig=<ID=GL000191.1,length=106433,assembly=b37>
+##contig=<ID=GL000192.1,length=547496,assembly=b37>
+##contig=<ID=GL000193.1,length=189789,assembly=b37>
+##contig=<ID=GL000194.1,length=191469,assembly=b37>
+##contig=<ID=GL000195.1,length=182896,assembly=b37>
+##contig=<ID=GL000196.1,length=38914,assembly=b37>
+##contig=<ID=GL000197.1,length=37175,assembly=b37>
+##contig=<ID=GL000198.1,length=90085,assembly=b37>
+##contig=<ID=GL000199.1,length=169874,assembly=b37>
+##contig=<ID=GL000200.1,length=187035,assembly=b37>
+##contig=<ID=GL000201.1,length=36148,assembly=b37>
+##contig=<ID=GL000202.1,length=40103,assembly=b37>
+##contig=<ID=GL000203.1,length=37498,assembly=b37>
+##contig=<ID=GL000204.1,length=81310,assembly=b37>
+##contig=<ID=GL000205.1,length=174588,assembly=b37>
+##contig=<ID=GL000206.1,length=41001,assembly=b37>
+##contig=<ID=GL000207.1,length=4262,assembly=b37>
+##contig=<ID=GL000208.1,length=92689,assembly=b37>
+##contig=<ID=GL000209.1,length=159169,assembly=b37>
+##contig=<ID=GL000210.1,length=27682,assembly=b37>
+##contig=<ID=GL000211.1,length=166566,assembly=b37>
+##contig=<ID=GL000212.1,length=186858,assembly=b37>
+##contig=<ID=GL000213.1,length=164239,assembly=b37>
+##contig=<ID=GL000214.1,length=137718,assembly=b37>
+##contig=<ID=GL000215.1,length=172545,assembly=b37>
+##contig=<ID=GL000216.1,length=172294,assembly=b37>
+##contig=<ID=GL000217.1,length=172149,assembly=b37>
+##contig=<ID=GL000218.1,length=161147,assembly=b37>
+##contig=<ID=GL000219.1,length=179198,assembly=b37>
+##contig=<ID=GL000220.1,length=161802,assembly=b37>
+##contig=<ID=GL000221.1,length=155397,assembly=b37>
+##contig=<ID=GL000222.1,length=186861,assembly=b37>
+##contig=<ID=GL000223.1,length=180455,assembly=b37>
+##contig=<ID=GL000224.1,length=179693,assembly=b37>
+##contig=<ID=GL000225.1,length=211173,assembly=b37>
+##contig=<ID=GL000226.1,length=15008,assembly=b37>
+##contig=<ID=GL000227.1,length=128374,assembly=b37>
+##contig=<ID=GL000228.1,length=129120,assembly=b37>
+##contig=<ID=GL000229.1,length=19913,assembly=b37>
+##contig=<ID=GL000230.1,length=43691,assembly=b37>
+##contig=<ID=GL000231.1,length=27386,assembly=b37>
+##contig=<ID=GL000232.1,length=40652,assembly=b37>
+##contig=<ID=GL000233.1,length=45941,assembly=b37>
+##contig=<ID=GL000234.1,length=40531,assembly=b37>
+##contig=<ID=GL000235.1,length=34474,assembly=b37>
+##contig=<ID=GL000236.1,length=41934,assembly=b37>
+##contig=<ID=GL000237.1,length=45867,assembly=b37>
+##contig=<ID=GL000238.1,length=39939,assembly=b37>
+##contig=<ID=GL000239.1,length=33824,assembly=b37>
+##contig=<ID=GL000240.1,length=41933,assembly=b37>
+##contig=<ID=GL000241.1,length=42152,assembly=b37>
+##contig=<ID=GL000242.1,length=43523,assembly=b37>
+##contig=<ID=GL000243.1,length=43341,assembly=b37>
+##contig=<ID=GL000244.1,length=39929,assembly=b37>
+##contig=<ID=GL000245.1,length=36651,assembly=b37>
+##contig=<ID=GL000246.1,length=38154,assembly=b37>
+##contig=<ID=GL000247.1,length=36422,assembly=b37>
+##contig=<ID=GL000248.1,length=39786,assembly=b37>
+##contig=<ID=GL000249.1,length=38502,assembly=b37>
+##contig=<ID=MT,length=16569,assembly=b37>
+##contig=<ID=X,length=155270560,assembly=b37>
+##contig=<ID=Y,length=59373566,assembly=b37>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	100	a	G	A	232.46	PASS	.
+1	199	b	GG	G	232.46	PASS	.
+1	200	c	G	A	232.46	PASS	.
+1	203	d	GGGG	G	232.46	PASS	.
+1	280	e	G	A	232.46	PASS	.
+1	284	f	GGG	G	232.46	PASS	.
+1	285	g	G	A	232.46	PASS	.
+1	286	h	G	A	232.46	PASS	.
+1	999	i	G	A	232.46	PASS	.
+1	1000	j	G	A	232.46	PASS	.
+1	1000	k	GGGG	G	232.46	PASS	.
+1	1076	l	G	A	232.46	PASS	.
+1	1150	m	G	A	232.46	PASS	.
+1	1176	n	G	A	232.46	PASS	.
+2	200	o	G	A	232.46	PASS	.
+2	525	p	G	A	232.46	PASS	.
+2	548	q	GGG	G	232.46	PASS	.
+2	640	r	G	A	232.46	PASS	.
+2	700	s	G	A	232.46	PASS	.
+3	1	t	G	A	232.46	PASS	.
+3	300	u	G	A	232.46	PASS	.
+3	300	v	GGGG	G	232.46	PASS	.
+3	400	w	G	A	232.46	PASS	.
+4	600	x	G	A	232.46	PASS	.
+4	775	y	G	A	232.46	PASS	.
+4	776	z	GGGG	G	232.46	PASS	.

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -453,3 +453,26 @@ def test_vcf_to_zarr__mixed_ploidy_vcf_exception(
             truncate_calls=truncate_calls,
         )
     assert "Genotype call longer than ploidy." == str(excinfo.value)
+
+
+def test_vcf_to_zarr__no_genotypes(shared_datadir, tmp_path):
+    path = path_for_test(shared_datadir, "no_genotypes.vcf")
+    output = tmp_path.joinpath("vcf.zarr").as_posix()
+
+    with pytest.raises(
+        ValueError,
+        match=r"Genotype information missing from VCF.",
+    ):
+        vcf_to_zarr(path, output)
+
+
+def test_vcf_to_zarr__contig_not_defined_in_header(shared_datadir, tmp_path):
+    # sample.vcf does not define the contigs in the header, and isn't indexed
+    path = path_for_test(shared_datadir, "sample.vcf")
+    output = tmp_path.joinpath("vcf.zarr").as_posix()
+
+    with pytest.raises(
+        ValueError,
+        match=r"Contig '19' is not defined in the header.",
+    ):
+        vcf_to_zarr(path, output)

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -113,6 +113,18 @@ def test_vcf_to_zarr__large_vcf(shared_datadir, is_path, tmp_path):
     assert ds["variant_id"].dtype == "O"
 
 
+def test_vcf_to_zarr__plain_vcf_with_no_index(shared_datadir, tmp_path):
+    path = path_for_test(
+        shared_datadir,
+        "mixed.vcf",
+    )
+    output = tmp_path.joinpath("vcf.zarr").as_posix()
+
+    vcf_to_zarr(path, output, truncate_calls=True)
+    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    assert ds["sample_id"].shape == (3,)
+
+
 @pytest.mark.parametrize(
     "is_path",
     [True, False],


### PR DESCRIPTION
This fixes a couple of problems found in #432.