### PR TITLE
Fix change in make_meta in Dask 2021.5.1 #590

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 xarray
-dask[array]
-distributed
+dask[array] != 2021.5.1
+distributed != 2021.5.1
 dask-ml
 scipy
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 install_requires =
     numpy
     xarray
-    dask[array]
-    distributed
+    dask[array] != 2021.5.1
+    distributed != 2021.5.1
     dask-ml
     scipy
     zarr


### PR DESCRIPTION
Fixes #590. It wasn't sufficient to just rename `make_meta` to `make_meta_util`, I had to also set `parent_meta`. 

I haven't tried to do anything for older versions of Dask - is is worth setting a minimum version in requirements?

The incompatible change was made in https://github.com/dask/dask/pull/7586.