### PR TITLE
Cohort Observed Heterozygosity

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -83,6 +83,8 @@ Methods
    Garud_H
    gwas_linear_regression
    hardy_weinberg_test
+   individual_heterozygosity
+   observed_heterozygosity
    pc_relate
    regenie
    sample_stats
@@ -118,6 +120,7 @@ Variables
     variables.call_genotype_phased_spec
     variables.call_genotype_probability_spec
     variables.call_genotype_probability_mask_spec
+    variables.call_heterozygosity_spec
     variables.cohort_allele_count_spec
     variables.covariates_spec
     variables.dosage_spec
@@ -140,6 +143,7 @@ Variables
     variables.stat_Garud_h12_spec
     variables.stat_Garud_h123_spec
     variables.stat_Garud_h2_h1_spec
+    variables.stat_observed_heterozygosity_spec
     variables.stat_Tajimas_D_spec
     variables.traits_spec
     variables.variant_allele_spec

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -15,6 +15,7 @@ from .stats.aggregation import (
     count_call_alleles,
     count_cohort_alleles,
     count_variant_alleles,
+    individual_heterozygosity,
     sample_stats,
     variant_stats,
 )
@@ -23,7 +24,15 @@ from .stats.conversion import convert_probability_to_call
 from .stats.hwe import hardy_weinberg_test
 from .stats.pc_relate import pc_relate
 from .stats.pca import pca
-from .stats.popgen import Fst, Garud_H, Tajimas_D, divergence, diversity, pbs
+from .stats.popgen import (
+    Fst,
+    Garud_H,
+    Tajimas_D,
+    divergence,
+    diversity,
+    observed_heterozygosity,
+    pbs,
+)
 from .stats.preprocessing import filter_partial_calls
 from .stats.regenie import regenie
 from .testing import simulate_genotype_call_dataset
@@ -51,6 +60,7 @@ __all__ = [
     "read_vcfzarr",
     "regenie",
     "hardy_weinberg_test",
+    "individual_heterozygosity",
     "sample_stats",
     "variant_stats",
     "diversity",
@@ -62,6 +72,7 @@ __all__ = [
     "pc_relate",
     "simulate_genotype_call_dataset",
     "variables",
+    "observed_heterozygosity",
     "pca",
     "window",
     "load_dataset",

--- a/sgkit/stats/aggregation.py
+++ b/sgkit/stats/aggregation.py
@@ -720,13 +720,13 @@ def individual_heterozygosity(
     call_allele_count: Hashable = variables.call_allele_count,
     merge: bool = True,
 ) -> Dataset:
-    """Compute per sample observed heterozygosity.
+    """Compute per call individual heterozygosity.
 
-    Individual heterozygosity is defined as the probability that
-    two alleles drawn at random without replacement are not identical
-    in state. Therefore, individual heterozygosity is defined for
-    diploid and polyploid calls but will return nan in the case of
-    haploid calls.
+    Individual heterozygosity is the probability that two alleles
+    drawn at random without replacement, from an individual at a
+    given site, are not identical in state. Therefore, individual
+    heterozygosity is defined for diploid and polyploid calls but
+    will return nan in the case of haploid calls.
 
     Parameters
     ----------
@@ -746,7 +746,7 @@ def individual_heterozygosity(
     -------
     A dataset containing :data:`sgkit.variables.call_heterozygosity_spec`
     of per genotype observed heterozygosity with shape (variants, samples)
-    containing values within the inteval [0, 1] or nan if ploidy < 2.
+    containing values within the interval [0, 1] or nan if ploidy < 2.
 
     Examples
     --------
@@ -777,7 +777,7 @@ def individual_heterozygosity(
     # use nan denominator to avoid divide by zero with K - 1
     K2 = da.where(K > 1, K, np.nan)
     AF = AC / K2[..., None]
-    HI = (1 - da.sum(da.power(AF, 2), axis=-1)) * (K / (K2 - 1))
+    HI = (1 - da.sum(AF ** 2, axis=-1)) * (K / (K2 - 1))
     new_ds = create_dataset(
         {variables.call_heterozygosity: (("variants", "samples"), HI)}
     )

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -969,6 +969,12 @@ def observed_heterozygosity(
 ) -> Dataset:
     """Compute per cohort observed heterozygosity.
 
+    The observed heterozygosity of a cohort is the mean of individual
+    heterozygosity values among all samples of that cohort as described
+    in :func:`individual_heterozygosity`. Calls with a nan value for
+    individual heterozygosity are ignored when calculating the cohort
+    mean.
+
     By default, values of this statistic are calculated per variant.
     To compute values in windows, call :func:`window` before calling
     this function.

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -995,7 +995,7 @@ def observed_heterozygosity(
         See :ref:`dataset_merge` for more details.
     Returns
     -------
-    A dataset containing :data:`sgkit.variables.stat_heterozygosity_observed_spec`
+    A dataset containing :data:`sgkit.variables.stat_observed_heterozygosity_spec`
     of per cohort observed heterozygosity with shape (variants, cohorts)
     containing values within the inteval [0, 1] or nan.
 

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -955,7 +955,7 @@ def _cohort_observed_heterozygosity(
             _[c] += 1
     for j in range(n_cohorts):
         n = _[j]
-        if n:
+        if n != 0:
             out[j] /= n
         else:
             out[j] = np.nan

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -10,6 +10,7 @@ from sgkit.stats.aggregation import (
     count_call_alleles,
     count_cohort_alleles,
     count_variant_alleles,
+    individual_heterozygosity,
     infer_call_ploidy,
     infer_sample_ploidy,
     infer_variant_ploidy,
@@ -349,3 +350,48 @@ def test_infer_variant_ploidy():
     ds.call_genotype.attrs["mixed_ploidy"] = True
     vp = infer_variant_ploidy(ds).variant_ploidy
     np.testing.assert_equal(vp, np.array([-1, 4, 2]))
+
+
+def test_individual_heterozygosity():
+    ds = individual_heterozygosity(
+        get_dataset(
+            [
+                [[0, 0, -2, -2, -2, -2], [0, 0, 0, 0, -2, -2], [0, 0, 0, 0, 0, 0]],
+                [[0, 1, -2, -2, -2, -2], [0, 0, 0, 1, -2, -2], [0, 0, 0, 0, 0, 1]],
+                [[1, 1, -2, -2, -2, -2], [0, 0, 1, 1, -2, -2], [0, 0, 0, 0, 1, 1]],
+                [[0, -1, -2, -2, -2, -2], [0, 1, 1, 1, -2, -2], [0, 0, 0, 1, 1, 1]],
+                [[-1, 1, -2, -2, -2, -2], [1, 1, 1, 1, -2, -2], [0, 0, 0, 0, 1, 2]],
+                [[-1, -1, -2, -2, -2, -2], [0, 0, 1, 2, -2, -2], [0, 0, 0, 1, 1, 2]],
+                [[-1, -1, -2, -2, -2, -2], [0, 1, 2, 2, -2, -2], [0, 0, 1, 1, 2, 2]],
+                [[-1, -1, -2, -2, -2, -2], [0, 0, -1, -1, -2, -2], [0, 0, 0, 1, 2, 3]],
+                [[-1, -1, -2, -2, -2, -2], [0, 1, -1, -1, -2, -2], [0, 0, 1, 1, 2, 3]],
+                [[-1, -1, -2, -2, -2, -2], [0, -1, -1, -1, -2, -2], [0, 0, 1, 2, 3, 4]],
+                [
+                    [-1, -1, -2, -2, -2, -2],
+                    [-1, -1, -1, -1, -2, -2],
+                    [0, 1, 2, 3, 4, 5],
+                ],
+            ],
+            n_ploidy=6,
+            n_allele=6,
+        )
+    )
+    hi = ds["call_heterozygosity"]
+    np.testing.assert_almost_equal(
+        hi,
+        np.array(
+            [
+                [0, 0, 0],
+                [1, 3 / 6, 5 / 15],
+                [0, 4 / 6, 8 / 15],
+                [np.nan, 3 / 6, 9 / 15],
+                [np.nan, 0, 9 / 15],
+                [np.nan, 5 / 6, 11 / 15],
+                [np.nan, 5 / 6, 12 / 15],
+                [np.nan, 0, 12 / 15],
+                [np.nan, 1, 13 / 15],
+                [np.nan, np.nan, 14 / 15],
+                [np.nan, np.nan, 1],
+            ]
+        ),
+    )

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -593,15 +593,16 @@ def test_observed_heterozygosity__windowed(chunks):
 @pytest.mark.parametrize(
     "n_variant,n_sample,missing_pct", [(30, 20, 0), (47, 17, 0.25)]
 )
+@pytest.mark.parametrize("seed", [1, 3, 7])
 def test_observed_heterozygosity__scikit_allel_comparison(
-    n_variant, n_sample, missing_pct, window_size
+    n_variant, n_sample, missing_pct, window_size, seed
 ):
     ds = simulate_genotype_call_dataset(
         n_variant=n_variant,
         n_sample=n_sample,
         n_ploidy=2,
         missing_pct=missing_pct,
-        seed=1,
+        seed=seed,
     )
     ds["sample_cohort"] = (
         ["samples"],

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -460,9 +460,7 @@ def test_Garud_h__raise_on_no_windows():
         Garud_H(ds)
 
 
-@pytest.mark.parametrize(
-    "chunks", [((4,), (6,), (4,)), ((2, 2), (3, 3), (2, 2)), ((3, 1), (4, 2), (1, 3))]
-)
+@pytest.mark.parametrize("chunks", [((4,), (6,), (4,)), ((2, 2), (3, 3), (2, 2))])
 def test_observed_heterozygosity(chunks):
     ds = simulate_genotype_call_dataset(
         n_variant=4,
@@ -527,9 +525,7 @@ def test_observed_heterozygosity(chunks):
     )
 
 
-@pytest.mark.parametrize(
-    "chunks", [((4,), (6,), (4,)), ((2, 2), (3, 3), (2, 2)), ((3, 1), (4, 2), (1, 3))]
-)
+@pytest.mark.parametrize("chunks", [((4,), (6,), (4,)), ((2, 2), (3, 3), (2, 2))])
 def test_observed_heterozygosity__windowed(chunks):
     ds = simulate_genotype_call_dataset(
         n_variant=4,

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -318,6 +318,17 @@ completely missing genotype calls.
     )
 )
 
+call_heterozygosity, call_heterozygosity_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "call_heterozygosity",
+        kind="f",
+        ndim=2,
+        __doc__="""
+Observed heterozygosity of each call genotype.
+""",
+    )
+)
+
 call_ploidy, call_ploidy_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_ploidy",
@@ -604,6 +615,20 @@ stat_Garud_h2_h1, stat_Garud_h2_h1_spec = SgkitVariables.register_variable(
         ndim={1, 2},
         kind="f",
         __doc__="""Garud H2/H1 statistic for cohorts.""",
+    )
+)
+
+(
+    stat_observed_heterozygosity,
+    stat_observed_heterozygosity_spec,
+) = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "stat_observed_heterozygosity",
+        kind="f",
+        ndim=2,
+        __doc__="""
+Observed heterozygosity for cohorts.
+""",
     )
 )
 


### PR DESCRIPTION
Implements #499 

Some thoughts:
- This implementation aims to match that of the existing `diversity` method. One difference is that individual heterozygosity is undefined for haploid calls and hence any haploid calls won't contribute to the cohort observed heterozygosity.
- I have followed the use of `np.sum` in the windowed version of  `diversity` [(line)](https://github.com/pystatgen/sgkit/blob/master/sgkit/stats/popgen.py#L104). I couldn't find much discussion on this choice but I assume it's to avoid taking the mean prior to its use in other statistics?
- I'm not super happy with the length of `'stat_observed_heterozygosity'` as a variable name but `'stat_heterozygosity'` could easily be mistaken for the expected heterozygosity.
- I'm not sure if `aggregation.py` is the best place for `individual_heterozygosity` but it is an aggregation of sorts and it doesn't really fit in `popgen.py` as there is no use of cohorts.

I also noted that there is a bit of discrepancy in naming conventions with capitalized names used for Dask arrays in `aggregation.py ` and lower case used in `popgen.py`. I have followed the style used in each file for now.