### PR TITLE
Fix various indexing bugs

### DIFF
--- a/sgkit/stats/pca.py
+++ b/sgkit/stats/pca.py
@@ -320,7 +320,7 @@ def pca(
 
 def count_call_alternate_alleles(ds: Dataset, merge: bool = True) -> Dataset:
     # TODO: Add to public API (https://github.com/pystatgen/sgkit/issues/282)
-    AC = count_call_alleles(ds, merge=False)["call_allele_count"]
+    AC = count_call_alleles(ds)["call_allele_count"]
     AC = AC[..., 1:].sum(dim="alleles").astype("int16")
     AC = AC.where(~ds.call_genotype_mask.any(dim="ploidy"), AC.dtype.type(-1))
     new_ds = Dataset({"call_alternate_allele_count": AC})

--- a/sgkit/tests/test_aggregation.py
+++ b/sgkit/tests/test_aggregation.py
@@ -260,6 +260,7 @@ def test_variant_stats(precompute_variant_allele_count):
     ds = get_dataset(
         [[[1, 0], [-1, -1]], [[1, 0], [1, 1]], [[0, 1], [1, 0]], [[-1, -1], [0, 0]]]
     )
+    ds = ds.set_index({"variants": ("variant_contig", "variant_position")})
     if precompute_variant_allele_count:
         ds = count_variant_alleles(ds)
     vs = variant_stats(ds)

--- a/sgkit/tests/test_pca.py
+++ b/sgkit/tests/test_pca.py
@@ -108,6 +108,16 @@ def test_pca__default_allele_counts(sample_dataset):
     ).compute()
 
 
+def test_pca__default_allele_counts_with_index(sample_dataset):
+    pca.pca(
+        sample_dataset.drop_vars("call_alternate_allele_count").set_index(
+            {"variants": ("variant_contig", "variant_position")}
+        ),
+        n_components=2,
+        merge=False,
+    ).compute()
+
+
 def test_pca__raise_on_no_ploidy(sample_dataset):
     with pytest.raises(ValueError, match="`ploidy` must be specified explicitly"):
         pca.pca_est(sample_dataset.drop_dims("ploidy"), n_components=2, ploidy=None)

--- a/sgkit/tests/test_variables.py
+++ b/sgkit/tests/test_variables.py
@@ -16,12 +16,19 @@ def test_variables__variables_registered():
 
 @pytest.fixture()
 def dummy_ds():
-    return xr.Dataset({"foo": np.asarray([1, 2, 3]), "bar": np.asarray([1, 2, 3])})
+    # foo is a data variable, bar is a coordinate
+    return xr.Dataset(
+        {
+            "foo": ("d1", np.asarray([1, 2, 3])),
+            "bar": np.asarray([1, 2, 3]),
+        }
+    )
 
 
 def test_variables__no_spec(dummy_ds: xr.Dataset) -> None:
     with pytest.raises(ValueError, match="No array spec registered for foo"):
         variables.validate(dummy_ds, "foo")
+    variables.validate(dummy_ds, "bar")  # no spec needed for coordinates or indexes
 
 
 def test_variables__validate_by_name(dummy_ds: xr.Dataset) -> None:
@@ -79,8 +86,6 @@ def test_variables__whole_ds(dummy_ds: xr.Dataset) -> None:
         SgkitVariables.register_variable(spec_foo)
         with pytest.raises(ValueError, match="`foo` already registered"):
             SgkitVariables.register_variable(spec_foo)
-        with pytest.raises(ValueError, match="No array spec registered for bar"):
-            variables.validate(dummy_ds)
         SgkitVariables.register_variable(spec_bar)
         variables.validate(dummy_ds)
     finally:

--- a/sgkit/tests/test_variables.py
+++ b/sgkit/tests/test_variables.py
@@ -91,3 +91,11 @@ def test_variables__whole_ds(dummy_ds: xr.Dataset) -> None:
     finally:
         SgkitVariables.registered_variables.pop("foo", None)
         SgkitVariables.registered_variables.pop("bar", None)
+
+
+def test_variables_in_multi_index(dummy_ds: xr.Dataset) -> None:
+    # create a multi index
+    ds = dummy_ds.set_index({"ind": ("foo", "bar")})
+
+    spec = ArrayLikeSpec("foo", kind="i", ndim=1)
+    variables.validate(ds, spec)

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -146,18 +146,18 @@ class SgkitVariables:
             field_spec, ArrayLikeSpec
         ), "ArrayLikeSpec is the only currently supported variable spec"
 
-        if field not in xr_dataset:
-            raise ValueError(f"{field} not present in {xr_dataset}")
         try:
-            check_array_like(
-                xr_dataset[field], kind=field_spec.kind, ndim=field_spec.ndim
-            )
-            if add_comment_attr and field_spec.__doc__ is not None:
-                xr_dataset[field].attrs["comment"] = field_spec.__doc__.strip()
-        except (TypeError, ValueError) as e:
-            raise ValueError(
-                f"{field} does not match the spec, see the error above for more detail"
-            ) from e
+            arr = xr_dataset[field]
+            try:
+                check_array_like(arr, kind=field_spec.kind, ndim=field_spec.ndim)
+                if add_comment_attr and field_spec.__doc__ is not None:
+                    arr.attrs["comment"] = field_spec.__doc__.strip()
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    f"{field} does not match the spec, see the error above for more detail"
+                ) from e
+        except KeyError:
+            raise ValueError(f"{field} not present in {xr_dataset}")
 
 
 validate = SgkitVariables._validate

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -119,14 +119,17 @@ class SgkitVariables:
             elif s:
                 try:
                     field_spec = cls.registered_variables[s]
+                    cls._check_field(
+                        xr_dataset,
+                        field_spec,
+                        field_spec.default_name,
+                        add_comment_attr=add_comment_attr,
+                    )
                 except KeyError:
-                    raise ValueError(f"No array spec registered for {s}")
-                cls._check_field(
-                    xr_dataset,
-                    field_spec,
-                    field_spec.default_name,
-                    add_comment_attr=add_comment_attr,
-                )
+                    if s in xr_dataset.indexes.keys():
+                        logger.debug(f"Ignoring missing spec for index: {s}")
+                    else:
+                        raise ValueError(f"No array spec registered for {s}")
         return xr_dataset
 
     @classmethod


### PR DESCRIPTION
This fixes #506, and a couple of other related bugs that occur when an index is set and were found when working on #463:

* `var_name in ds` fails if the data variable `var_name` has been "moved" to be an index field of `ds`
* PCA doesn't work properly if there is an index set
 
Both of these cases are triggered by setting an index like this:
```python
ds = ds.set_index({"variants": ("variant_contig", "variant_position")})
```

See also #473 