### PR TITLE
Fix type checking errors as a result of using NumPy 1.21.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -147,6 +147,7 @@ ignore_missing_imports = True
 [mypy-sgkit.*]
 allow_redefinition = True
 [mypy-sgkit.*.tests.*]
+disallow_untyped_calls = False
 disallow_untyped_defs = False
 disallow_untyped_decorators = False
 [mypy-validation.*]

--- a/sgkit/io/bgen/bgen_reader.py
+++ b/sgkit/io/bgen/bgen_reader.py
@@ -23,6 +23,7 @@ import pandas as pd
 import xarray as xr
 import zarr
 from cbgen import bgen_file, bgen_metafile
+from numpy.typing import NDArray
 from rechunker import api as rechunker_api
 from xarray import Dataset
 
@@ -92,7 +93,7 @@ class BgenReader:
         self.precision = 64 if self.dtype.itemsize >= 8 else 32
         self.ndim = 3
 
-    def __getitem__(self, idx: Any) -> np.ndarray:
+    def __getitem__(self, idx: Any) -> NDArray[Any]:
         if not isinstance(idx, tuple):
             raise IndexError(f"Indexer must be tuple (received {type(idx)})")
         if len(idx) != self.ndim:
@@ -326,7 +327,7 @@ def _default_sample_ids(path: PathType) -> ArrayLike:
         if bgen.contain_samples:
             return bgen.read_samples()
         else:
-            return np.char.add(b"sample_", np.arange(bgen.nsamples).astype("S"))
+            return np.char.add(b"sample_", np.arange(bgen.nsamples).astype("S"))  # type: ignore[no-untyped-call]
 
 
 def _to_dosage(probs: ArrayLike) -> ArrayLike:

--- a/sgkit/io/plink/plink_reader.py
+++ b/sgkit/io/plink/plink_reader.py
@@ -7,6 +7,7 @@ import dask.dataframe as dd
 import numpy as np
 from bed_reader import open_bed
 from dask.dataframe import DataFrame
+from numpy.typing import NDArray
 from xarray import Dataset
 
 from sgkit import create_genotype_call_dataset
@@ -62,7 +63,7 @@ class BedReader(object):
         self.dtype = dtype
         self.ndim = 3
 
-    def __getitem__(self, idx: Tuple[Any, ...]) -> np.ndarray:
+    def __getitem__(self, idx: Tuple[Any, ...]) -> NDArray[Any]:
         if not isinstance(idx, tuple):
             raise IndexError(  # pragma: no cover
                 f"Indexer must be tuple (received {type(idx)})"

--- a/sgkit/io/utils.py
+++ b/sgkit/io/utils.py
@@ -30,12 +30,12 @@ def dataframe_to_dict(
     return arrs
 
 
-def encode_contigs(contig: ArrayLike) -> Tuple[np.ndarray, np.ndarray]:
+def encode_contigs(contig: ArrayLike) -> Tuple[ArrayLike, ArrayLike]:
     # TODO: test preservation of int16
     # If contigs are already integers, use them as-is
     if np.issubdtype(contig.dtype, np.integer):
         ids = contig
-        names = np.unique(np.asarray(ids)).astype(str)
+        names = np.unique(np.asarray(ids)).astype(str)  # type: ignore[no-untyped-call]
     # Otherwise create index for contig names based
     # on order of appearance in underlying file
     else:
@@ -149,7 +149,7 @@ def concatenate_and_rechunk(
         )
 
     lengths = np.array([z.shape[0] for z in zarrs])
-    lengths0 = np.insert(lengths, 0, 0, axis=0)
+    lengths0 = np.insert(lengths, 0, 0, axis=0)  # type: ignore[no-untyped-call]
     offsets = np.cumsum(lengths0)
     total_length = offsets[-1]
 
@@ -197,7 +197,7 @@ def _slice_zarrs(
         if stop > offsets[i1]:
             slices.append((i1, slice(0, stop - offsets[i1])))
         parts = [zarrs[i][(sel, *locs[1:])] for (i, sel) in slices]
-        return np.concatenate(parts)
+        return np.concatenate(parts)  # type: ignore[no-untyped-call]
 
 
 def str_is_int(x: str) -> bool:

--- a/sgkit/io/vcf/vcf_partition.py
+++ b/sgkit/io/vcf/vcf_partition.py
@@ -158,10 +158,10 @@ def partition_into_regions(
     ind = np.searchsorted(file_offsets, part_lengths)
 
     # Drop any parts that are greater than the file offsets (these will be covered by a region with no end)
-    ind = np.delete(ind, ind >= len(file_offsets))
+    ind = np.delete(ind, ind >= len(file_offsets))  # type: ignore[no-untyped-call]
 
     # Drop any duplicates
-    ind = np.unique(ind)
+    ind = np.unique(ind)  # type: ignore[no-untyped-call]
 
     # Calculate region contig and start for each index
     region_contigs = region_contig_indexes[ind]

--- a/sgkit/stats/hwe.py
+++ b/sgkit/stats/hwe.py
@@ -3,7 +3,7 @@ from typing import Hashable, Optional
 import dask.array as da
 import numpy as np
 from numba import njit
-from numpy import ndarray
+from numpy.typing import NDArray
 from xarray import Dataset
 
 from sgkit import variables
@@ -104,8 +104,8 @@ hardy_weinberg_p_value_jit = njit(hardy_weinberg_p_value, fastmath=True, nogil=T
 
 
 def hardy_weinberg_p_value_vec(
-    obs_hets: ndarray, obs_hom1: ndarray, obs_hom2: ndarray
-) -> ndarray:
+    obs_hets: NDArray[np.int_], obs_hom1: NDArray[np.int_], obs_hom2: NDArray[np.int_]
+) -> NDArray[np.float64]:
     arrs = [obs_hets, obs_hom1, obs_hom2]
     if len(set(map(len, arrs))) != 1:
         raise ValueError("All arrays must have same length")

--- a/sgkit/stats/ld.py
+++ b/sgkit/stats/ld.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Hashable, List, Optional
+from typing import Any, Hashable, List, Optional, Tuple
 
 import dask
 import dask.array as da
@@ -155,7 +155,7 @@ def ld_matrix(
         chunk_window_stops = rel_window_stops[
             chunk_offset_index_start:chunk_offset_index_stop
         ]
-        max_stop = np.max(chunk_window_stops) if len(chunk_window_stops) > 0 else 0
+        max_stop = np.max(chunk_window_stops) if len(chunk_window_stops) > 0 else 0  # type: ignore[no-untyped-call]
         abs_chunk_start = chunk_starts[chunk_index]
         abs_chunk_end = abs_chunk_start + max_stop  # this may extend into later chunks
         block_x = x[abs_chunk_start:abs_chunk_end]
@@ -188,7 +188,11 @@ def ld_matrix(
             threshold=threshold,
             scores=block_scores,
         )
-        meta = [("i", index_dtype), ("j", index_dtype), ("value", value_dtype)]
+        meta: List[Tuple[str, DType]] = [
+            ("i", index_dtype),
+            ("j", index_dtype),
+            ("value", value_dtype),
+        ]
         if scores is not None:
             meta.append(("cmp", np.int8))
         return dd.from_delayed([f], meta=meta)

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -789,7 +789,7 @@ def _Garud_h_cohorts(
     # transpose to hash columns (haplotypes)
     haplotypes = hash_array(gt.transpose()).transpose().flatten()
     arr = np.full((n_cohorts, N_GARUD_H_STATS), np.nan)
-    for c in np.nditer(ct):
+    for c in np.nditer(ct):  # type: ignore[attr-defined]
         arr[c, :] = _Garud_h(haplotypes[sample_cohort == c])
     return arr
 

--- a/sgkit/stats/utils.py
+++ b/sgkit/stats/utils.py
@@ -68,7 +68,7 @@ def r2_score(YP: ArrayLike, YT: ArrayLike) -> ArrayLike:
         R2 scores array with shape equal to all leading
         (i.e. batch) dimensions of the provided arrays.
     """
-    YP, YT = np.broadcast_arrays(YP, YT)
+    YP, YT = np.broadcast_arrays(YP, YT)  # type: ignore[no-untyped-call]
     tot = np.power(YT - YT.mean(axis=-1, keepdims=True), 2)
     tot = tot.sum(axis=-1, keepdims=True)
     res = np.power(YT - YP, 2)

--- a/sgkit/testing.py
+++ b/sgkit/testing.py
@@ -70,8 +70,8 @@ def simulate_genotype_call_dataset(
 
     contig_size = split_array_chunks(n_variant, n_contig)
     contig = np.repeat(np.arange(n_contig), contig_size)
-    contig_names = np.unique(contig).tolist()
-    position = np.concatenate([np.arange(contig_size[i]) for i in range(n_contig)])
+    contig_names = np.unique(contig).tolist()  # type: ignore[no-untyped-call]
+    position = np.concatenate([np.arange(contig_size[i]) for i in range(n_contig)])  # type: ignore[no-untyped-call]
     assert position.size == contig.size
     alleles = rs.choice(["A", "C", "G", "T"], size=(n_variant, n_allele)).astype("S")
     sample_id = np.array([f"S{i}" for i in range(n_sample)])

--- a/sgkit/tests/io/bgen/test_bgen_reader.py
+++ b/sgkit/tests/io/bgen/test_bgen_reader.py
@@ -131,7 +131,7 @@ def test_read_bgen__contig_dtype(shared_datadir, dtype):
     ds = read_bgen(path, contig_dtype=dtype)
     dtype = np.dtype(dtype)
     if dtype.kind in {"U", "S"}:
-        assert ds["variant_contig"].dtype == np.int64
+        assert ds["variant_contig"].dtype == np.int64  # type: ignore[comparison-overlap]
     else:
         assert ds["variant_contig"].dtype == dtype
 

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -20,7 +20,7 @@ def test_vcf_to_zarr__small_vcf(shared_datadir, is_path, tmp_path):
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
     vcf_to_zarr(path, output, chunk_length=5, chunk_width=2)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds.attrs["contigs"] == ["19", "20", "X"]
     assert_array_equal(ds["variant_contig"], [0, 0, 1, 1, 1, 1, 1, 1, 2])
@@ -97,7 +97,7 @@ def test_vcf_to_zarr__max_alt_alleles(shared_datadir, is_path, tmp_path):
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
     vcf_to_zarr(path, output, chunk_length=5, chunk_width=2, max_alt_alleles=1)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     # extra alt alleles are silently dropped
     assert_array_equal(
@@ -125,7 +125,7 @@ def test_vcf_to_zarr__large_vcf(shared_datadir, is_path, tmp_path):
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
     vcf_to_zarr(path, output, chunk_length=5_000)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (19910, 1, 2)
@@ -149,7 +149,7 @@ def test_vcf_to_zarr__plain_vcf_with_no_index(shared_datadir, tmp_path):
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
     vcf_to_zarr(path, output, truncate_calls=True)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
     assert ds["sample_id"].shape == (3,)
 
 
@@ -162,7 +162,7 @@ def test_vcf_to_zarr__mutable_mapping(shared_datadir, is_path):
     output: MutableMapping[str, bytes] = {}
 
     vcf_to_zarr(path, output, chunk_length=5_000)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (19910, 1, 2)
@@ -188,7 +188,7 @@ def test_vcf_to_zarr__parallel(shared_datadir, is_path, tmp_path):
     regions = ["20", "21"]
 
     vcf_to_zarr(path, output, regions=regions, chunk_length=5_000)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (19910, 1, 2)
@@ -214,7 +214,7 @@ def test_vcf_to_zarr__empty_region(shared_datadir, is_path, tmp_path):
     regions = "23"
 
     vcf_to_zarr(path, output, regions=regions)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (0, 1, 2)
@@ -240,7 +240,7 @@ def test_vcf_to_zarr__parallel_temp_chunk_length(shared_datadir, is_path, tmp_pa
     vcf_to_zarr(
         path, output, regions=regions, chunk_length=5_000, temp_chunk_length=2_500
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (19910, 1, 2)
@@ -288,7 +288,7 @@ def test_vcf_to_zarr__parallel_partitioned(shared_datadir, is_path, tmp_path):
     regions = partition_into_regions(path, num_parts=4)
 
     vcf_to_zarr(path, output, regions=regions, chunk_length=1_000, chunk_width=1_000)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (2535,)
     assert ds["variant_id"].shape == (1406,)
@@ -309,7 +309,7 @@ def test_vcf_to_zarr__parallel_partitioned_by_size(shared_datadir, is_path, tmp_
     vcf_to_zarr(
         path, output, target_part_size="4MB", chunk_length=1_000, chunk_width=1_000
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (2535,)
     assert ds["variant_id"].shape == (1406,)
@@ -327,7 +327,7 @@ def test_vcf_to_zarr__multiple(shared_datadir, is_path, tmp_path):
     output = tmp_path.joinpath("vcf_concat.zarr").as_posix()
 
     vcf_to_zarr(paths, output, target_part_size=None, chunk_length=5_000)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (19910, 1, 2)
@@ -356,7 +356,7 @@ def test_vcf_to_zarr__multiple_partitioned(shared_datadir, is_path, tmp_path):
     regions = [partition_into_regions(path, num_parts=2) for path in paths]
 
     vcf_to_zarr(paths, output, regions=regions, chunk_length=5_000)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (19910, 1, 2)
@@ -383,7 +383,7 @@ def test_vcf_to_zarr__multiple_partitioned_by_size(shared_datadir, is_path, tmp_
     output = tmp_path.joinpath("vcf_concat.zarr").as_posix()
 
     vcf_to_zarr(paths, output, target_part_size="40KB", chunk_length=5_000)
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert ds["sample_id"].shape == (1,)
     assert ds["call_genotype"].shape == (19910, 1, 2)
@@ -464,12 +464,12 @@ def test_vcf_to_zarr__mixed_ploidy_vcf(
             dtype=variant_dtype,
         ),
     )
-    assert ds["variant_allele"].dtype == variant_dtype
+    assert ds["variant_allele"].dtype == variant_dtype  # type: ignore[comparison-overlap]
     assert_array_equal(
         ds["variant_id"],
         np.array([".", "."], dtype=variant_dtype),
     )
-    assert ds["variant_id"].dtype == variant_dtype
+    assert ds["variant_id"].dtype == variant_dtype  # type: ignore[comparison-overlap]
     assert_array_equal(
         ds["variant_id_mask"],
         [True, True],
@@ -524,7 +524,7 @@ def test_vcf_to_zarr__no_genotypes(shared_datadir, tmp_path):
 
     vcf_to_zarr(path, output)
 
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert "call_genotype" not in ds
     assert "call_genotype_mask" not in ds
@@ -544,7 +544,7 @@ def test_vcf_to_zarr__no_genotypes_with_gt_header(shared_datadir, tmp_path):
 
     vcf_to_zarr(path, output)
 
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert_array_equal(ds["call_genotype"], -1)
     assert_array_equal(ds["call_genotype_mask"], 1)
@@ -581,7 +581,7 @@ def test_vcf_to_zarr__fields(shared_datadir, tmp_path):
         chunk_width=2,
         fields=["INFO/DP", "INFO/AA", "INFO/DB", "FORMAT/DP"],
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert_array_equal(ds["variant_DP"], [-1, -1, 14, 11, 10, 13, 9, -1, -1])
     assert ds["variant_DP"].attrs["comment"] == "Total Depth"
@@ -625,7 +625,7 @@ def test_vcf_to_zarr__parallel_with_fields(shared_datadir, tmp_path):
         temp_chunk_length=2_500,
         fields=["INFO/MQ", "FORMAT/PGT"],
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     # select a small region to check
     ds = ds.set_index(variants=("variant_contig", "variant_position")).sel(
@@ -651,7 +651,7 @@ def test_vcf_to_zarr__field_defs(shared_datadir, tmp_path):
         fields=["INFO/DP"],
         field_defs={"INFO/DP": {"Description": "Combined depth across samples"}},
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert_array_equal(ds["variant_DP"], [-1, -1, 14, 11, 10, 13, 9, -1, -1])
     assert ds["variant_DP"].attrs["comment"] == "Combined depth across samples"
@@ -662,7 +662,7 @@ def test_vcf_to_zarr__field_defs(shared_datadir, tmp_path):
         fields=["INFO/DP"],
         field_defs={"INFO/DP": {"Description": ""}},  # blank description
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert_array_equal(ds["variant_DP"], [-1, -1, 14, 11, 10, 13, 9, -1, -1])
     assert "comment" not in ds["variant_DP"].attrs
@@ -679,7 +679,7 @@ def test_vcf_to_zarr__field_number_A(shared_datadir, tmp_path):
         fields=["INFO/AC"],
         field_defs={"INFO/AC": {"Number": "A"}},
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert_array_equal(
         ds["variant_AC"],
@@ -711,7 +711,7 @@ def test_vcf_to_zarr__field_number_R(shared_datadir, tmp_path):
         fields=["FORMAT/AD"],
         field_defs={"FORMAT/AD": {"Number": "R"}},
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     # select a small region to check
     ds = ds.set_index(variants="variant_position").sel(
@@ -738,7 +738,7 @@ def test_vcf_to_zarr__field_number_G(shared_datadir, tmp_path):
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
     vcf_to_zarr(path, output, fields=["FORMAT/PL"])
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     # select a small region to check
     ds = ds.set_index(variants="variant_position").sel(
@@ -765,7 +765,7 @@ def test_vcf_to_zarr__field_number_G_non_diploid(shared_datadir, tmp_path):
     output = tmp_path.joinpath("vcf.zarr").as_posix()
 
     vcf_to_zarr(path, output, ploidy=4, max_alt_alleles=3, fields=["FORMAT/GL"])
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     # comb(n_alleles + ploidy - 1, ploidy) = comb(4 + 4 - 1, 4) = comb(7, 4) = 35
     assert_array_equal(ds["call_GL"].shape, (4, 3, 35))
@@ -783,7 +783,7 @@ def test_vcf_to_zarr__field_number_fixed(shared_datadir, tmp_path):
         fields=["FORMAT/HQ"],
         field_defs={"FORMAT/HQ": {"dimension": "haplotypes"}},
     )
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     assert_array_equal(
         ds["call_HQ"],

--- a/sgkit/tests/test_mis.py
+++ b/sgkit/tests/test_mis.py
@@ -5,17 +5,19 @@ import networkx as nx
 import numpy as np
 import pytest
 import toolz
-from numpy import ndarray
+from numpy.typing import NDArray
 
 from sgkit.stats.ld import _maximal_independent_set as numba_mis
 
 
-def to_vertex_ids(g: nx.Graph) -> Tuple[ndarray, ndarray]:
+def to_vertex_ids(g: nx.Graph) -> Tuple[NDArray[np.int_], NDArray[np.int_]]:
     g = np.array(sorted(g.edges))
     return g[:, 0], g[:, 1]
 
 
-def plink_mis(idi: ndarray, idj: ndarray, cmp: Optional[ndarray] = None) -> List[int]:
+def plink_mis(
+    idi: NDArray[np.int_], idj: NDArray[np.int_], cmp: Optional[NDArray[np.int_]] = None
+) -> List[int]:
     # Direct port of https://groups.google.com/forum/#!msg/plink2-users/w5TuZo2fgsQ/WbNnE16_xDIJ
     if cmp is None:
         cmp = np.zeros(len(idi))

--- a/sgkit/tests/test_pc_relate.py
+++ b/sgkit/tests/test_pc_relate.py
@@ -1,9 +1,12 @@
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
 from hypothesis import given, settings
 from hypothesis.extra.numpy import arrays
+from numpy.typing import NDArray
 
 from sgkit import pc_relate, pca
 from sgkit.stats.pc_relate import (
@@ -48,7 +51,7 @@ def test_pc_relate__maf_inputs_checks() -> None:
 
 @given(arrays(np.int8, (3, 5)))
 @settings(max_examples=10)
-def test_gramian_is_symmetric(a: np.ndarray) -> None:
+def test_gramian_is_symmetric(a: NDArray[Any]) -> None:
     b = gramian(a)
     assert np.allclose(b, b.T)
 

--- a/sgkit/tests/test_pca.py
+++ b/sgkit/tests/test_pca.py
@@ -5,6 +5,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
+from numpy.typing import NDArray
 from xarray import Dataset
 
 from sgkit.stats import pca
@@ -15,7 +16,7 @@ from sgkit.typing import ArrayLike
 
 def simulate_cohort_genotypes(
     n_variant: int, n_sample: int, n_cohort: int, seed: int = 0
-) -> np.ndarray:
+) -> NDArray[np.int8]:
     """ Sample genotypes from distinct ancestral populations """
     rs = np.random.RandomState(seed)
     # Determine size of each cohort (which will be roughly equal)

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -113,8 +113,8 @@ def add_cohorts(ds, ts, n_cohorts=1, cohort_key_names=["cohorts_0", "cohorts_1"]
 )
 def test_diversity(sample_size, chunks, cohort_allele_count):
     ts = simulate_ts(sample_size)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, cohort_key_names=["cohorts"])  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)
+    ds, subsets = add_cohorts(ds, ts, cohort_key_names=["cohorts"])
     if cohort_allele_count is not None:
         ds = count_cohort_alleles(ds, merge=False).rename(
             {variables.cohort_allele_count: cohort_allele_count}
@@ -133,8 +133,8 @@ def test_diversity(sample_size, chunks, cohort_allele_count):
 @pytest.mark.parametrize("sample_size", [10])
 def test_diversity__windowed(sample_size):
     ts = simulate_ts(sample_size, length=200)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, cohort_key_names=["cohorts"])  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)
+    ds, subsets = add_cohorts(ds, ts, cohort_key_names=["cohorts"])
     ds = window_by_variant(ds, size=25)
     ds = diversity(ds)
     div = ds["stat_diversity"].sel(cohorts="co_0").compute()
@@ -148,7 +148,7 @@ def test_diversity__windowed(sample_size):
 
     # Calculate diversity using scikit-allel moving_statistic
     # (Don't use windowed_diversity, since it treats the last window differently)
-    ds = count_variant_alleles(ts_to_dataset(ts))  # type: ignore[no-untyped-call]
+    ds = count_variant_alleles(ts_to_dataset(ts))
     ac = ds["variant_allele_count"].values
     mpd = allel.mean_pairwise_difference(ac, fill=0)
     ska_div = allel.moving_statistic(mpd, np.sum, size=25)
@@ -170,8 +170,8 @@ def test_diversity__missing_call_genotype():
 @pytest.mark.parametrize("chunks", [(-1, -1), (10, -1)])
 def test_divergence(sample_size, n_cohorts, chunks):
     ts = simulate_ts(sample_size)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)
+    ds, subsets = add_cohorts(ds, ts, n_cohorts)
     ds = divergence(ds)
     div = ds.stat_divergence.sum(axis=0, skipna=False).values
 
@@ -193,8 +193,8 @@ def test_divergence(sample_size, n_cohorts, chunks):
 @pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
 def test_divergence__windowed(sample_size, n_cohorts, chunks):
     ts = simulate_ts(sample_size, length=200)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)
+    ds, subsets = add_cohorts(ds, ts, n_cohorts)
     ds = window_by_variant(ds, size=25)
     ds = divergence(ds)
     div = ds["stat_divergence"].values
@@ -220,8 +220,8 @@ def test_divergence__windowed(sample_size, n_cohorts, chunks):
 @pytest.mark.xfail()  # combine with test_divergence__windowed when this is passing
 def test_divergence__windowed_scikit_allel_comparison(sample_size, n_cohorts, chunks):
     ts = simulate_ts(sample_size, length=200)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)
+    ds, subsets = add_cohorts(ds, ts, n_cohorts)
     ds = window_by_variant(ds, size=25)
     ds = divergence(ds)
     div = ds["stat_divergence"].values
@@ -230,8 +230,8 @@ def test_divergence__windowed_scikit_allel_comparison(sample_size, n_cohorts, ch
 
     # Calculate divergence using scikit-allel moving_statistic
     # (Don't use windowed_divergence, since it treats the last window differently)
-    ds1 = count_variant_alleles(ts_to_dataset(ts, samples=ts.samples()[:1]))  # type: ignore[no-untyped-call]
-    ds2 = count_variant_alleles(ts_to_dataset(ts, samples=ts.samples()[1:]))  # type: ignore[no-untyped-call]
+    ds1 = count_variant_alleles(ts_to_dataset(ts, samples=ts.samples()[:1]))
+    ds2 = count_variant_alleles(ts_to_dataset(ts, samples=ts.samples()[1:]))
     ac1 = ds1["variant_allele_count"].values
     ac2 = ds2["variant_allele_count"].values
     mpd = allel.mean_pairwise_difference_between(ac1, ac2, fill=0)
@@ -258,8 +258,8 @@ def test_Fst__Hudson(sample_size):
     # scikit-allel can only calculate Fst for pairs of cohorts (populations)
     n_cohorts = 2
     ts = simulate_ts(sample_size)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)
+    ds, subsets = add_cohorts(ds, ts, n_cohorts)
     n_variants = ds.dims["variants"]
     ds = window_by_variant(ds, size=n_variants)  # single window
     ds = Fst(ds, estimator="Hudson")
@@ -280,8 +280,8 @@ def test_Fst__Hudson(sample_size):
 )
 def test_Fst__Nei(sample_size, n_cohorts):
     ts = simulate_ts(sample_size)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)
+    ds, subsets = add_cohorts(ds, ts, n_cohorts)
     n_variants = ds.dims["variants"]
     ds = window_by_variant(ds, size=n_variants)  # single window
     ds = Fst(ds, estimator="Nei")
@@ -296,7 +296,7 @@ def test_Fst__Nei(sample_size, n_cohorts):
 
 def test_Fst__unknown_estimator():
     ts = simulate_ts(2)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)
     with pytest.raises(
         ValueError, match="Estimator 'Unknown' is not a known estimator"
     ):
@@ -310,8 +310,8 @@ def test_Fst__unknown_estimator():
 @pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
 def test_Fst__windowed(sample_size, n_cohorts, chunks):
     ts = simulate_ts(sample_size, length=200)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)
+    ds, subsets = add_cohorts(ds, ts, n_cohorts)
     ds = window_by_variant(ds, size=25)
     fst_ds = Fst(ds, estimator="Nei")
     fst = fst_ds["stat_Fst"].values
@@ -351,8 +351,8 @@ def test_Fst__windowed(sample_size, n_cohorts, chunks):
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_Tajimas_D(sample_size):
     ts = simulate_ts(sample_size)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, cohort_key_names=None)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)
+    ds, subsets = add_cohorts(ds, ts, cohort_key_names=None)
     n_variants = ds.dims["variants"]
     ds = window_by_variant(ds, size=n_variants)  # single window
     ds = Tajimas_D(ds)
@@ -365,8 +365,8 @@ def test_Tajimas_D(sample_size):
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_Tajimas_D_per_site(sample_size):
     ts = simulate_ts(sample_size, random_seed=1234)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, cohort_key_names=None)  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)
+    ds, subsets = add_cohorts(ds, ts, cohort_key_names=None)
     ds = Tajimas_D(ds)
     d = ds.stat_Tajimas_D.compute().squeeze()
     ts_d = ts.Tajimas_D(windows="sites")
@@ -379,8 +379,10 @@ def test_Tajimas_D_per_site(sample_size):
 )
 def test_pbs(sample_size, n_cohorts):
     ts = simulate_ts(sample_size)
-    ds = ts_to_dataset(ts)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts, cohort_key_names=["cohorts_0", "cohorts_1", "cohorts_2"])  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts)
+    ds, subsets = add_cohorts(
+        ds, ts, n_cohorts, cohort_key_names=["cohorts_0", "cohorts_1", "cohorts_2"]
+    )
     n_variants = ds.dims["variants"]
     ds = window_by_variant(ds, size=n_variants)  # single window
 
@@ -414,8 +416,10 @@ def test_pbs(sample_size, n_cohorts):
 @pytest.mark.parametrize("chunks", [(-1, -1), (50, -1)])
 def test_pbs__windowed(sample_size, n_cohorts, cohorts, cohort_indexes, chunks):
     ts = simulate_ts(sample_size, length=200)
-    ds = ts_to_dataset(ts, chunks)  # type: ignore[no-untyped-call]
-    ds, subsets = add_cohorts(ds, ts, n_cohorts, cohort_key_names=["cohorts_0", "cohorts_1", "cohorts_2"])  # type: ignore[no-untyped-call]
+    ds = ts_to_dataset(ts, chunks)
+    ds, subsets = add_cohorts(
+        ds, ts, n_cohorts, cohort_key_names=["cohorts_0", "cohorts_1", "cohorts_2"]
+    )
     ds = window_by_variant(ds, size=25)
 
     ds = pbs(ds, cohorts=cohorts)
@@ -465,7 +469,7 @@ def test_Garud_h(
     ds["sample_cohort"] = xr.DataArray(sample_cohorts, dims="samples")
     cohort_names = [f"co_{i}" for i in range(n_cohorts)]
     coords = {k: cohort_names for k in ["cohorts"]}
-    ds = ds.assign_coords(coords)  # type: ignore[no-untyped-call]
+    ds = ds.assign_coords(coords)
     ds = window_by_variant(ds, size=3)
 
     gh = Garud_H(ds, cohorts=cohorts)

--- a/sgkit/tests/test_stats_utils.py
+++ b/sgkit/tests/test_stats_utils.py
@@ -22,7 +22,7 @@ def test_r2_score__batch_dims():
     np.random.seed(0)
     X = np.random.normal(size=(n, p))
     B = np.random.normal(size=(p, y))
-    Y = (X @ B).T
+    Y = (X @ B).T  # type: ignore[attr-defined]
     YP = Y + np.random.normal(size=(6, 8, y, n), scale=0.1)
 
     # Test case with perfect predictions

--- a/sgkit/tests/test_testing.py
+++ b/sgkit/tests/test_testing.py
@@ -10,7 +10,7 @@ def test_simulate_genotype_call_dataset__zarr(tmp_path):
     path = str(tmp_path / "ds.zarr")
     ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10)
     ds.to_zarr(path)
-    xr.testing.assert_equal(ds, xr.open_zarr(path, concat_characters=False))  # type: ignore[no-untyped-call]
+    xr.testing.assert_equal(ds, xr.open_zarr(path, concat_characters=False))
 
 
 def test_simulate_genotype_call_dataset__invalid_missing_pct():

--- a/sgkit/tests/test_vcfzarr_reader.py
+++ b/sgkit/tests/test_vcfzarr_reader.py
@@ -37,7 +37,7 @@ def test_ensure_2d():
 
 
 def test_read_vcfzarr(shared_datadir, tmpdir):
-    vcfzarr_path = create_vcfzarr(shared_datadir, tmpdir)  # type: ignore[no-untyped-call]
+    vcfzarr_path = create_vcfzarr(shared_datadir, tmpdir)
     ds = read_vcfzarr(vcfzarr_path)
 
     assert ds.attrs["contigs"] == ["19", "20", "X"]
@@ -123,7 +123,7 @@ def test_vcfzarr_to_zarr(
             "samples",
         ]
 
-    vcfzarr_path = create_vcfzarr(  # type: ignore[no-untyped-call]
+    vcfzarr_path = create_vcfzarr(
         shared_datadir,
         tmpdir,
         fields=fields,
@@ -140,7 +140,7 @@ def test_vcfzarr_to_zarr(
         consolidated=consolidated,
     )
 
-    ds = xr.open_zarr(output)  # type: ignore[no-untyped-call]
+    ds = xr.open_zarr(output)
 
     # Note that variant_allele values are byte strings, not unicode strings (unlike for read_vcfzarr)
     # We should make the two consistent.

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -98,7 +98,7 @@ def encode_array(x: ArrayLike) -> Tuple[ArrayLike, List[Any]]:
         Unique values in original array in order of appearance.
     """
     # argsort not implemented in dask: https://github.com/dask/dask/issues/4368
-    names, index, inverse = np.unique(x, return_index=True, return_inverse=True)
+    names, index, inverse = np.unique(x, return_index=True, return_inverse=True)  # type: ignore[no-untyped-call]
     index = np.argsort(index)
     rank = np.empty_like(index)
     rank[index] = np.arange(len(index))
@@ -299,7 +299,7 @@ def max_str_len(a: ArrayLike) -> ArrayLike:
     if a.dtype.kind not in {"U", "S"}:
         raise ValueError(f"Array must have string dtype (got dtype {a.dtype})")
 
-    lens = np.frompyfunc(len, 1, 1)(a)
+    lens = np.frompyfunc(len, 1, 1)(a)  # type: ignore[no-untyped-call]
     if isinstance(a, np.ndarray):
         lens = np.asarray(lens)
     return lens.max()

--- a/sgkit/window.py
+++ b/sgkit/window.py
@@ -228,7 +228,7 @@ def _window_per_contig(
     contig_ids = np.arange(n_contigs)
     variant_contig = ds["variant_contig"]
     contig_starts = np.searchsorted(variant_contig.values, contig_ids)
-    contig_bounds = np.append(contig_starts, [n_variants], axis=0)
+    contig_bounds = np.append(contig_starts, [n_variants], axis=0)  # type: ignore[no-untyped-call]
 
     contig_window_contigs = []
     contig_window_starts = []
@@ -241,9 +241,9 @@ def _window_per_contig(
         contig_window_stops.append(stops)
         contig_window_contigs.append(np.full_like(starts, i))
 
-    window_contigs = np.concatenate(contig_window_contigs)
-    window_starts = np.concatenate(contig_window_starts)
-    window_stops = np.concatenate(contig_window_stops)
+    window_contigs = np.concatenate(contig_window_contigs)  # type: ignore[no-untyped-call]
+    window_starts = np.concatenate(contig_window_starts)  # type: ignore[no-untyped-call]
+    window_stops = np.concatenate(contig_window_stops)  # type: ignore[no-untyped-call]
 
     new_ds = create_dataset(
         {
@@ -316,9 +316,10 @@ def moving_statistic(
     length = values.shape[0]
     chunks = values.chunks[0]
     if len(chunks) > 1:
-        min_chunksize = np.min(chunks[:-1])  # ignore last chunk
+        # ignore last chunk
+        min_chunksize = np.min(chunks[:-1])  # type: ignore[no-untyped-call]
     else:
-        min_chunksize = np.min(chunks)
+        min_chunksize = np.min(chunks)  # type: ignore[no-untyped-call]
     if min_chunksize < size:
         raise ValueError(
             f"Minimum chunk size ({min_chunksize}) must not be smaller than size ({size})."
@@ -344,7 +345,7 @@ def window_statistic(
     desired_chunks = chunks or values.chunks
 
     window_lengths = window_stops - window_starts
-    depth = np.max(window_lengths)
+    depth = np.max(window_lengths)  # type: ignore[no-untyped-call]
 
     # Dask will raise an error if the last chunk size is smaller than the depth
     # Workaround by rechunking to combine the last two chunks in first axis
@@ -402,7 +403,7 @@ def window_statistic(
 
 def _sizes_to_start_offsets(sizes: ArrayLike) -> ArrayLike:
     """Convert an array of sizes, to cumulative offsets, starting with 0"""
-    return np.cumsum(np.insert(sizes, 0, 0, axis=0))
+    return np.cumsum(np.insert(sizes, 0, 0, axis=0))  # type: ignore[no-untyped-call]
 
 
 def _get_chunked_windows(
@@ -417,13 +418,15 @@ def _get_chunked_windows(
     chunk_starts = _sizes_to_start_offsets(chunks)
 
     # Find which chunk each window falls in
-    chunk_numbers = np.searchsorted(chunk_starts, window_starts, side="right") - 1
+    chunk_numbers: ArrayLike = (
+        np.searchsorted(chunk_starts, window_starts, side="right") - 1
+    )
 
     # Find the start positions for each window relative to each chunk start
     rel_window_starts = window_starts - chunk_starts[chunk_numbers]
 
     # Find the number of windows in each chunk
-    unique_chunk_numbers, unique_chunk_counts = np.unique(
+    unique_chunk_numbers, unique_chunk_counts = np.unique(  # type: ignore[no-untyped-call]
         chunk_numbers, return_counts=True
     )
     windows_per_chunk = np.zeros_like(chunks)

--- a/validation/gwas/method/pc_relate/validate_pc_relate.py
+++ b/validation/gwas/method/pc_relate/validate_pc_relate.py
@@ -33,6 +33,6 @@ def test_same_as_the_reference_implementation() -> None:
     genesis_phi = pd.read_csv(d.joinpath("kinbtwe.csv"))
     genesis_phi = genesis_phi[["kin"]].to_numpy()
 
-    phi_s = phi.data[np.triu_indices_from(phi.data, 1)]
+    phi_s = phi.data[np.triu_indices_from(phi.data, 1)]  # type: ignore[no-untyped-call]
     assert phi_s.size == genesis_phi.size
     assert np.allclose(phi_s, genesis_phi.T)


### PR DESCRIPTION
* Ignore 'no-untyped-call' mypy errors in tests, due to large number of NumPy false positives.
* Use new NDArray generic type.
* Ignore new NumPy false positive errors.
* 
Fixes #631 