### PR TITLE
Make VCF genotypes optional

### DIFF
--- a/sgkit/model.py
+++ b/sgkit/model.py
@@ -20,10 +20,9 @@ def create_genotype_call_dataset(
     variant_position: ArrayLike,
     variant_allele: ArrayLike,
     sample_id: ArrayLike,
-    call_genotype: ArrayLike,
+    call_genotype: Optional[ArrayLike] = None,
     call_genotype_phased: Optional[ArrayLike] = None,
     variant_id: Optional[ArrayLike] = None,
-    mixed_ploidy: bool = False,
 ) -> xr.Dataset:
     """Create a dataset of genotype calls.
 
@@ -53,9 +52,6 @@ def create_genotype_call_dataset(
     variant_id
         [array_like, element type: str or object, optional]
         The unique identifier of the variant.
-    mixed_ploidy
-        Specify if the dataset contains genotype calls with a mixture of ploidy levels
-        using the value -2 to indicate non-alleles.
 
     Returns
     -------
@@ -66,25 +62,21 @@ def create_genotype_call_dataset(
         "variant_position": ([DIM_VARIANT], variant_position),
         "variant_allele": ([DIM_VARIANT, DIM_ALLELE], variant_allele),
         "sample_id": ([DIM_SAMPLE], sample_id),
-        "call_genotype": (
+    }
+    if call_genotype is not None:
+        data_vars["call_genotype"] = (
             [DIM_VARIANT, DIM_SAMPLE, DIM_PLOIDY],
             call_genotype,
-            {"mixed_ploidy": mixed_ploidy},
-        ),
-        "call_genotype_mask": (
+            {"mixed_ploidy": False},
+        )
+        data_vars["call_genotype_mask"] = (
             [DIM_VARIANT, DIM_SAMPLE, DIM_PLOIDY],
             call_genotype < 0,
-        ),
-    }
+        )
     if call_genotype_phased is not None:
         data_vars["call_genotype_phased"] = (
             [DIM_VARIANT, DIM_SAMPLE],
             call_genotype_phased,
-        )
-    if mixed_ploidy is True:
-        data_vars["call_genotype_non_allele"] = (
-            [DIM_VARIANT, DIM_SAMPLE, DIM_PLOIDY],
-            call_genotype < -1,
         )
     if variant_id is not None:
         data_vars["variant_id"] = ([DIM_VARIANT], variant_id)

--- a/sgkit/tests/io/vcf/data/no_genotypes_with_gt_header.vcf
+++ b/sgkit/tests/io/vcf/data/no_genotypes_with_gt_header.vcf
@@ -1,0 +1,113 @@
+##fileformat=VCFv4.1
+##contig=<ID=1,length=249250621,assembly=b37>
+##contig=<ID=10,length=135534747,assembly=b37>
+##contig=<ID=11,length=135006516,assembly=b37>
+##contig=<ID=12,length=133851895,assembly=b37>
+##contig=<ID=13,length=115169878,assembly=b37>
+##contig=<ID=14,length=107349540,assembly=b37>
+##contig=<ID=15,length=102531392,assembly=b37>
+##contig=<ID=16,length=90354753,assembly=b37>
+##contig=<ID=17,length=81195210,assembly=b37>
+##contig=<ID=18,length=78077248,assembly=b37>
+##contig=<ID=19,length=59128983,assembly=b37>
+##contig=<ID=2,length=243199373,assembly=b37>
+##contig=<ID=20,length=63025520,assembly=b37>
+##contig=<ID=21,length=48129895,assembly=b37>
+##contig=<ID=22,length=51304566,assembly=b37>
+##contig=<ID=3,length=198022430,assembly=b37>
+##contig=<ID=4,length=191154276,assembly=b37>
+##contig=<ID=5,length=180915260,assembly=b37>
+##contig=<ID=6,length=171115067,assembly=b37>
+##contig=<ID=7,length=159138663,assembly=b37>
+##contig=<ID=8,length=146364022,assembly=b37>
+##contig=<ID=9,length=141213431,assembly=b37>
+##contig=<ID=GL000191.1,length=106433,assembly=b37>
+##contig=<ID=GL000192.1,length=547496,assembly=b37>
+##contig=<ID=GL000193.1,length=189789,assembly=b37>
+##contig=<ID=GL000194.1,length=191469,assembly=b37>
+##contig=<ID=GL000195.1,length=182896,assembly=b37>
+##contig=<ID=GL000196.1,length=38914,assembly=b37>
+##contig=<ID=GL000197.1,length=37175,assembly=b37>
+##contig=<ID=GL000198.1,length=90085,assembly=b37>
+##contig=<ID=GL000199.1,length=169874,assembly=b37>
+##contig=<ID=GL000200.1,length=187035,assembly=b37>
+##contig=<ID=GL000201.1,length=36148,assembly=b37>
+##contig=<ID=GL000202.1,length=40103,assembly=b37>
+##contig=<ID=GL000203.1,length=37498,assembly=b37>
+##contig=<ID=GL000204.1,length=81310,assembly=b37>
+##contig=<ID=GL000205.1,length=174588,assembly=b37>
+##contig=<ID=GL000206.1,length=41001,assembly=b37>
+##contig=<ID=GL000207.1,length=4262,assembly=b37>
+##contig=<ID=GL000208.1,length=92689,assembly=b37>
+##contig=<ID=GL000209.1,length=159169,assembly=b37>
+##contig=<ID=GL000210.1,length=27682,assembly=b37>
+##contig=<ID=GL000211.1,length=166566,assembly=b37>
+##contig=<ID=GL000212.1,length=186858,assembly=b37>
+##contig=<ID=GL000213.1,length=164239,assembly=b37>
+##contig=<ID=GL000214.1,length=137718,assembly=b37>
+##contig=<ID=GL000215.1,length=172545,assembly=b37>
+##contig=<ID=GL000216.1,length=172294,assembly=b37>
+##contig=<ID=GL000217.1,length=172149,assembly=b37>
+##contig=<ID=GL000218.1,length=161147,assembly=b37>
+##contig=<ID=GL000219.1,length=179198,assembly=b37>
+##contig=<ID=GL000220.1,length=161802,assembly=b37>
+##contig=<ID=GL000221.1,length=155397,assembly=b37>
+##contig=<ID=GL000222.1,length=186861,assembly=b37>
+##contig=<ID=GL000223.1,length=180455,assembly=b37>
+##contig=<ID=GL000224.1,length=179693,assembly=b37>
+##contig=<ID=GL000225.1,length=211173,assembly=b37>
+##contig=<ID=GL000226.1,length=15008,assembly=b37>
+##contig=<ID=GL000227.1,length=128374,assembly=b37>
+##contig=<ID=GL000228.1,length=129120,assembly=b37>
+##contig=<ID=GL000229.1,length=19913,assembly=b37>
+##contig=<ID=GL000230.1,length=43691,assembly=b37>
+##contig=<ID=GL000231.1,length=27386,assembly=b37>
+##contig=<ID=GL000232.1,length=40652,assembly=b37>
+##contig=<ID=GL000233.1,length=45941,assembly=b37>
+##contig=<ID=GL000234.1,length=40531,assembly=b37>
+##contig=<ID=GL000235.1,length=34474,assembly=b37>
+##contig=<ID=GL000236.1,length=41934,assembly=b37>
+##contig=<ID=GL000237.1,length=45867,assembly=b37>
+##contig=<ID=GL000238.1,length=39939,assembly=b37>
+##contig=<ID=GL000239.1,length=33824,assembly=b37>
+##contig=<ID=GL000240.1,length=41933,assembly=b37>
+##contig=<ID=GL000241.1,length=42152,assembly=b37>
+##contig=<ID=GL000242.1,length=43523,assembly=b37>
+##contig=<ID=GL000243.1,length=43341,assembly=b37>
+##contig=<ID=GL000244.1,length=39929,assembly=b37>
+##contig=<ID=GL000245.1,length=36651,assembly=b37>
+##contig=<ID=GL000246.1,length=38154,assembly=b37>
+##contig=<ID=GL000247.1,length=36422,assembly=b37>
+##contig=<ID=GL000248.1,length=39786,assembly=b37>
+##contig=<ID=GL000249.1,length=38502,assembly=b37>
+##contig=<ID=MT,length=16569,assembly=b37>
+##contig=<ID=X,length=155270560,assembly=b37>
+##contig=<ID=Y,length=59373566,assembly=b37>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	100	a	G	A	232.46	PASS	.
+1	199	b	GG	G	232.46	PASS	.
+1	200	c	G	A	232.46	PASS	.
+1	203	d	GGGG	G	232.46	PASS	.
+1	280	e	G	A	232.46	PASS	.
+1	284	f	GGG	G	232.46	PASS	.
+1	285	g	G	A	232.46	PASS	.
+1	286	h	G	A	232.46	PASS	.
+1	999	i	G	A	232.46	PASS	.
+1	1000	j	G	A	232.46	PASS	.
+1	1000	k	GGGG	G	232.46	PASS	.
+1	1076	l	G	A	232.46	PASS	.
+1	1150	m	G	A	232.46	PASS	.
+1	1176	n	G	A	232.46	PASS	.
+2	200	o	G	A	232.46	PASS	.
+2	525	p	G	A	232.46	PASS	.
+2	548	q	GGG	G	232.46	PASS	.
+2	640	r	G	A	232.46	PASS	.
+2	700	s	G	A	232.46	PASS	.
+3	1	t	G	A	232.46	PASS	.
+3	300	u	G	A	232.46	PASS	.
+3	300	v	GGGG	G	232.46	PASS	.
+3	400	w	G	A	232.46	PASS	.
+4	600	x	G	A	232.46	PASS	.
+4	775	y	G	A	232.46	PASS	.
+4	776	z	GGGG	G	232.46	PASS	.

--- a/sgkit/tests/io/vcf/test_vcf_roundtrip.py
+++ b/sgkit/tests/io/vcf/test_vcf_roundtrip.py
@@ -103,7 +103,7 @@ def test_DP_field(shared_datadir, tmpdir):
     allel_ds = sg.read_vcfzarr(allel_vcfzarr_path)
 
     sg_vcfzarr_path = create_sg_vcfzarr(
-        shared_datadir, tmpdir, fields=["INFO/DP", "FORMAT/DP"]
+        shared_datadir, tmpdir, fields=["INFO/DP", "FORMAT/DP", "FORMAT/GT"]
     )
     sg_ds = sg.load_dataset(str(sg_vcfzarr_path))
     sg_ds = sg_ds.drop_vars("call_genotype_phased")  # not included in scikit-allel

--- a/sgkit/tests/test_variables.py
+++ b/sgkit/tests/test_variables.py
@@ -32,7 +32,7 @@ def test_variables__no_spec(dummy_ds: xr.Dataset) -> None:
 
 
 def test_variables__validate_by_name(dummy_ds: xr.Dataset) -> None:
-    spec = ArrayLikeSpec("foo", kind="i", ndim=1)
+    spec = ArrayLikeSpec("foo", "foo doc", kind="i", ndim=1)
     try:
         assert "foo" not in SgkitVariables.registered_variables
         name, spec_b = SgkitVariables.register_variable(spec)
@@ -46,30 +46,30 @@ def test_variables__validate_by_name(dummy_ds: xr.Dataset) -> None:
 
 
 def test_variables__validate_by_dummy_spec(dummy_ds: xr.Dataset) -> None:
-    spec = ArrayLikeSpec("foo", kind="i", ndim=1)
+    spec = ArrayLikeSpec("foo", "foo doc", kind="i", ndim=1)
     variables.validate(dummy_ds, spec)
 
 
 def test_variables__invalid_spec_fails(dummy_ds: xr.Dataset) -> None:
-    invalid_spec = ArrayLikeSpec("foo", kind="i", ndim=2)
+    invalid_spec = ArrayLikeSpec("foo", "foo doc", kind="i", ndim=2)
     with pytest.raises(ValueError, match="foo does not match the spec"):
         variables.validate(dummy_ds, invalid_spec)
 
 
 def test_variables__alternative_names(dummy_ds: xr.Dataset) -> None:
-    spec = ArrayLikeSpec("baz", kind="i", ndim=1)
+    spec = ArrayLikeSpec("baz", "baz doc", kind="i", ndim=1)
     variables.validate(dummy_ds, {"foo": spec, "bar": spec})
 
 
 def test_variables__no_present_in_ds(dummy_ds: xr.Dataset) -> None:
-    spec = ArrayLikeSpec("baz", kind="i", ndim=1)
+    spec = ArrayLikeSpec("baz", "baz doc", kind="i", ndim=1)
     with pytest.raises(ValueError, match="foobarbaz not present in"):
         variables.validate(dummy_ds, {"foobarbaz": spec})
 
 
 def test_variables__multiple_specs(dummy_ds: xr.Dataset) -> None:
-    spec = ArrayLikeSpec("baz", kind="i", ndim=1)
-    invalid_spec = ArrayLikeSpec("baz", kind="i", ndim=2)
+    spec = ArrayLikeSpec("baz", "baz doc", kind="i", ndim=1)
+    invalid_spec = ArrayLikeSpec("baz", "baz doc", kind="i", ndim=2)
     variables.validate(dummy_ds, {"foo": spec, "bar": spec})
     variables.validate(dummy_ds, {"foo": spec})
     variables.validate(dummy_ds, {"bar": spec})
@@ -80,8 +80,8 @@ def test_variables__multiple_specs(dummy_ds: xr.Dataset) -> None:
 
 
 def test_variables__whole_ds(dummy_ds: xr.Dataset) -> None:
-    spec_foo = ArrayLikeSpec("foo", kind="i", ndim=1)
-    spec_bar = ArrayLikeSpec("bar", kind="i", ndim=1)
+    spec_foo = ArrayLikeSpec("foo", "foo doc", kind="i", ndim=1)
+    spec_bar = ArrayLikeSpec("bar", "bar doc", kind="i", ndim=1)
     try:
         SgkitVariables.register_variable(spec_foo)
         with pytest.raises(ValueError, match="`foo` already registered"):
@@ -97,5 +97,5 @@ def test_variables_in_multi_index(dummy_ds: xr.Dataset) -> None:
     # create a multi index
     ds = dummy_ds.set_index({"ind": ("foo", "bar")})
 
-    spec = ArrayLikeSpec("foo", kind="i", ndim=1)
+    spec = ArrayLikeSpec("foo", "foo doc", kind="i", ndim=1)
     variables.validate(ds, spec)

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -1,7 +1,6 @@
-import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import Dict, Hashable, Mapping, Optional, Set, Tuple, Union, overload
+from typing import Dict, Hashable, Mapping, Set, Tuple, Union, overload
 
 import xarray as xr
 
@@ -13,7 +12,7 @@ class Spec:
     """Root type Spec"""
 
     default_name: str
-    __doc__: Optional[str] = dataclasses.field(default=None, repr=False)
+    __doc__: str
 
     # Note: we want to prevent dev/users from mistakenly
     #       using Spec as a hashable obj in dict, xr.Dataset


### PR DESCRIPTION
Fixes #618 

This change makes it possible to load GWAS summary statistics (#440) from https://github.com/MRCIEU/pygwasvcf/blob/master/tests/data/:

```
>>> import sgkit as sg
>>> from sgkit.io.vcf import vcf_to_zarr
>>> vcf_to_zarr("case.control.example.vcf.gz", "case.control.example.zarr", max_alt_alleles=1, fields=["INFO/*", "FORMAT/*"])
>>> ds = sg.load_dataset("case.control.example.zarr")
>>> ds.load()
<xarray.Dataset>
Dimensions:           (alleles: 2, alt_alleles: 1, samples: 1, variants: 72)
Dimensions without coordinates: alleles, alt_alleles, samples, variants
Data variables: (12/15)
    call_AF           (variants, samples, alt_alleles) float32 0.6238 ... 0.1296
    call_ES           (variants, samples, alt_alleles) float32 -8.975e-07 ......
    call_EZ           (variants, samples, alt_alleles) float32 nan nan ... nan
    call_ID           (variants, samples) object 'rs10399793' ... 'rs60320384'
    call_LP           (variants, samples, alt_alleles) float32 0.01773 ... 1.004
    call_NC           (variants, samples, alt_alleles) float32 nan nan ... nan
    ...                ...
    sample_id         (samples) <U11 'UKB-b:13008'
    variant_allele    (variants, alleles) object 'T' 'C' 'C' 'T' ... 'T' 'C' 'G'
    variant_contig    (variants) int8 0 0 0 0 0 0 0 0 0 0 ... 0 0 0 0 0 0 0 0 0
    variant_id        (variants) object '.' '.' '.' '.' '.' ... '.' '.' '.' '.'
    variant_id_mask   (variants) bool True True True True ... True True True
    variant_position  (variants) int32 49298 54676 86028 ... 768819 769223
Attributes:
    contigs:  ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12',...
```