### PR TITLE
Upgrade dask to 2021.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 xarray
-dask[array] == 2.30.0
+dask[array] == 2021.1.1
 dask-ml
 scipy
 typing-extensions


### PR DESCRIPTION
A quick PR to see what works and what doesn't by upgrading the dask to latest.

2021.1.1 was released on Jan 22, 2021, the one we are using was released on Oct 6 2020.