### PR TITLE
Use the same distributed as dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 xarray
 dask[array] == 2.30.0
+distributed == 2.30.0
 dask-ml
 scipy
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     numpy
     xarray
     dask[array] == 2.30.0
+    distributed == 2.30.0
     dask-ml
     scipy
     zarr


### PR DESCRIPTION
Re: #374 
There seem to be some dependencies between those two (like `dask.utils`), so if we pin `dask` (like in #426), we should also pin `distributed`, otherwise users (or in this case validation suite) will experience hard to debug failures. In case of the validation suite it was a cryptic:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'stringify' from 'dask.utils' (/Users/rav/miniconda3/envs/_sgkit_test/lib/python3.8/site-packages/dask/utils.py)
```