### PR TITLE
Issue a warning if the number of alt alleles exceeds the maximum specified

### DIFF
--- a/sgkit/io/utils.py
+++ b/sgkit/io/utils.py
@@ -100,6 +100,11 @@ def zarrs_to_dataset(
             ds[variable_name] = ds[variable_name].astype(f"S{max_length}")
             del ds.attrs[attr]
 
+    if "max_alt_alleles_seen" in datasets[0].attrs:
+        ds.attrs["max_alt_alleles_seen"] = max(
+            ds.attrs["max_alt_alleles_seen"] for ds in datasets
+        )
+
     return ds
 
 

--- a/sgkit/io/vcf/__init__.py
+++ b/sgkit/io/vcf/__init__.py
@@ -3,9 +3,10 @@ import platform
 try:
     from ..utils import zarrs_to_dataset
     from .vcf_partition import partition_into_regions
-    from .vcf_reader import vcf_to_zarr, vcf_to_zarrs
+    from .vcf_reader import MaxAltAllelesExceededWarning, vcf_to_zarr, vcf_to_zarrs
 
     __all__ = [
+        "MaxAltAllelesExceededWarning",
         "partition_into_regions",
         "vcf_to_zarr",
         "vcf_to_zarrs",

--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -615,7 +615,8 @@ def vcf_to_zarrs(
         specified ploidy will raise an exception.
     max_alt_alleles
         The (maximum) number of alternate alleles in the VCF file. Any records with more than
-        this number of alternate alleles will have the extra alleles dropped.
+        this number of alternate alleles will have the extra alleles dropped (the `variant_allele`
+        variable will be truncated). Call genotype fields will however be unaffected.
     fields
         Extra fields to extract data for. A list of strings, with ``INFO`` or ``FORMAT`` prefixes.
         Wildcards are permitted too, for example: ``["INFO/*", "FORMAT/DP"]``.
@@ -782,7 +783,8 @@ def vcf_to_zarr(
         specified ploidy will raise an exception.
     max_alt_alleles
         The (maximum) number of alternate alleles in the VCF file. Any records with more than
-        this number of alternate alleles will have the extra alleles dropped.
+        this number of alternate alleles will have the extra alleles dropped (the `variant_allele`
+        variable will be truncated). Call genotype fields will however be unaffected.
     fields
         Extra fields to extract data for. A list of strings, with ``INFO`` or ``FORMAT`` prefixes.
         Wildcards are permitted too, for example: ``["INFO/*", "FORMAT/DP"]``.

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -103,7 +103,10 @@ def test_vcf_to_zarr__max_alt_alleles(shared_datadir, is_path, tmp_path):
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
     with pytest.warns(MaxAltAllelesExceededWarning):
-        vcf_to_zarr(path, output, chunk_length=5, chunk_width=2, max_alt_alleles=1)
+        max_alt_alleles = 1
+        vcf_to_zarr(
+            path, output, chunk_length=5, chunk_width=2, max_alt_alleles=max_alt_alleles
+        )
         ds = xr.open_zarr(output)
 
         # extra alt alleles are dropped
@@ -121,6 +124,9 @@ def test_vcf_to_zarr__max_alt_alleles(shared_datadir, is_path, tmp_path):
                 ["AC", "A"],
             ],
         )
+
+        # genotype calls are truncated
+        assert np.all(ds["call_genotype"].values <= max_alt_alleles)
 
         # the maximum number of alt alleles actually seen is stored as an attribute
         assert ds.attrs["max_alt_alleles_seen"] == 3

--- a/sgkit/tests/io/vcf/test_vcf_roundtrip.py
+++ b/sgkit/tests/io/vcf/test_vcf_roundtrip.py
@@ -79,6 +79,7 @@ def test_default_fields(shared_datadir, tmpdir):
     sg_vcfzarr_path = create_sg_vcfzarr(shared_datadir, tmpdir)
     sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
     sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel
+    del sg_ds.attrs["max_alt_alleles_seen"]  # not saved by scikit-allel
 
     assert_identical(allel_ds, sg_ds)
 
@@ -107,6 +108,7 @@ def test_DP_field(shared_datadir, tmpdir):
     )
     sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
     sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel
+    del sg_ds.attrs["max_alt_alleles_seen"]  # not saved by scikit-allel
 
     assert_identical(allel_ds, sg_ds)
 
@@ -120,6 +122,7 @@ def test_DP_field(shared_datadir, tmpdir):
         ("CEUTrio.20.21.gatk3.4.g.vcf.bgz", ["calldata/PL"], ["FORMAT/PL"]),
     ],
 )
+@pytest.mark.filterwarnings("ignore::sgkit.io.vcf.MaxAltAllelesExceededWarning")
 def test_all_fields(
     shared_datadir, tmpdir, vcf_file, allel_exclude_fields, sgkit_exclude_fields
 ):
@@ -159,6 +162,7 @@ def test_all_fields(
     )
     sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
     sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel
+    del sg_ds.attrs["max_alt_alleles_seen"]  # not saved by scikit-allel
 
     # scikit-allel only records contigs for which there are actual variants,
     # whereas sgkit records contigs from the header

--- a/sgkit/tests/io/vcf/test_vcf_roundtrip.py
+++ b/sgkit/tests/io/vcf/test_vcf_roundtrip.py
@@ -114,17 +114,23 @@ def test_DP_field(shared_datadir, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "vcf_file,allel_exclude_fields,sgkit_exclude_fields",
+    "vcf_file,allel_exclude_fields,sgkit_exclude_fields,max_alt_alleles",
     [
-        ("sample.vcf.gz", None, None),
-        ("mixed.vcf.gz", None, None),
+        ("sample.vcf.gz", None, None, 3),
+        ("mixed.vcf.gz", None, None, 3),
         # exclude PL since it has Number=G, which is not yet supported
-        ("CEUTrio.20.21.gatk3.4.g.vcf.bgz", ["calldata/PL"], ["FORMAT/PL"]),
+        # increase max_alt_alleles since scikit-allel does not truncate genotype calls
+        ("CEUTrio.20.21.gatk3.4.g.vcf.bgz", ["calldata/PL"], ["FORMAT/PL"], 7),
     ],
 )
 @pytest.mark.filterwarnings("ignore::sgkit.io.vcf.MaxAltAllelesExceededWarning")
 def test_all_fields(
-    shared_datadir, tmpdir, vcf_file, allel_exclude_fields, sgkit_exclude_fields
+    shared_datadir,
+    tmpdir,
+    vcf_file,
+    allel_exclude_fields,
+    sgkit_exclude_fields,
+    max_alt_alleles,
 ):
     # change scikit-allel type defaults back to the VCF default
     types = {
@@ -140,6 +146,7 @@ def test_all_fields(
         fields=["*"],
         exclude_fields=allel_exclude_fields,
         types=types,
+        alt_number=max_alt_alleles,
     )
 
     field_defs = {
@@ -159,6 +166,7 @@ def test_all_fields(
         exclude_fields=sgkit_exclude_fields,
         field_defs=field_defs,
         truncate_calls=True,
+        max_alt_alleles=max_alt_alleles,
     )
     sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
     sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel


### PR DESCRIPTION
Fixes #487. The maximum number of alleles found while parsing is stored in `ds.attrs["max_alt_alleles_seen"]` (in all cases).