### PR TITLE
Don't use Numba 0.54.0 since it doesn't work with NumPy 1.21

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        channels: conda-forge
+        channels: conda-forge,numba
         miniconda-version: "latest"
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ distributed != 2021.5.1
 dask-ml
 scipy
 typing-extensions
-numba
+numba != 0.54.0
 zarr
 fsspec != 2021.6.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     dask-ml
     scipy
     zarr
-    numba
+    numba != 0.54.0
     typing-extensions
     fsspec != 2021.6.*
     setuptools >= 41.2  # For pkg_resources


### PR DESCRIPTION
Fixes #654.

This is a point fix, which may break again when Numba 0.54.1 is released - but we should probably re-evaluate at that point (since it is possible that Numba will support NumPy 1.21 at that point).