### PR TITLE
Add VCF exclude_fields parameter and fix test_all_fields #491

### DIFF
--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -734,6 +734,12 @@ def test_vcf_to_zarr__fields_errors(shared_datadir, tmp_path):
 
     with pytest.raises(
         ValueError,
+        match=r"FORMAT field 'XX' is not defined in the header.",
+    ):
+        vcf_to_zarr(path, output, exclude_fields=["FORMAT/XX"])
+
+    with pytest.raises(
+        ValueError,
         match=r"INFO field 'AC' is defined as Number '.', which is not supported.",
     ):
         vcf_to_zarr(path, output, fields=["INFO/AC"])


### PR DESCRIPTION
Fixes #491.

This actually runs the tests against the other files. In doing so it exposed the fact that Number=G is not supported, so I added a way to exclude fields. There were a few other minor changes needed to get tests to pass.

I also removed two large files from the test, since they add ~120s to the test time. These would be better suited to testing in #478.