### PR TITLE
Fix issues in Tajima's D calculation

### DIFF
--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -347,9 +347,7 @@ def test_Fst__windowed(sample_size, n_cohorts, chunks):
         )  # scikit-allel has final window missing
 
 
-# Skipping values > 2, because of this issue:
-# https://github.com/pystatgen/sgkit/issues/522
-@pytest.mark.parametrize("sample_size", [2])
+@pytest.mark.parametrize("sample_size", [2, 3, 5, 10, 100])
 def test_Tajimas_D(sample_size):
     ts = simulate_ts(sample_size)
     ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
@@ -359,6 +357,22 @@ def test_Tajimas_D(sample_size):
     ds = Tajimas_D(ds)
     d = ds.stat_Tajimas_D.compute()
     ts_d = ts.Tajimas_D()
+    print("d = ", ts_d)
+    np.testing.assert_allclose(d, ts_d)
+
+
+@pytest.mark.parametrize("sample_size", [2, 3, 5, 10, 100])
+def test_Tajimas_D_per_site(sample_size):
+    ts = simulate_ts(sample_size, random_seed=1234)
+    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
+    ds, subsets = add_cohorts(ds, ts, cohort_key_names=None)  # type: ignore[no-untyped-call]
+    ds = window(ds, size=1)  # by site
+    print(ds)
+    ds = Tajimas_D(ds)
+    d = ds.stat_Tajimas_D.compute()
+    ts_d = ts.Tajimas_D(windows="sites")
+    print("TS = ", ts_d)
+    print("SG = ", np.array(d)[:, 0])
     np.testing.assert_allclose(d, ts_d)
 
 


### PR DESCRIPTION
This is wip for fixing #523, and a few other issues that have cropped up while I was in there.

The original issue was easy enough to fix, but two other things have popped up:

1. It would be easiest if we produced exactly the same answer as tskit in division by zero cases. Tskit has taken the approach of letting the errors happen and using numpy to suppress the warnings, so we can get -inf, nan or inf, depending on the input. However, Dask doesn't support this, it seems (https://github.com/dask/dask/issues/3245), which is awkward. Not sure how to proceed here.
2. It's not clear to me that we're handling windows properly in Tajima's D.

@tomwhite, good to get your thoughts on this. Am I doing the windows-of-size-one thing correctly?