### PR TITLE
Push benchmarks to main branch instead of master

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,4 +64,4 @@ jobs:
           git config --global user.email "project@pystatgen.org"
           git config --global user.name "sgkit benchmark bot"
           git commit -m "Update benchmarks"
-          git push origin master
+          git push origin main


### PR DESCRIPTION
Fixes this issue: https://github.com/pystatgen/sgkit/runs/2033236920