### PR TITLE
Remove dev numba from GPU CI

### DIFF
--- a/.github/workflows/build-gpu.yml
+++ b/.github/workflows/build-gpu.yml
@@ -34,10 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          conda install -c conda-forge gsl
-          conda install -c numba/label/dev numba
           conda install -c anaconda cudatoolkit
-
           pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Run GPU tagged tests


### PR DESCRIPTION
Fixes #612 

dev numba isn't required. Also, there was bug as in numba is installed via requirements.txt anyways.
The tests passes now: https://github.com/aktech/sgkit/runs/2856192741?check_suite_focus=true

@ravwojdyla 