### PR TITLE
Exclude fsspec versions causing intermittant test failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ scipy
 typing-extensions
 numba
 zarr
-fsspec
+fsspec != 2021.6.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     zarr
     numba
     typing-extensions
-    fsspec
+    fsspec != 2021.6.*
     setuptools >= 41.2  # For pkg_resources
 setup_requires =
     setuptools >= 41.2


### PR DESCRIPTION
Fixes #617 until the next release of fsspec which should contain a fix for the underlying issue (see linked issue in #617)