### PR TITLE
Deploy distribution artifacts to test PyPi on a tagged commit #606

### DIFF
--- a/.github/scripts/test_sgkit.py
+++ b/.github/scripts/test_sgkit.py
@@ -1,0 +1,5 @@
+import sgkit as sg
+
+if __name__ == "__main__":
+    ds = sg.simulate_genotype_call_dataset(n_variant=100, n_sample=50, n_contig=23)
+    print(ds)

--- a/.github/scripts/test_sgkit_bgen.py
+++ b/.github/scripts/test_sgkit_bgen.py
@@ -1,0 +1,11 @@
+import urllib.request
+
+from sgkit.io.bgen import read_bgen
+
+if __name__ == "__main__":
+    urllib.request.urlretrieve(
+        "https://github.com/pystatgen/sgkit/raw/main/sgkit/tests/io/bgen/data/example.bgen",
+        "example.bgen",
+    )
+    ds = read_bgen("example.bgen")
+    print(ds)

--- a/.github/scripts/test_sgkit_plink.py
+++ b/.github/scripts/test_sgkit_plink.py
@@ -1,0 +1,12 @@
+import urllib.request
+
+from sgkit.io.plink import read_plink
+
+if __name__ == "__main__":
+    for ext in (".bed", ".bim", ".fam"):
+        urllib.request.urlretrieve(
+            f"https://github.com/pystatgen/sgkit/raw/main/sgkit/tests/io/plink/data/plink_sim_10s_100v_10pmiss{ext}",
+            f"plink_sim_10s_100v_10pmiss{ext}",
+        )
+    ds = read_plink(path="plink_sim_10s_100v_10pmiss")
+    print(ds)

--- a/.github/scripts/test_sgkit_vcf.py
+++ b/.github/scripts/test_sgkit_vcf.py
@@ -1,0 +1,15 @@
+import urllib.request
+
+import xarray as xr
+
+from sgkit.io.vcf import vcf_to_zarr
+
+if __name__ == "__main__":
+    for ext in (".gz", ".gz.tbi"):
+        urllib.request.urlretrieve(
+            f"https://github.com/pystatgen/sgkit/raw/main/sgkit/tests/io/vcf/data/sample.vcf{ext}",
+            f"sample.vcf{ext}",
+        )
+    vcf_to_zarr("sample.vcf.gz", "out")
+    ds = xr.open_zarr("out")  # type: ignore[no-untyped-call]
+    print(ds)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,124 @@
+name: Wheels
+
+on:
+  push:
+    branches:
+      - main
+      - test
+    tags:
+      - '*'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    # This workflow only runs on the origin org
+    if: github.repository_owner == 'pystatgen'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+    - name: Build a source distribution and a wheel
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist
+
+  unix-test:
+    # This workflow only runs on the origin org
+    if: github.repository_owner == 'pystatgen'
+    needs: ['build']
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.7, 3.8, 3.9]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # checkout repo to subdirectory to get access to scripts
+      - uses: actions/checkout@v2
+        with:
+          path: sgkit-copy
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install wheel and test
+        run: |
+          python -VV
+          # Install the local wheel
+          wheel=$(ls artifact/sgkit-*.whl)
+          pip install ${wheel} ${wheel}[bgen] ${wheel}[plink] ${wheel}[vcf]
+          python sgkit-copy/.github/scripts/test_sgkit.py
+          python sgkit-copy/.github/scripts/test_sgkit_bgen.py
+          python sgkit-copy/.github/scripts/test_sgkit_plink.py
+          python sgkit-copy/.github/scripts/test_sgkit_vcf.py
+
+  # Windows doesn't support vcf
+  windows-test:
+    # This workflow only runs on the origin org
+    if: github.repository_owner == 'pystatgen'
+    runs-on: windows-latest
+    needs: ['build']
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+      # checkout repo to subdirectory to get access to scripts
+      - uses: actions/checkout@v2
+        with:
+          path: sgkit-copy
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install wheel and test
+        run: |
+          python -VV
+          # Install the local wheel
+          $env:wheel = $(ls artifact/sgkit-*.whl)
+          pip install $env:wheel "$env:wheel[bgen]" "$env:wheel[plink]"
+          python sgkit-copy/.github/scripts/test_sgkit.py
+          python sgkit-copy/.github/scripts/test_sgkit_bgen.py
+          python sgkit-copy/.github/scripts/test_sgkit_plink.py
+
+  pypi-upload:
+    if: github.repository_owner == 'pystatgen'
+    runs-on: ubuntu-latest
+    needs: ['unix-test', 'windows-test']
+    steps:
+      - name: Download all
+        uses: actions/download-artifact@v2
+      - name: Move to dist
+        run: |
+          mkdir dist
+          cp */*.{whl,gz} dist/.
+      - name: Publish package to TestPyPI
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish package to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,10 +28,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel
+        pip install setuptools twine wheel
     - name: Build a source distribution and a wheel
       run: |
         python setup.py sdist bdist_wheel
+        python -m twine check --strict dist/*
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 # Ignore VCF files during pytest collection, so it doesn't fail if cyvcf2 isn't installed.
-collect_ignore_glob = ["sgkit/io/vcf/*.py"]
+collect_ignore_glob = ["sgkit/io/vcf/*.py", ".github/scripts/*.py"]
 
 
 def pytest_configure(config) -> None:  # type: ignore


### PR DESCRIPTION
Fixes #606 

This workflow builds and tests wheels for each combination of the following (except VCF on Windows):
* IO: BGEN, PLINK, VCF
* Python: 3.7, 3.8, 3.9
* OS: Linux, MacOS, Windows

If successful it will push to test PyPi if the commit is tagged. I've tested this works by running it in the `test` branch in this repository. (See https://github.com/pystatgen/sgkit/runs/2830563755?check_suite_focus=true and https://test.pypi.org/project/sgkit/0.3.0a2/)

If there is no tag the wheels are still built and tested for every push to main - do we want that?