### PR TITLE
Xarray consolidate metadata change

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -63,6 +63,9 @@ Similarly, the function :func:`sgkit.save_dataset` can be used to save the datas
 This can be used to save a newly-loaded dataset, or a dataset with new variables that are the
 result of running genetic methods on the data, so it can be loaded again later.
 
+By default, Zarr datasets created by sgkit (and Xarray) have `consolidated metadata <http://xarray.pydata.org/en/stable/user-guide/io.html#consolidated-metadata>`_,
+which makes opening the dataset faster.
+
 BGEN
 ----
 

--- a/sgkit/io/bgen/bgen_reader.py
+++ b/sgkit/io/bgen/bgen_reader.py
@@ -518,6 +518,8 @@ def rechunk_bgen(
         )
         rechunked.execute()
 
+    zarr.consolidate_metadata(output)
+
     ds: Dataset = xr.open_zarr(output, concat_characters=False)  # type: ignore[no-untyped-call]
     if pack:
         ds = unpack_variables(ds)

--- a/sgkit/io/utils.py
+++ b/sgkit/io/utils.py
@@ -74,14 +74,10 @@ def zarrs_to_dataset(
 
     datasets = []
     for path in urls:
-        try:
-            dataset = xr.open_zarr(  # type: ignore[no-untyped-call]
-                fsspec.get_mapper(path, **storage_options), concat_characters=False
-            )
-            datasets.append(dataset)
-        except zarr.errors.GroupNotFoundError:
-            # ignore empty directory, occurs if no variants in region
-            pass
+        dataset = xr.open_zarr(  # type: ignore[no-untyped-call]
+            fsspec.get_mapper(path, **storage_options), concat_characters=False
+        )
+        datasets.append(dataset)
 
     # Combine the datasets into one
     ds = xr.concat(datasets, dim="variants", data_vars="minimal")

--- a/sgkit/io/vcf/utils.py
+++ b/sgkit/io/vcf/utils.py
@@ -19,16 +19,23 @@ def ceildiv(a: int, b: int) -> int:
     return -(-a // b)
 
 
-# https://dev.to/orenovadia/solution-chunked-iterator-python-riddle-3ple
+# Based on https://dev.to/orenovadia/solution-chunked-iterator-python-riddle-3ple
 def chunks(iterator: Iterator[T], n: int) -> Iterator[Iterator[T]]:
     """
     Convert an iterator into an iterator of iterators, where the inner iterators
     each return `n` items, except the last, which may return fewer.
+
+    For the special case of an empty iterator, an iterator of an empty iterator is
+    returned.
     """
 
+    empty_iterator = True
     for first in iterator:  # take one item out (exits loop if `iterator` is empty)
+        empty_iterator = False
         rest_of_chunk = itertools.islice(iterator, 0, n - 1)
         yield itertools.chain([first], rest_of_chunk)  # concatenate the first item back
+    if empty_iterator:
+        yield iter([])
 
 
 def get_file_length(

--- a/sgkit/io/vcfzarr_reader.py
+++ b/sgkit/io/vcfzarr_reader.py
@@ -340,6 +340,9 @@ def _concat_zarrs_optimized(
         # copy top-level attributes
         output_zarr.attrs.update(first_zarr_group.attrs)
 
+    # consolidate metadata
+    zarr.consolidate_metadata(str(output))
+
 
 def _to_zarr(  # type: ignore[no-untyped-def]
     arr,

--- a/sgkit/tests/io/vcf/test_utils.py
+++ b/sgkit/tests/io/vcf/test_utils.py
@@ -6,7 +6,7 @@ import fsspec
 import pytest
 from callee.strings import StartsWith
 
-from sgkit.io.vcf.utils import build_url, temporary_directory
+from sgkit.io.vcf.utils import build_url, chunks, temporary_directory
 
 
 def directory_with_file_scheme() -> str:
@@ -89,3 +89,19 @@ def test_build_url():
         build_url("http://host/a%20path", "subpath") == "http://host/a%20path/subpath"
     )
     assert build_url("http://host/a path", "subpath") == "http://host/a%20path/subpath"
+
+
+@pytest.mark.parametrize(
+    "x,n,expected_values",
+    [
+        (0, 1, [[]]),
+        (1, 1, [[0]]),
+        (4, 1, [[0], [1], [2], [3]]),
+        (4, 2, [[0, 1], [2, 3]]),
+        (5, 2, [[0, 1], [2, 3], [4]]),
+        (5, 5, [[0, 1, 2, 3, 4]]),
+        (5, 6, [[0, 1, 2, 3, 4]]),
+    ],
+)
+def test_chunks(x, n, expected_values):
+    assert [list(i) for i in chunks(iter(range(x)), n)] == expected_values

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -206,6 +206,29 @@ def test_vcf_to_zarr__parallel(shared_datadir, is_path, tmp_path):
 
 @pytest.mark.parametrize(
     "is_path",
+    [True, False],
+)
+def test_vcf_to_zarr__empty_region(shared_datadir, is_path, tmp_path):
+    path = path_for_test(shared_datadir, "CEUTrio.20.21.gatk3.4.g.vcf.bgz", is_path)
+    output = tmp_path.joinpath("vcf_concat.zarr").as_posix()
+    regions = "23"
+
+    vcf_to_zarr(path, output, regions=regions)
+    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+
+    assert ds["sample_id"].shape == (1,)
+    assert ds["call_genotype"].shape == (0, 1, 2)
+    assert ds["call_genotype_mask"].shape == (0, 1, 2)
+    assert ds["call_genotype_phased"].shape == (0, 1)
+    assert ds["variant_allele"].shape == (0, 4)
+    assert ds["variant_contig"].shape == (0,)
+    assert ds["variant_id"].shape == (0,)
+    assert ds["variant_id_mask"].shape == (0,)
+    assert ds["variant_position"].shape == (0,)
+
+
+@pytest.mark.parametrize(
+    "is_path",
     [False],
 )
 def test_vcf_to_zarr__parallel_temp_chunk_length(shared_datadir, is_path, tmp_path):

--- a/sgkit/tests/test_regenie.py
+++ b/sgkit/tests/test_regenie.py
@@ -243,7 +243,7 @@ def check_simulation_result(
 
     # Load simulated data
     with zarr.ZipStore(str(dataset_dir / "genotypes.zarr.zip"), mode="r") as store:
-        ds = xr.open_zarr(store)  # type: ignore[no-untyped-call]
+        ds = xr.open_zarr(store, consolidated=False)  # type: ignore[no-untyped-call]
         df_covariate = load_covariates(dataset_dir)
         df_trait = load_traits(dataset_dir)
         contigs = ds["variant_contig"].values


### PR DESCRIPTION
Fixes #615.

This uncovered a bug, where VCF part files with no variants were not being written, which manifested as an error with the new version of Xarray when it tried to consolidate their metadata. This change includes a fix so that empty part files are written (containing zero variants).