### PR TITLE
Fix tests failing due to Xarray dims ordering change

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,8 @@ bgen =
 fail_under = 100
 
 [tool:pytest]
-addopts = --doctest-modules --ignore=validation --cov-fail-under=100
+# TODO: remove ignored doctests below once Xarray>0.18.2 is released (with https://github.com/pydata/xarray/pull/4753)
+addopts = --doctest-modules --ignore=validation --cov-fail-under=100 --ignore=sgkit/stats/regenie.py --ignore=sgkit/stats/pca.py
 norecursedirs = .eggs build docs
 filterwarnings =
     error

--- a/sgkit/tests/test_association.py
+++ b/sgkit/tests/test_association.py
@@ -133,9 +133,10 @@ def _get_statistics(
         )
         res = _sm_statistics(ds, i, add_intercept)
         df_pred.append(
-            dsr.to_dataframe()
+            dsr.isel(variants=i)
+            .to_dataframe()
             .rename(columns=lambda c: c.replace("variant_linreg_", ""))
-            .iloc[i]
+            .iloc[0]
             .to_dict()
         )
         # First result in satsmodels RegressionResultsWrapper for


### PR DESCRIPTION
There are two parts to this fix: one that removes an assumption of dimension ordering (in `test_gwas_linear_regression__validate_statistics`), and another that ignores the two doctests that fail due to the `repr` having changed. These ignores can be removed once the next release of Xarray is made, so I'll open an issue to do that if this fix looks OK.

Fixes #583

