### PR TITLE
Unpin Dask versions now that 2021.3.1 has been released and fixes #482

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 xarray
-dask[array] == 2021.02.0
-distributed == 2021.02.0
+dask[array]
+distributed
 dask-ml
 scipy
 typing-extensions


### PR DESCRIPTION
Fixes #483 