### PR TITLE
Add alt_number to VCF reading

### DIFF
--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -58,12 +58,10 @@ def vcf_to_zarr_sequential(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
+    alt_number: int = DEFAULT_ALT_NUMBER,
 ) -> None:
 
     with open_vcf(input) as vcf:
-
-        alt_number = DEFAULT_ALT_NUMBER
-
         sample_id = np.array(vcf.samples, dtype=str)
         n_sample = len(sample_id)
         n_allele = alt_number + 1
@@ -190,6 +188,7 @@ def vcf_to_zarr_parallel(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
+    alt_number: int = DEFAULT_ALT_NUMBER,
 ) -> None:
     """Convert specified regions of one or more VCF files to zarr files, then concat, rechunk, write to zarr"""
 
@@ -210,6 +209,7 @@ def vcf_to_zarr_parallel(
             ploidy=ploidy,
             mixed_ploidy=mixed_ploidy,
             truncate_calls=truncate_calls,
+            alt_number=alt_number,
         )
 
         ds = zarrs_to_dataset(paths, chunk_length, chunk_width, tempdir_storage_options)
@@ -229,6 +229,7 @@ def vcf_to_zarrs(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
+    alt_number: int = DEFAULT_ALT_NUMBER,
 ) -> Sequence[str]:
     """Convert VCF files to multiple Zarr on-disk stores, one per region.
 
@@ -261,6 +262,9 @@ def vcf_to_zarrs(
         If True, genotype calls with more alleles than the specified (maximum) ploidy value
         will be truncated to size ploidy. If false, calls with more alleles than the
         specified ploidy will raise an exception.
+    alt_number
+        The (maximum) number of alternate alleles in the VCF file. Any records with more than
+        this number of alternate alleles will have the extra alleles dropped.
 
     Returns
     -------
@@ -309,6 +313,7 @@ def vcf_to_zarrs(
                 ploidy=ploidy,
                 mixed_ploidy=mixed_ploidy,
                 truncate_calls=truncate_calls,
+                alt_number=alt_number,
             )
             tasks.append(task)
     dask.compute(*tasks)
@@ -329,6 +334,7 @@ def vcf_to_zarr(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
+    alt_number: int = DEFAULT_ALT_NUMBER,
 ) -> None:
     """Convert VCF files to a single Zarr on-disk store.
 
@@ -387,6 +393,9 @@ def vcf_to_zarr(
         If True, genotype calls with more alleles than the specified (maximum) ploidy value
         will be truncated to size ploidy. If false, calls with more alleles than the
         specified ploidy will raise an exception.
+    alt_number
+        The (maximum) number of alternate alleles in the VCF file. Any records with more than
+        this number of alternate alleles will have the extra alleles dropped.
     """
 
     if temp_chunk_length is not None:
@@ -428,6 +437,7 @@ def vcf_to_zarr(
         ploidy=ploidy,
         mixed_ploidy=mixed_ploidy,
         truncate_calls=truncate_calls,
+        alt_number=alt_number,
     )
 
 

--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -16,7 +16,9 @@ from sgkit.io.vcf.utils import build_url, chunks, temporary_directory, url_filen
 from sgkit.model import DIM_VARIANT, create_genotype_call_dataset
 from sgkit.typing import PathType
 
-DEFAULT_ALT_NUMBER = 3  # see vcf_read.py in scikit_allel
+DEFAULT_MAX_ALT_ALLELES = (
+    3  # equivalent to DEFAULT_ALT_NUMBER in vcf_read.py in scikit_allel
+)
 
 
 @contextmanager
@@ -58,13 +60,13 @@ def vcf_to_zarr_sequential(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
-    alt_number: int = DEFAULT_ALT_NUMBER,
+    max_alt_alleles: int = DEFAULT_MAX_ALT_ALLELES,
 ) -> None:
 
     with open_vcf(input) as vcf:
         sample_id = np.array(vcf.samples, dtype=str)
         n_sample = len(sample_id)
-        n_allele = alt_number + 1
+        n_allele = max_alt_alleles + 1
 
         variant_contig_names = vcf.seqnames
 
@@ -188,7 +190,7 @@ def vcf_to_zarr_parallel(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
-    alt_number: int = DEFAULT_ALT_NUMBER,
+    max_alt_alleles: int = DEFAULT_MAX_ALT_ALLELES,
 ) -> None:
     """Convert specified regions of one or more VCF files to zarr files, then concat, rechunk, write to zarr"""
 
@@ -209,7 +211,7 @@ def vcf_to_zarr_parallel(
             ploidy=ploidy,
             mixed_ploidy=mixed_ploidy,
             truncate_calls=truncate_calls,
-            alt_number=alt_number,
+            max_alt_alleles=max_alt_alleles,
         )
 
         ds = zarrs_to_dataset(paths, chunk_length, chunk_width, tempdir_storage_options)
@@ -229,7 +231,7 @@ def vcf_to_zarrs(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
-    alt_number: int = DEFAULT_ALT_NUMBER,
+    max_alt_alleles: int = DEFAULT_MAX_ALT_ALLELES,
 ) -> Sequence[str]:
     """Convert VCF files to multiple Zarr on-disk stores, one per region.
 
@@ -262,7 +264,7 @@ def vcf_to_zarrs(
         If True, genotype calls with more alleles than the specified (maximum) ploidy value
         will be truncated to size ploidy. If false, calls with more alleles than the
         specified ploidy will raise an exception.
-    alt_number
+    max_alt_alleles
         The (maximum) number of alternate alleles in the VCF file. Any records with more than
         this number of alternate alleles will have the extra alleles dropped.
 
@@ -313,7 +315,7 @@ def vcf_to_zarrs(
                 ploidy=ploidy,
                 mixed_ploidy=mixed_ploidy,
                 truncate_calls=truncate_calls,
-                alt_number=alt_number,
+                max_alt_alleles=max_alt_alleles,
             )
             tasks.append(task)
     dask.compute(*tasks)
@@ -334,7 +336,7 @@ def vcf_to_zarr(
     ploidy: int = 2,
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
-    alt_number: int = DEFAULT_ALT_NUMBER,
+    max_alt_alleles: int = DEFAULT_MAX_ALT_ALLELES,
 ) -> None:
     """Convert VCF files to a single Zarr on-disk store.
 
@@ -393,7 +395,7 @@ def vcf_to_zarr(
         If True, genotype calls with more alleles than the specified (maximum) ploidy value
         will be truncated to size ploidy. If false, calls with more alleles than the
         specified ploidy will raise an exception.
-    alt_number
+    max_alt_alleles
         The (maximum) number of alternate alleles in the VCF file. Any records with more than
         this number of alternate alleles will have the extra alleles dropped.
     """
@@ -437,7 +439,7 @@ def vcf_to_zarr(
         ploidy=ploidy,
         mixed_ploidy=mixed_ploidy,
         truncate_calls=truncate_calls,
-        alt_number=alt_number,
+        max_alt_alleles=max_alt_alleles,
     )
 
 

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -92,11 +92,11 @@ def test_vcf_to_zarr__small_vcf(shared_datadir, is_path, tmp_path):
     "is_path",
     [True, False],
 )
-def test_vcf_to_zarr__alt_number(shared_datadir, is_path, tmp_path):
+def test_vcf_to_zarr__max_alt_alleles(shared_datadir, is_path, tmp_path):
     path = path_for_test(shared_datadir, "sample.vcf.gz", is_path)
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
-    vcf_to_zarr(path, output, chunk_length=5, chunk_width=2, alt_number=1)
+    vcf_to_zarr(path, output, chunk_length=5, chunk_width=2, max_alt_alleles=1)
     ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
 
     # extra alt alleles are silently dropped

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -92,6 +92,34 @@ def test_vcf_to_zarr__small_vcf(shared_datadir, is_path, tmp_path):
     "is_path",
     [True, False],
 )
+def test_vcf_to_zarr__alt_number(shared_datadir, is_path, tmp_path):
+    path = path_for_test(shared_datadir, "sample.vcf.gz", is_path)
+    output = tmp_path.joinpath("vcf.zarr").as_posix()
+
+    vcf_to_zarr(path, output, chunk_length=5, chunk_width=2, alt_number=1)
+    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+
+    # extra alt alleles are silently dropped
+    assert_array_equal(
+        ds["variant_allele"],
+        [
+            ["A", "C"],
+            ["A", "G"],
+            ["G", "A"],
+            ["T", "A"],
+            ["A", "G"],
+            ["T", ""],
+            ["G", "GA"],
+            ["T", ""],
+            ["AC", "A"],
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "is_path",
+    [True, False],
+)
 def test_vcf_to_zarr__large_vcf(shared_datadir, is_path, tmp_path):
     path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
     output = tmp_path.joinpath("vcf.zarr").as_posix()


### PR DESCRIPTION
This exposes `alt_number` in the VCF reading API, just like [scikit-allel](https://scikit-allel.readthedocs.io/en/stable/io.html#allel.vcf_to_zarr) does. 