### PR TITLE
Add rechunker to upstream tests #549

### DIFF
--- a/.github/scripts/upstream_install.py
+++ b/.github/scripts/upstream_install.py
@@ -17,6 +17,7 @@ def install_deps() -> None:
         "git+https://github.com/dask/dask.git#egg=dask[array]",
         "git+https://github.com/dask/distributed.git#egg=distributed",
         "git+https://github.com/dask/dask-ml.git#egg=dask-ml",
+        "git+https://github.com/pangeo-data/rechunker.git#egg=rechunker",
         "git+https://github.com/pydata/xarray.git#egg=xarray",
         "git+https://github.com/zarr-developers/zarr-python.git#egg=zarr",
     )


### PR DESCRIPTION
This should probably wait until https://github.com/pangeo-data/rechunker/pull/87 is in.

Fixes #549