### PR TITLE
Add missing pbs API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -90,6 +90,7 @@ Methods
    ld_prune
    maximal_independent_set
    observed_heterozygosity
+   pbs
    pc_relate
    regenie
    sample_stats


### PR DESCRIPTION
Trivial fix for missing docs for `pbs` on https://pystatgen.github.io/sgkit/latest/api.html