### PR TITLE
Review variables

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -115,7 +115,7 @@ Variables
 .. autosummary::
    :toctree: generated/
 
-    variables.base_prediction_spec
+    variables.regenie_base_prediction_spec
     variables.call_allele_count_spec
     variables.call_dosage_spec
     variables.call_dosage_mask_spec
@@ -134,8 +134,8 @@ Variables
     variables.dosage_spec
     variables.genotype_counts_spec
     variables.ld_prune_index_to_drop_spec
-    variables.loco_prediction_spec
-    variables.meta_prediction_spec
+    variables.regenie_loco_prediction_spec
+    variables.regenie_meta_prediction_spec
     variables.pc_relate_phi_spec
     variables.sample_call_rate_spec
     variables.sample_id_spec

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -149,7 +149,7 @@ Variables
     variables.sample_pca_explained_variance_ratio_spec
     variables.sample_pca_loading_spec
     variables.sample_pca_projection_spec
-    variables.sample_pcs_spec
+    variables.sample_pc_spec
     variables.sample_ploidy_spec
     variables.stat_divergence_spec
     variables.stat_diversity_spec

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -112,6 +112,8 @@ Utilities
 Variables
 =========
 
+By convention, variable names are singular in sgkit. For example, ``genotype_count``, *not* ``genotype_counts``.
+
 .. autosummary::
    :toctree: generated/
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -132,7 +132,7 @@ Variables
     variables.cohort_allele_count_spec
     variables.covariates_spec
     variables.dosage_spec
-    variables.genotype_counts_spec
+    variables.genotype_count_spec
     variables.ld_prune_index_to_drop_spec
     variables.regenie_loco_prediction_spec
     variables.regenie_meta_prediction_spec

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -144,6 +144,11 @@ Variables
     variables.sample_n_hom_alt_spec
     variables.sample_n_hom_ref_spec
     variables.sample_n_non_ref_spec
+    variables.sample_pca_component_spec
+    variables.sample_pca_explained_variance_spec
+    variables.sample_pca_explained_variance_ratio_spec
+    variables.sample_pca_loading_spec
+    variables.sample_pca_projection_spec
     variables.sample_pcs_spec
     variables.sample_ploidy_spec
     variables.stat_divergence_spec
@@ -154,6 +159,7 @@ Variables
     variables.stat_Garud_h123_spec
     variables.stat_Garud_h2_h1_spec
     variables.stat_observed_heterozygosity_spec
+    variables.stat_pbs_spec
     variables.stat_Tajimas_D_spec
     variables.traits_spec
     variables.variant_allele_spec
@@ -175,5 +181,6 @@ Variables
     variables.variant_position_spec
     variables.variant_score_spec
     variables.variant_t_value_spec
+    variables.window_contig_spec
     variables.window_start_spec
     variables.window_stop_spec

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -166,7 +166,7 @@ Variables
     variables.variant_allele_count_spec
     variables.variant_allele_frequency_spec
     variables.variant_allele_total_spec
-    variables.variant_beta_spec
+    variables.variant_linreg_beta_spec
     variables.variant_call_rate_spec
     variables.variant_contig_spec
     variables.variant_hwe_p_value_spec
@@ -176,11 +176,11 @@ Variables
     variables.variant_n_hom_alt_spec
     variables.variant_n_hom_ref_spec
     variables.variant_n_non_ref_spec
-    variables.variant_p_value_spec
+    variables.variant_linreg_p_value_spec
     variables.variant_ploidy_spec
     variables.variant_position_spec
     variables.variant_score_spec
-    variables.variant_t_value_spec
+    variables.variant_linreg_t_value_spec
     variables.window_contig_spec
     variables.window_start_spec
     variables.window_stop_spec

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -349,6 +349,10 @@ Discussions around bringing stricter array type enforcement into the API:
 - https://github.com/pystatgen/sgkit/pull/124
 - https://github.com/pystatgen/sgkit/pull/276
 
+Dataset variables
+~~~~~~~~~~~~~~~~~
+
+Naming conventions for variables: https://github.com/pystatgen/sgkit/issues/295
 
 Delayed invariant checks
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sgkit/stats/association.py
+++ b/sgkit/stats/association.py
@@ -177,11 +177,11 @@ def gwas_linear_regression(
     -------
     Dataset containing (N = num variants, O = num traits):
 
-    variant_beta : [array-like, shape: (N, O)]
+    variant_linreg_beta : [array-like, shape: (N, O)]
         Beta values associated with each variant and trait
-    variant_t_value : [array-like, shape: (N, O)]
+    variant_linreg_t_value : [array-like, shape: (N, O)]
         T statistics for each beta
-    variant_p_value : [array-like, shape: (N, O)]
+    variant_linreg_p_value : [array-like, shape: (N, O)]
         P values as float in [0, 1]
 
     References
@@ -233,9 +233,9 @@ def gwas_linear_regression(
     res = linear_regression(G.T, X, Y)
     new_ds = create_dataset(
         {
-            variables.variant_beta: (("variants", "traits"), res.beta),
-            variables.variant_t_value: (("variants", "traits"), res.t_value),
-            variables.variant_p_value: (("variants", "traits"), res.p_value),
+            variables.variant_linreg_beta: (("variants", "traits"), res.beta),
+            variables.variant_linreg_t_value: (("variants", "traits"), res.t_value),
+            variables.variant_linreg_p_value: (("variants", "traits"), res.p_value),
         }
     )
     return conditional_merge_datasets(ds, new_ds, merge)

--- a/sgkit/stats/hwe.py
+++ b/sgkit/stats/hwe.py
@@ -126,7 +126,7 @@ hardy_weinberg_p_value_vec_jit = njit(
 def hardy_weinberg_test(
     ds: Dataset,
     *,
-    genotype_counts: Optional[Hashable] = None,
+    genotype_count: Optional[Hashable] = None,
     ploidy: Optional[int] = None,
     alleles: Optional[int] = None,
     merge: bool = True
@@ -137,7 +137,7 @@ def hardy_weinberg_test(
     ----------
     ds
         Dataset containing genotype calls or precomputed genotype counts.
-    genotype_counts
+    genotype_count
         Name of variable containing precomputed genotype counts, by default
         None. If not provided, these counts will be computed automatically
         from genotype calls. If present, must correspond to an (`N`, 3) array
@@ -201,9 +201,9 @@ def hardy_weinberg_test(
         raise NotImplementedError("HWE test only implemented for biallelic genotypes")
 
     # Use precomputed genotype counts if provided
-    if genotype_counts is not None:
-        variables.validate(ds, {genotype_counts: variables.genotype_counts_spec})
-        obs = list(da.asarray(ds[genotype_counts]).T)
+    if genotype_count is not None:
+        variables.validate(ds, {genotype_count: variables.genotype_count_spec})
+        obs = list(da.asarray(ds[genotype_count]).T)
     # Otherwise compute genotype counts from calls
     else:
         ds = count_genotypes(ds, dim="samples")

--- a/sgkit/stats/pc_relate.py
+++ b/sgkit/stats/pc_relate.py
@@ -38,7 +38,7 @@ def pc_relate(
     maf: float = 0.01,
     call_genotype: Hashable = variables.call_genotype,
     call_genotype_mask: Hashable = variables.call_genotype_mask,
-    sample_pcs: Hashable = variables.sample_pcs,
+    sample_pc: Hashable = variables.sample_pc,
     merge: bool = True
 ) -> xr.Dataset:
     """Compute PC-Relate as described in Conomos, et al. 2016 [1].
@@ -86,9 +86,9 @@ def pc_relate(
     call_genotype_mask
         Input variable name holding call_genotype_mask.
         Defined by :data:`sgkit.variables.call_genotype_mask_spec`
-    sample_pcs
-        Input variable name holding sample_pcs.
-        Defined by :data:`sgkit.variables.sample_pcs_spec`
+    sample_pc
+        Input variable name holding sample principal components.
+        Defined by :data:`sgkit.variables.sample_pc_spec`
     merge
         If True (the default), merge the input dataset and the computed
         output variables into a single dataset, otherwise return only
@@ -137,7 +137,7 @@ def pc_relate(
         {
             call_genotype: variables.call_genotype_spec,
             call_genotype_mask: variables.call_genotype_mask_spec,
-            sample_pcs: variables.sample_pcs_spec,
+            sample_pc: variables.sample_pc_spec,
         },
     )
 
@@ -146,7 +146,7 @@ def pc_relate(
 
     # 𝔼[gs|V] = 1β0 + Vβ, where 1 is a length _s_ vector of 1s, and β = (β1,...,βD)^T
     # is a length D vector of regression coefficients for each of the PCs
-    pcs = ds[sample_pcs]
+    pcs = ds[sample_pc]
     pcsi = da.concatenate([da.ones((1, pcs.shape[1]), dtype=pcs.dtype), pcs], axis=0)
     # Note: dask qr decomp requires no chunking in one dimension, and because number of
     # components should be smaller than number of samples in most cases, we disable

--- a/sgkit/stats/regenie.py
+++ b/sgkit/stats/regenie.py
@@ -629,12 +629,12 @@ def regenie_transform(
     -------
     A dataset containing the following variables:
 
-    - `base_prediction` (blocks, alphas, samples, outcomes): Stage 1
+    - `regenie_base_prediction` (blocks, alphas, samples, outcomes): Stage 1
         predictions from ridge regression reduction .
-    - `meta_prediction` (samples, outcomes): Stage 2 predictions from
+    - `regenie_meta_prediction` (samples, outcomes): Stage 2 predictions from
         the best meta estimator trained on the out-of-sample Stage 1
         predictions.
-    - `loco_prediction` (contigs, samples, outcomes): LOCO predictions
+    - `regenie_loco_prediction` (contigs, samples, outcomes): LOCO predictions
         resulting from Stage 2 predictions ignoring effects for variant
         blocks on held out contigs. This will be absent if the
         data provided does not contain at least 2 contigs.
@@ -708,16 +708,16 @@ def regenie_transform(
     YP3 = _stage_3(B2, YP1, X, Y, contigs, variant_chunk_start)
 
     data_vars: Dict[Hashable, Any] = {}
-    data_vars[variables.base_prediction] = xr.DataArray(
+    data_vars[variables.regenie_base_prediction] = xr.DataArray(
         YP1,
         dims=("blocks", "alphas", "samples", "outcomes"),
         attrs={"description": DESC_BASE_PRED},
     )
-    data_vars[variables.meta_prediction] = xr.DataArray(
+    data_vars[variables.regenie_meta_prediction] = xr.DataArray(
         YP2, dims=("samples", "outcomes"), attrs={"description": DESC_META_PRED}
     )
     if YP3 is not None:
-        data_vars[variables.loco_prediction] = xr.DataArray(
+        data_vars[variables.regenie_loco_prediction] = xr.DataArray(
             YP3,
             dims=("contigs", "samples", "outcomes"),
             attrs={"description": DESC_LOCO_PRED},
@@ -807,19 +807,19 @@ def regenie(
     -------
     A dataset containing the following variables:
 
-    - `base_prediction` (blocks, alphas, samples, outcomes): Stage 1
+    - `regenie_base_prediction` (blocks, alphas, samples, outcomes): Stage 1
         predictions from ridge regression reduction. Defined by
-        :data:`sgkit.variables.base_prediction_spec`.
+        :data:`sgkit.variables.regenie_base_prediction_spec`.
 
-    - `meta_prediction` (samples, outcomes): Stage 2 predictions from
+    - `regenie_meta_prediction` (samples, outcomes): Stage 2 predictions from
         the best meta estimator trained on the out-of-sample Stage 1
-        predictions. Defined by :data:`sgkit.variables.meta_prediction_spec`.
+        predictions. Defined by :data:`sgkit.variables.regenie_meta_prediction_spec`.
 
-    - `loco_prediction` (contigs, samples, outcomes): LOCO predictions
+    - `regenie_loco_prediction` (contigs, samples, outcomes): LOCO predictions
         resulting from Stage 2 predictions ignoring effects for variant
         blocks on held out contigs. This will be absent if the
         data provided does not contain at least 2 contigs. Defined by
-        :data:`sgkit.variables.loco_prediction_spec`.
+        :data:`sgkit.variables.regenie_loco_prediction_spec`.
 
     Raises
     ------
@@ -842,12 +842,12 @@ def regenie(
     >>> res = regenie(ds, dosage="call_dosage", covariates="sample_covariate", traits="sample_trait", merge=False)
     >>> res.compute() # doctest: +NORMALIZE_WHITESPACE
     <xarray.Dataset>
-    Dimensions:          (alphas: 5, blocks: 2, contigs: 2, outcomes: 5, samples: 50)
+    Dimensions:                  (alphas: 5, blocks: 2, contigs: 2, outcomes: 5, samples: 50)
     Dimensions without coordinates: alphas, blocks, contigs, outcomes, samples
     Data variables:
-        base_prediction  (blocks, alphas, samples, outcomes) float64 0.3343 ... -...
-        meta_prediction  (samples, outcomes) float64 -0.4588 0.78 ... -0.3984 0.3734
-        loco_prediction  (contigs, samples, outcomes) float64 0.4886 ... -0.01498
+        regenie_base_prediction  (blocks, alphas, samples, outcomes) float64 0.33...
+        regenie_meta_prediction  (samples, outcomes) float64 -0.4588 0.78 ... 0.3734
+        regenie_loco_prediction  (contigs, samples, outcomes) float64 0.4886 ... ...
 
     References
     ----------

--- a/sgkit/tests/test_association.py
+++ b/sgkit/tests/test_association.py
@@ -134,7 +134,7 @@ def _get_statistics(
         res = _sm_statistics(ds, i, add_intercept)
         df_pred.append(
             dsr.to_dataframe()
-            .rename(columns=lambda c: c.replace("variant_", ""))
+            .rename(columns=lambda c: c.replace("variant_linreg_", ""))
             .iloc[i]
             .to_dict()
         )

--- a/sgkit/tests/test_hwe.py
+++ b/sgkit/tests/test_hwe.py
@@ -138,8 +138,8 @@ def test_hwep_dataset__precomputed_counts(ds_neq: Dataset) -> None:
     ac = ds["call_genotype"].sum(dim="ploidy")
     cts = [1, 0, 2]  # arg order: hets, hom1, hom2
     gtc = xr.concat([(ac == ct).sum(dim="samples") for ct in cts], dim="counts").T
-    ds = ds.assign(**{"variant_genotype_counts": gtc})
-    p = hwep_test(ds, genotype_counts="variant_genotype_counts", merge=False)[
+    ds = ds.assign(**{"variant_genotype_count": gtc})
+    p = hwep_test(ds, genotype_count="variant_genotype_count", merge=False)[
         "variant_hwe_p_value"
     ].values
     assert np.all(p < 1e-8)

--- a/sgkit/tests/test_pc_relate.py
+++ b/sgkit/tests/test_pc_relate.py
@@ -27,7 +27,7 @@ def test_pc_relate__genotype_inputs_checks() -> None:
         pc_relate(g_non_biallelic)
 
     g_no_pcs = simulate_genotype_call_dataset(100, 10)
-    with pytest.raises(ValueError, match="sample_pcs not present"):
+    with pytest.raises(ValueError, match="sample_pc not present"):
         pc_relate(g_no_pcs)
 
     with pytest.raises(ValueError, match="call_genotype not present"):
@@ -104,7 +104,7 @@ def test_pc_relate__values_within_range() -> None:
     g = simulate_genotype_call_dataset(1000, n_samples)
     call_g, _ = _collapse_ploidy(g)
     pcs = PCA(n_components=2, svd_solver="full").fit_transform(call_g.T)
-    g["sample_pcs"] = (("components", "samples"), pcs.T)
+    g["sample_pc"] = (("components", "samples"), pcs.T)
     phi = pc_relate(g)
     assert phi.pc_relate_phi.shape == (n_samples, n_samples)
     data_np = phi.pc_relate_phi.data.compute()  # to be able to use fancy indexing below
@@ -117,7 +117,7 @@ def test_pc_relate__identical_sample_should_be_05() -> None:
     g = simulate_genotype_call_dataset(1000, n_samples, missing_pct=0.1)
     call_g, _ = _collapse_ploidy(g)
     pcs = PCA(n_components=2, svd_solver="full").fit_transform(call_g.T)
-    g["sample_pcs"] = (("components", "samples"), pcs.T)
+    g["sample_pc"] = (("components", "samples"), pcs.T)
     # Add identical sample
     g.call_genotype.loc[dict(samples=8)] = g.call_genotype.isel(samples=0)
     phi = pc_relate(g)
@@ -156,7 +156,7 @@ def test_pc_relate__parent_child_relationship() -> None:
     # Infer kinship
     call_g, _ = _collapse_ploidy(ds)
     pcs = PCA(n_components=2, svd_solver="full").fit_transform(call_g.T)
-    ds["sample_pcs"] = (("components", "samples"), pcs.T)
+    ds["sample_pc"] = (("components", "samples"), pcs.T)
     ds["pc_relate_phi"] = pc_relate(ds)["pc_relate_phi"].compute()
 
     # Check that all coefficients are in expected ranges

--- a/sgkit/tests/test_regenie.py
+++ b/sgkit/tests/test_regenie.py
@@ -269,8 +269,8 @@ def check_simulation_result(
             _glow_adj_scaling=True,
             _glow_adj_alpha=True,
         )
-        YBP = res["base_prediction"].data
-        YMP = res["meta_prediction"].data
+        YBP = res["regenie_base_prediction"].data
+        YMP = res["regenie_meta_prediction"].data
 
         # Check equality of stage 1 and 2 transformations
         check_stage_1_results(YBP, ds_config, ps_config, result_dir)
@@ -300,7 +300,7 @@ def test_regenie__no_loco_with_one_contig():
     )
     res = regenie_sim(ds=ds, merge=False)
     assert len(res) == 2
-    assert "loco_prediction" not in res
+    assert "regenie_loco_prediction" not in res
 
 
 def test_regenie__32bit_float(ds):
@@ -321,7 +321,7 @@ def test_regenie__custom_variant_block_size(ds):
     vbs = (50, 25, 25)
     assert sum(vbs) == ds.dims["variants"]
     res = regenie_sim(ds=ds, variant_block_size=vbs)
-    assert res["base_prediction"].sizes["blocks"] == 3
+    assert res["regenie_base_prediction"].sizes["blocks"] == 3
 
 
 def test_regenie__raise_on_bad_variant_block_size(ds):
@@ -352,7 +352,7 @@ def test_regenie__block_size_1(ds):
     # only one element to ensure that no unwanted squeezing occurs
     vbs, sbs = ds.dims["variants"] - 1, ds.dims["samples"] - 1
     res = regenie_sim(ds=ds, variant_block_size=vbs, sample_block_size=sbs)
-    assert res["base_prediction"].sizes["blocks"] == 2
+    assert res["regenie_base_prediction"].sizes["blocks"] == 2
 
 
 def test_ridge_regression():

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -725,9 +725,9 @@ variant_allele_total, variant_allele_total_spec = SgkitVariables.register_variab
     )
 )
 
-variant_beta, variant_beta_spec = SgkitVariables.register_variable(
+variant_linreg_beta, variant_linreg_beta_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "variant_beta",
+        "variant_linreg_beta",
         __doc__="""Beta values associated with each variant and trait.""",
     )
 )
@@ -816,9 +816,9 @@ variant_n_non_ref, variant_n_non_ref_spec = SgkitVariables.register_variable(
     )
 )
 
-variant_p_value, variant_p_value_spec = SgkitVariables.register_variable(
+variant_linreg_p_value, variant_linreg_p_value_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "variant_p_value", kind="f", __doc__="""P values as float in [0, 1]."""
+        "variant_linreg_p_value", kind="f", __doc__="""P values as float in [0, 1]."""
     )
 )
 
@@ -830,8 +830,8 @@ variant_position, variant_position_spec = SgkitVariables.register_variable(
         __doc__="""The reference position of the variant.""",
     )
 )
-variant_t_value, variant_t_value_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_t_value", __doc__="""T statistics for each beta.""")
+variant_linreg_t_value, variant_linreg_t_value_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("variant_linreg_t_value", __doc__="""T statistics for each beta.""")
 )
 
 variant_ploidy, variant_ploidy_spec = SgkitVariables.register_variable(

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -505,8 +505,8 @@ sample_n_non_ref, sample_n_non_ref_spec = SgkitVariables.register_variable(
     )
 )
 
-sample_pcs, sample_pcs_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("sample_pcs", ndim=2, kind="f", __doc__="""Sample PCs (PCxS).""")
+sample_pc, sample_pc_spec = SgkitVariables.register_variable(
+    ArrayLikeSpec("sample_pc", ndim=2, kind="f", __doc__="""Sample PCs (PCxS).""")
 )
 
 sample_pca_component, sample_pca_component_spec = SgkitVariables.register_variable(

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -361,9 +361,9 @@ one of several possible quantities, e.g.:
     )
 )
 
-genotype_counts, genotype_counts_spec = SgkitVariables.register_variable(
+genotype_count, genotype_count_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "genotype_counts",
+        "genotype_count",
         ndim=2,
         kind="i",
         __doc__="""

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -182,18 +182,6 @@ summary page. The rest of the docstring will appear on the variable
 specific page.
 """
 
-base_prediction, base_prediction_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec(
-        "base_prediction",
-        ndim=4,
-        kind="f",
-        __doc__="""
-REGENIE's base prediction (blocks, alphas, samples, outcomes). Stage 1
-predictions from ridge regression reduction.
-""",
-    )
-)
-
 call_allele_count, call_allele_count_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_allele_count",
@@ -398,13 +386,31 @@ Variant indexes to drop for LD prune.
     )
 )
 
-loco_prediction, loco_prediction_spec = SgkitVariables.register_variable(
+(
+    regenie_base_prediction,
+    regenie_base_prediction_spec,
+) = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "loco_prediction",
+        "regenie_base_prediction",
+        ndim=4,
+        kind="f",
+        __doc__="""
+REGENIE's base prediction (blocks, alphas, samples, outcomes). Stage 1
+predictions from ridge regression reduction.
+""",
+    )
+)
+
+(
+    regenie_loco_prediction,
+    regenie_loco_prediction_spec,
+) = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "regenie_loco_prediction",
         ndim=3,
         kind="f",
         __doc__="""
-REGENIE's loco_prediction (contigs, samples, outcomes). LOCO predictions
+REGENIE's regenie_loco_prediction (contigs, samples, outcomes). LOCO predictions
 resulting from Stage 2 predictions ignoring effects for variant blocks on
 held out contigs. This will be absent if the data provided does not contain
 at least 2 contigs.
@@ -412,13 +418,16 @@ at least 2 contigs.
     )
 )
 
-meta_prediction, meta_prediction_spec = SgkitVariables.register_variable(
+(
+    regenie_meta_prediction,
+    regenie_meta_prediction_spec,
+) = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "meta_prediction",
+        "regenie_meta_prediction",
         ndim=2,
         kind="f",
         __doc__="""
-REGENIE's meta_prediction (samples, outcomes). Stage 2 predictions from
+REGENIE's regenie_meta_prediction (samples, outcomes). Stage 2 predictions from
 the best meta estimator trained on the out-of-sample Stage 1 predictions.
 """,
     )

--- a/validation/gwas/method/pc_relate/validate_pc_relate.py
+++ b/validation/gwas/method/pc_relate/validate_pc_relate.py
@@ -21,7 +21,7 @@ def test_same_as_the_reference_implementation() -> None:
     pcs = da.from_array(
         pd.read_csv(d.joinpath("pcs.csv").as_posix(), usecols=[1, 2]).to_numpy()
     ).T
-    ds["sample_pcs"] = (("components", "samples"), pcs)
+    ds["sample_pc"] = (("components", "samples"), pcs)
     phi = pc_relate(ds).pc_relate_phi.compute()
 
     n_samples = 90

--- a/validation/gwas/method/regenie/unit_test_dev.ipynb
+++ b/validation/gwas/method/regenie/unit_test_dev.ipynb
@@ -390,18 +390,18 @@
        "Dimensions:          (alphas: 1, blocks: 30, contigs: 10, outcomes: 1, samples: 50)\n",
        "Dimensions without coordinates: alphas, blocks, contigs, outcomes, samples\n",
        "Data variables:\n",
-       "    base_prediction  (blocks, alphas, samples, outcomes) float64 dask.array&lt;chunksize=(1, 1, 10, 1), meta=np.ndarray&gt;\n",
-       "    meta_prediction  (samples, outcomes) float64 dask.array&lt;chunksize=(10, 1), meta=np.ndarray&gt;\n",
-       "    loco_prediction  (contigs, samples, outcomes) float64 dask.array&lt;chunksize=(1, 10, 1), meta=np.ndarray&gt;</pre>"
+       "    regenie_base_prediction  (blocks, alphas, samples, outcomes) float64 dask.array&lt;chunksize=(1, 1, 10, 1), meta=np.ndarray&gt;\n",
+       "    regenie_meta_prediction  (samples, outcomes) float64 dask.array&lt;chunksize=(10, 1), meta=np.ndarray&gt;\n",
+       "    regenie_loco_prediction  (contigs, samples, outcomes) float64 dask.array&lt;chunksize=(1, 10, 1), meta=np.ndarray&gt;</pre>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
        "Dimensions:          (alphas: 1, blocks: 30, contigs: 10, outcomes: 1, samples: 50)\n",
        "Dimensions without coordinates: alphas, blocks, contigs, outcomes, samples\n",
        "Data variables:\n",
-       "    base_prediction  (blocks, alphas, samples, outcomes) float64 dask.array<chunksize=(1, 1, 10, 1), meta=np.ndarray>\n",
-       "    meta_prediction  (samples, outcomes) float64 dask.array<chunksize=(10, 1), meta=np.ndarray>\n",
-       "    loco_prediction  (contigs, samples, outcomes) float64 dask.array<chunksize=(1, 10, 1), meta=np.ndarray>"
+       "    regenie_base_prediction  (blocks, alphas, samples, outcomes) float64 dask.array<chunksize=(1, 1, 10, 1), meta=np.ndarray>\n",
+       "    regenie_meta_prediction  (samples, outcomes) float64 dask.array<chunksize=(10, 1), meta=np.ndarray>\n",
+       "    regenie_loco_prediction  (contigs, samples, outcomes) float64 dask.array<chunksize=(1, 10, 1), meta=np.ndarray>"
       ]
      },
      "execution_count": 10,
@@ -432,18 +432,18 @@
        "Dimensions:          (alphas: 5, blocks: 2, contigs: 2, outcomes: 5, samples: 50)\n",
        "Dimensions without coordinates: alphas, blocks, contigs, outcomes, samples\n",
        "Data variables:\n",
-       "    base_prediction  (blocks, alphas, samples, outcomes) float64 0.3343 ... -...\n",
-       "    meta_prediction  (samples, outcomes) float64 -0.4588 0.78 ... -0.3984 0.3734\n",
-       "    loco_prediction  (contigs, samples, outcomes) float64 0.4886 ... -0.01498</pre>"
+       "    regenie_base_prediction  (blocks, alphas, samples, outcomes) float64 0.3343 ... -...\n",
+       "    regenie_meta_prediction  (samples, outcomes) float64 -0.4588 0.78 ... -0.3984 0.3734\n",
+       "    regenie_loco_prediction  (contigs, samples, outcomes) float64 0.4886 ... -0.01498</pre>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
        "Dimensions:          (alphas: 5, blocks: 2, contigs: 2, outcomes: 5, samples: 50)\n",
        "Dimensions without coordinates: alphas, blocks, contigs, outcomes, samples\n",
        "Data variables:\n",
-       "    base_prediction  (blocks, alphas, samples, outcomes) float64 0.3343 ... -...\n",
-       "    meta_prediction  (samples, outcomes) float64 -0.4588 0.78 ... -0.3984 0.3734\n",
-       "    loco_prediction  (contigs, samples, outcomes) float64 0.4886 ... -0.01498"
+       "    regenie_base_prediction  (blocks, alphas, samples, outcomes) float64 0.3343 ... -...\n",
+       "    regenie_meta_prediction  (samples, outcomes) float64 -0.4588 0.78 ... -0.3984 0.3734\n",
+       "    regenie_loco_prediction  (contigs, samples, outcomes) float64 0.4886 ... -0.01498"
       ]
      },
      "execution_count": 11,


### PR DESCRIPTION
This fixes #295.

To find missing variables on the API page I ran:

```bash
for v in $(python -c 'import sgkit; print("\n".join(list(sgkit.variables.SgkitVariables.registered_variables.keys())))')
do
  if ! grep "variables.${v}_spec" docs/api.rst >/dev/null; then
    echo $v
  fi
done
```

I've also renamed some variables for greater specificity/consistency:
* `{base,loco,meta}_prediction` -> `regenie_{base,loco,meta}_prediction`
* `variant_{beta,p_value,t_value}` -> `variant_linreg_{beta,p_value,t_value}`
* `genotype_counts` -> `genotype_count`
* `sample_pcs` -> `sample_pc`

This makes it clearer if we have both `variant_linreg_p_value` and `variant_hwe_p_value` in a dataset.