### PR TITLE
VCF info and format fields

### DIFF
--- a/sgkit/io/utils.py
+++ b/sgkit/io/utils.py
@@ -202,3 +202,12 @@ def _slice_zarrs(
             slices.append((i1, slice(0, stop - offsets[i1])))
         parts = [zarrs[i][(sel, *locs[1:])] for (i, sel) in slices]
         return np.concatenate(parts)
+
+
+def str_is_int(x: str) -> bool:
+    """Test if a string can be parsed as an int"""
+    try:
+        int(x)
+        return True
+    except ValueError:
+        return False

--- a/sgkit/io/utils.py
+++ b/sgkit/io/utils.py
@@ -97,19 +97,12 @@ def zarrs_to_dataset(
 
     # Set variable length strings to fixed length ones to avoid xarray/conventions.py:188 warning
     # (Also avoids this issue: https://github.com/pydata/xarray/issues/3476)
-
-    if "max_variant_id_length" in datasets[0].attrs:
-        max_variant_id_length = max(
-            ds.attrs["max_variant_id_length"] for ds in datasets
-        )
-        ds["variant_id"] = ds["variant_id"].astype(f"S{max_variant_id_length}")
-        del ds.attrs["max_variant_id_length"]
-
-    max_variant_allele_length = max(
-        ds.attrs["max_variant_allele_length"] for ds in datasets
-    )
-    ds["variant_allele"] = ds["variant_allele"].astype(f"S{max_variant_allele_length}")
-    del ds.attrs["max_variant_allele_length"]
+    for attr in datasets[0].attrs:
+        if attr.startswith("max_length_"):
+            variable_name = attr[len("max_length_") :]
+            max_length = max(ds.attrs[attr] for ds in datasets)
+            ds[variable_name] = ds[variable_name].astype(f"S{max_length}")
+            del ds.attrs[attr]
 
     return ds
 

--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -103,6 +103,7 @@ def _vcf_type_to_numpy_type_and_fill_value(
         return "bool", False
     elif vcf_type == "Integer":
         return "i4", -1
+    # the VCF spec defines Float as 32 bit, and in BCF is stored as 32 bit
     elif vcf_type == "Float":
         return "f4", np.nan
     elif vcf_type == "String":
@@ -485,6 +486,8 @@ def vcf_to_zarrs(
         overrides the ``INFO/AC`` field to be Number ``A`` (useful if the VCF defines it as
         having variable length with ``.``), and names the final dimension of the ``HQ`` array
         (which is defined as Number 2 in the VCF header) as ``haplotypes``.
+        (Note that Number ``A`` is the number of alternate alleles, see section 1.4.2 of the
+        VCF spec https://samtools.github.io/hts-specs/VCFv4.3.pdf.)
 
     Returns
     -------
@@ -636,6 +639,8 @@ def vcf_to_zarr(
         overrides the ``INFO/AC`` field to be Number ``A`` (useful if the VCF defines it as
         having variable length with ``.``), and names the final dimension of the ``HQ`` array
         (which is defined as Number 2 in the VCF header) as ``haplotypes``.
+        (Note that Number ``A`` is the number of alternate alleles, see section 1.4.2 of the
+        VCF spec https://samtools.github.io/hts-specs/VCFv4.3.pdf.)
     """
 
     if temp_chunk_length is not None:

--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -61,6 +61,7 @@ def vcf_to_zarr_sequential(
     mixed_ploidy: bool = False,
     truncate_calls: bool = False,
     max_alt_alleles: int = DEFAULT_MAX_ALT_ALLELES,
+    add_str_max_length_attrs: bool = False,
 ) -> None:
 
     with open_vcf(input) as vcf:
@@ -152,8 +153,9 @@ def vcf_to_zarr_sequential(
                 [DIM_VARIANT],
                 variant_id_mask,
             )
-            ds.attrs["max_variant_id_length"] = max_variant_id_length
-            ds.attrs["max_variant_allele_length"] = max_variant_allele_length
+            if add_str_max_length_attrs:
+                ds.attrs["max_length_variant_id"] = max_variant_id_length
+                ds.attrs["max_length_variant_allele"] = max_variant_allele_length
 
             if first_variants_chunk:
                 # Enforce uniform chunks in the variants dimension
@@ -321,6 +323,7 @@ def vcf_to_zarrs(
                 mixed_ploidy=mixed_ploidy,
                 truncate_calls=truncate_calls,
                 max_alt_alleles=max_alt_alleles,
+                add_str_max_length_attrs=True,
             )
             tasks.append(task)
     dask.compute(*tasks)

--- a/sgkit/io/vcfzarr_reader.py
+++ b/sgkit/io/vcfzarr_reader.py
@@ -48,6 +48,8 @@ def read_vcfzarr(
         overrides the ``INFO/AC`` field to be Number ``A`` (useful if the VCF defines it as
         having variable length with ``.``), and names the final dimension of the ``HQ`` array
         (which is defined as Number 2 in the VCF header) as ``haplotypes``.
+        (Note that Number ``A`` is the number of alternate alleles, see section 1.4.2 of the
+        VCF spec https://samtools.github.io/hts-specs/VCFv4.3.pdf.)
 
     Returns
     -------

--- a/sgkit/io/vcfzarr_reader.py
+++ b/sgkit/io/vcfzarr_reader.py
@@ -201,7 +201,7 @@ def _vcfzarr_to_dataset(
                 ds[var] = arr.astype(dt)
 
                 if var in {"variant_id", "variant_allele"}:
-                    ds.attrs[f"max_{var}_length"] = max_len
+                    ds.attrs[f"max_length_{var}"] = max_len
 
     return ds
 
@@ -228,11 +228,8 @@ def _concat_zarrs_optimized(
         for var in vars_to_rechunk:
             var_to_attrs[var] = first_zarr_group[var].attrs.asdict()
             dtype = None
-            if var == "variant_id":
-                max_len = _get_max_len(zarr_groups, "max_variant_id_length")
-                dtype = f"S{max_len}"
-            elif var == "variant_allele":
-                max_len = _get_max_len(zarr_groups, "max_variant_allele_length")
+            if var in {"variant_id", "variant_allele"}:
+                max_len = _get_max_len(zarr_groups, f"max_length_{var}")
                 dtype = f"S{max_len}"
 
             arr = concatenate_and_rechunk(

--- a/sgkit/tests/io/vcf/test_vcf_roundtrip.py
+++ b/sgkit/tests/io/vcf/test_vcf_roundtrip.py
@@ -1,0 +1,147 @@
+# Test that converting a VCF file to a dataset using the two pathways
+# shown below are equivalent.
+#
+#                          allel.vcf_to_zarr
+#
+#                  vcf  +---------------------> zarr
+#
+#                   +                            +
+#                   |                            |
+#                   |                            |
+#                   |                            |
+# sg.vcf_to_zarr    |                            |   sg.read_vcfzarr
+#                   |                            |
+#                   |                            |
+#                   |                            |
+#                   v                            v
+#
+#                  zarr +--------------------->  ds
+#
+#                          sg.load_dataset
+
+from pathlib import Path
+from typing import Any
+
+import allel
+import pytest
+import xarray as xr
+from xarray import Dataset
+
+import sgkit as sg
+from sgkit.io.vcf import vcf_to_zarr
+
+
+def assert_identical(ds1: Dataset, ds2: Dataset) -> None:
+    """Assert two Datasets are identical, including dtypes for all variables, except strings."""
+    xr.testing.assert_identical(ds1, ds2)  # type: ignore[no-untyped-call]
+    # check all types except strings (since they may differ e.g. "O" vs "U")
+    assert all(
+        [
+            ds1[v].dtype == ds2[v].dtype
+            for v in ds1.data_vars
+            if ds1[v].dtype.kind not in ("O", "S", "U")
+        ]
+    )
+
+
+def create_allel_vcfzarr(
+    shared_datadir: Path,
+    tmpdir: Path,
+    *,
+    vcf_file: str = "sample.vcf.gz",
+    **kwargs: Any,
+) -> Path:
+    """Create a vcfzarr file using scikit-allel"""
+    vcf_path = shared_datadir / vcf_file
+    output_path = tmpdir / f"allel_{vcf_file}.zarr"
+    allel.vcf_to_zarr(str(vcf_path), str(output_path), **kwargs)
+    return output_path
+
+
+def create_sg_vcfzarr(
+    shared_datadir: Path,
+    tmpdir: Path,
+    *,
+    vcf_file: str = "sample.vcf.gz",
+    **kwargs: Any,
+) -> Path:
+    """Create a vcfzarr file using sgkit"""
+    vcf_path = shared_datadir / vcf_file
+    output_path = tmpdir / f"sg_{vcf_file}.zarr"
+    vcf_to_zarr(vcf_path, str(output_path), **kwargs)
+    return output_path
+
+
+def test_default_fields(shared_datadir, tmpdir):
+    allel_vcfzarr_path = create_allel_vcfzarr(shared_datadir, tmpdir)
+    allel_ds = sg.read_vcfzarr(allel_vcfzarr_path)
+
+    sg_vcfzarr_path = create_sg_vcfzarr(shared_datadir, tmpdir)
+    sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
+    sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel
+
+    assert_identical(allel_ds, sg_ds)
+
+
+def test_DP_field(shared_datadir, tmpdir):
+    fields = [
+        "variants/CHROM",
+        "variants/POS",
+        "variants/ID",
+        "variants/REF",
+        "variants/ALT",
+        "calldata/GT",
+        "samples",
+        # extra
+        "calldata/DP",
+        "variants/DP",
+    ]
+    types = {"calldata/DP": "i4"}  # override default of i2
+    allel_vcfzarr_path = create_allel_vcfzarr(
+        shared_datadir, tmpdir, fields=fields, types=types
+    )
+    allel_ds = sg.read_vcfzarr(allel_vcfzarr_path)
+
+    sg_vcfzarr_path = create_sg_vcfzarr(
+        shared_datadir, tmpdir, fields=["INFO/DP", "FORMAT/DP"]
+    )
+    sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
+    sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel
+
+    assert_identical(allel_ds, sg_ds)
+
+
+@pytest.mark.parametrize(
+    "vcf_file",
+    [
+        "sample.vcf.gz",
+        "CEUTrio.20.21.gatk3.4.g.vcf.bgz",
+        "mixed.vcf.gz",
+        "1000G.phase3.broad.withGenotypes.chr20.10100000.vcf.gz",
+        "NA12878.prod.chr20snippet.g.vcf.gz",
+    ],
+)
+def test_all_fields(shared_datadir, tmpdir, vcf_file):
+    types = {
+        "calldata/DP": "i4",
+        "calldata/GQ": "i4",
+        "calldata/HQ": "i4",
+    }  # override scikit-allel defaults
+    allel_vcfzarr_path = create_allel_vcfzarr(
+        shared_datadir, tmpdir, fields=["*"], types=types
+    )
+
+    field_defs = {
+        "INFO/AF": {"Number": "A"},
+        "INFO/AC": {"Number": "A"},
+        "FORMAT/HQ": {"dimension": "haplotypes"},
+    }
+    allel_ds = sg.read_vcfzarr(allel_vcfzarr_path, field_defs=field_defs)
+
+    sg_vcfzarr_path = create_sg_vcfzarr(
+        shared_datadir, tmpdir, fields=["INFO/*", "FORMAT/*"], field_defs=field_defs
+    )
+    sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
+    sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel
+
+    assert_identical(allel_ds, sg_ds)

--- a/sgkit/tests/io/vcf/test_vcf_roundtrip.py
+++ b/sgkit/tests/io/vcf/test_vcf_roundtrip.py
@@ -33,7 +33,7 @@ from sgkit.io.vcf import vcf_to_zarr
 
 def assert_identical(ds1: Dataset, ds2: Dataset) -> None:
     """Assert two Datasets are identical, including dtypes for all variables, except strings."""
-    xr.testing.assert_identical(ds1, ds2)  # type: ignore[no-untyped-call]
+    xr.testing.assert_identical(ds1, ds2)
     # check all types except strings (since they may differ e.g. "O" vs "U")
     assert all(
         [


### PR DESCRIPTION
This changes the VCF reader to handle INFO and FORMAT fields of type Flag, Integer, or Float, and where number is 1, as suggested in #464.

A few things for discussion:
* Unlike scikit-allel which has a single `fields` list, I've created two, `info_fields` and `format_fields` to avoid ambiguities (like `DP`, which can apply to either), Alternatively, we could have a single list, and namespace them, e.g. `FORMAT/DP`.
* Naming. As it stands INFO fields are prefixed with `variant_`, and FORMAT fields with `call_`. So `call_DP` is an example. Do we want to add a renaming keyword (like scikit-allel has) so it could be renamed to e.g. `call_depth`?
* The `GT` FORMAT field is special since it is always included, even if `format_fields` doesn't include it. Should we make it optional?
* The `vcf_to_zarr_sequential` is getting a bit unwieldy and should probably be refactored into a class or set of classes to handle various field types.