### PR TITLE
Dask crash related to uneven chunk size in test_observed_heterozygosity

### DIFF
--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -15,6 +15,7 @@ from .stats.aggregation import (
     count_call_alleles,
     count_cohort_alleles,
     count_variant_alleles,
+    individual_heterozygosity,
     sample_stats,
     variant_stats,
 )
@@ -23,7 +24,15 @@ from .stats.conversion import convert_probability_to_call
 from .stats.hwe import hardy_weinberg_test
 from .stats.pc_relate import pc_relate
 from .stats.pca import pca
-from .stats.popgen import Fst, Garud_H, Tajimas_D, divergence, diversity, pbs
+from .stats.popgen import (
+    Fst,
+    Garud_H,
+    Tajimas_D,
+    divergence,
+    diversity,
+    observed_heterozygosity,
+    pbs,
+)
 from .stats.preprocessing import filter_partial_calls
 from .stats.regenie import regenie
 from .testing import simulate_genotype_call_dataset
@@ -51,6 +60,7 @@ __all__ = [
     "read_vcfzarr",
     "regenie",
     "hardy_weinberg_test",
+    "individual_heterozygosity",
     "sample_stats",
     "variant_stats",
     "diversity",
@@ -62,6 +72,7 @@ __all__ = [
     "pc_relate",
     "simulate_genotype_call_dataset",
     "variables",
+    "observed_heterozygosity",
     "pca",
     "window",
     "load_dataset",

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -10,6 +10,7 @@ from sgkit.stats.aggregation import (
     count_call_alleles,
     count_cohort_alleles,
     count_variant_alleles,
+    individual_heterozygosity,
     infer_call_ploidy,
     infer_sample_ploidy,
     infer_variant_ploidy,
@@ -349,3 +350,48 @@ def test_infer_variant_ploidy():
     ds.call_genotype.attrs["mixed_ploidy"] = True
     vp = infer_variant_ploidy(ds).variant_ploidy
     np.testing.assert_equal(vp, np.array([-1, 4, 2]))
+
+
+def test_individual_heterozygosity():
+    ds = individual_heterozygosity(
+        get_dataset(
+            [
+                [[0, 0, -2, -2, -2, -2], [0, 0, 0, 0, -2, -2], [0, 0, 0, 0, 0, 0]],
+                [[0, 1, -2, -2, -2, -2], [0, 0, 0, 1, -2, -2], [0, 0, 0, 0, 0, 1]],
+                [[1, 1, -2, -2, -2, -2], [0, 0, 1, 1, -2, -2], [0, 0, 0, 0, 1, 1]],
+                [[0, -1, -2, -2, -2, -2], [0, 1, 1, 1, -2, -2], [0, 0, 0, 1, 1, 1]],
+                [[-1, 1, -2, -2, -2, -2], [1, 1, 1, 1, -2, -2], [0, 0, 0, 0, 1, 2]],
+                [[-1, -1, -2, -2, -2, -2], [0, 0, 1, 2, -2, -2], [0, 0, 0, 1, 1, 2]],
+                [[-1, -1, -2, -2, -2, -2], [0, 1, 2, 2, -2, -2], [0, 0, 1, 1, 2, 2]],
+                [[-1, -1, -2, -2, -2, -2], [0, 0, -1, -1, -2, -2], [0, 0, 0, 1, 2, 3]],
+                [[-1, -1, -2, -2, -2, -2], [0, 1, -1, -1, -2, -2], [0, 0, 1, 1, 2, 3]],
+                [[-1, -1, -2, -2, -2, -2], [0, -1, -1, -1, -2, -2], [0, 0, 1, 2, 3, 4]],
+                [
+                    [-1, -1, -2, -2, -2, -2],
+                    [-1, -1, -1, -1, -2, -2],
+                    [0, 1, 2, 3, 4, 5],
+                ],
+            ],
+            n_ploidy=6,
+            n_allele=6,
+        )
+    )
+    hi = ds["call_heterozygosity"]
+    np.testing.assert_almost_equal(
+        hi,
+        np.array(
+            [
+                [0, 0, 0],
+                [1, 3 / 6, 5 / 15],
+                [0, 4 / 6, 8 / 15],
+                [np.nan, 3 / 6, 9 / 15],
+                [np.nan, 0, 9 / 15],
+                [np.nan, 5 / 6, 11 / 15],
+                [np.nan, 5 / 6, 12 / 15],
+                [np.nan, 0, 12 / 15],
+                [np.nan, 1, 13 / 15],
+                [np.nan, np.nan, 14 / 15],
+                [np.nan, np.nan, 1],
+            ]
+        ),
+    )

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -318,6 +318,17 @@ completely missing genotype calls.
     )
 )
 
+call_heterozygosity, call_heterozygosity_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "call_heterozygosity",
+        kind="f",
+        ndim=2,
+        __doc__="""
+Observed heterozygosity of each call genotype.
+""",
+    )
+)
+
 call_ploidy, call_ploidy_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_ploidy",
@@ -604,6 +615,20 @@ stat_Garud_h2_h1, stat_Garud_h2_h1_spec = SgkitVariables.register_variable(
         ndim={1, 2},
         kind="f",
         __doc__="""Garud H2/H1 statistic for cohorts.""",
+    )
+)
+
+(
+    stat_observed_heterozygosity,
+    stat_observed_heterozygosity_spec,
+) = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "stat_observed_heterozygosity",
+        kind="f",
+        ndim=2,
+        __doc__="""
+Observed heterozygosity for cohorts.
+""",
     )
 )
 


### PR DESCRIPTION
Don't merge. 
This is a demonstration of the bug mentioned in #505 [(comment)](https://github.com/pystatgen/sgkit/pull/505#issuecomment-805604674).

cc @tomwhite 


This crash occurs (only?) when running the full unit test suit, usually after `test_observed_heterozygosity` and `test_observed_heterozygosity__windowed` have both passed. On my machine it most commonly occurs around `sgkit/tests/test_preprocessing.py::test_filter_partial_calls__mixed_ploidy` and `sgkit/tests/test_regenie.py::test_regenie__glow_comparison` though I think this is due to timing rather than an interaction with those tests.

This crash is highly reproducible on my machine (GNU/Linux 4.4.0-19041-Microsoft x86_64 in WSL1 on Ryzen 4700u).
The crash seems to specifically relate to the uneven chunk size on the sample dimension in the third iteration of both tests `((3, 1), (4, 2), (1, 3))`.

Example output from my machine: [(gist)](https://gist.github.com/timothymillar/fbc4a58562a9bf080a0a14de8e20b263)

I have tried chunk variations including `((3, 1), (3, 3), (1, 3))` and `((3, 1), (2, 2, 2), (1, 3))` which both seem reliably avoid the crash over several repetitions. I also *think* I had a single crash with  `((3, 1), (6,), (1, 3))` though if that wasn't my mistake then it is a less reproducible example.

