### PR TITLE
Test conversion VCF -> VCF Zarr -> VCF is lossless

### DIFF
--- a/sgkit/tests/io/vcf/data/all_fields.vcf
+++ b/sgkit/tests/io/vcf/data/all_fields.vcf
@@ -1,0 +1,257 @@
+##fileformat=VCFv4.3
+##contig=<ID=1>
+##contig=<ID=2>
+##INFO=<ID=IB0,Type=Flag,Number=0,Description="INFO,Type=Flag,Number=0">
+##INFO=<ID=II1,Type=Integer,Number=1,Description="INFO,Type=Integer,Number=1">
+##INFO=<ID=II2,Type=Integer,Number=2,Description="INFO,Type=Integer,Number=2">
+##INFO=<ID=IIA,Type=Integer,Number=A,Description="INFO,Type=Integer,Number=A">
+##INFO=<ID=IIR,Type=Integer,Number=R,Description="INFO,Type=Integer,Number=R">
+##INFO=<ID=IID,Type=Integer,Number=.,Description="INFO,Type=Integer,Number=.">
+##INFO=<ID=IF1,Type=Float,Number=1,Description="INFO,Type=Float,Number=1">
+##INFO=<ID=IF2,Type=Float,Number=2,Description="INFO,Type=Float,Number=2">
+##INFO=<ID=IFA,Type=Float,Number=A,Description="INFO,Type=Float,Number=A">
+##INFO=<ID=IFR,Type=Float,Number=R,Description="INFO,Type=Float,Number=R">
+##INFO=<ID=IFD,Type=Float,Number=.,Description="INFO,Type=Float,Number=.">
+##INFO=<ID=IC1,Type=Character,Number=1,Description="INFO,Type=Character,Number=1">
+##INFO=<ID=IC2,Type=Character,Number=2,Description="INFO,Type=Character,Number=2">
+##INFO=<ID=ICA,Type=Character,Number=A,Description="INFO,Type=Character,Number=A">
+##INFO=<ID=ICR,Type=Character,Number=R,Description="INFO,Type=Character,Number=R">
+##INFO=<ID=ICD,Type=Character,Number=.,Description="INFO,Type=Character,Number=.">
+##INFO=<ID=IS1,Type=String,Number=1,Description="INFO,Type=String,Number=1">
+##INFO=<ID=IS2,Type=String,Number=2,Description="INFO,Type=String,Number=2">
+##INFO=<ID=ISA,Type=String,Number=A,Description="INFO,Type=String,Number=A">
+##INFO=<ID=ISR,Type=String,Number=R,Description="INFO,Type=String,Number=R">
+##INFO=<ID=ISD,Type=String,Number=.,Description="INFO,Type=String,Number=.">
+##FORMAT=<ID=FI1,Type=Integer,Number=1,Description="FORMAT,Type=Integer,Number=1">
+##FORMAT=<ID=FI2,Type=Integer,Number=2,Description="FORMAT,Type=Integer,Number=2">
+##FORMAT=<ID=FIA,Type=Integer,Number=A,Description="FORMAT,Type=Integer,Number=A">
+##FORMAT=<ID=FIR,Type=Integer,Number=R,Description="FORMAT,Type=Integer,Number=R">
+##FORMAT=<ID=FIG,Type=Integer,Number=G,Description="FORMAT,Type=Integer,Number=G">
+##FORMAT=<ID=FID,Type=Integer,Number=.,Description="FORMAT,Type=Integer,Number=.">
+##FORMAT=<ID=FF1,Type=Float,Number=1,Description="FORMAT,Type=Float,Number=1">
+##FORMAT=<ID=FF2,Type=Float,Number=2,Description="FORMAT,Type=Float,Number=2">
+##FORMAT=<ID=FFA,Type=Float,Number=A,Description="FORMAT,Type=Float,Number=A">
+##FORMAT=<ID=FFR,Type=Float,Number=R,Description="FORMAT,Type=Float,Number=R">
+##FORMAT=<ID=FFG,Type=Float,Number=G,Description="FORMAT,Type=Float,Number=G">
+##FORMAT=<ID=FFD,Type=Float,Number=.,Description="FORMAT,Type=Float,Number=.">
+##FORMAT=<ID=FC1,Type=Character,Number=1,Description="FORMAT,Type=Character,Number=1">
+##FORMAT=<ID=FC2,Type=Character,Number=2,Description="FORMAT,Type=Character,Number=2">
+##FORMAT=<ID=FCA,Type=Character,Number=A,Description="FORMAT,Type=Character,Number=A">
+##FORMAT=<ID=FCR,Type=Character,Number=R,Description="FORMAT,Type=Character,Number=R">
+##FORMAT=<ID=FCG,Type=Character,Number=G,Description="FORMAT,Type=Character,Number=G">
+##FORMAT=<ID=FCD,Type=Character,Number=.,Description="FORMAT,Type=Character,Number=.">
+##FORMAT=<ID=FS1,Type=String,Number=1,Description="FORMAT,Type=String,Number=1">
+##FORMAT=<ID=FS2,Type=String,Number=2,Description="FORMAT,Type=String,Number=2">
+##FORMAT=<ID=FSA,Type=String,Number=A,Description="FORMAT,Type=String,Number=A">
+##FORMAT=<ID=FSR,Type=String,Number=R,Description="FORMAT,Type=String,Number=R">
+##FORMAT=<ID=FSG,Type=String,Number=G,Description="FORMAT,Type=String,Number=G">
+##FORMAT=<ID=FSD,Type=String,Number=.,Description="FORMAT,Type=String,Number=.">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s1	s2
+1	1	.	G	A,C	.	PASS	IB0	.	.	.
+1	2	.	A	G,G	.	PASS	II1=126	.	.	.
+1	3	.	A	G,G	.	PASS	II1=.	.	.	.
+1	4	.	T	A,C	.	PASS	II2=459,-140	.	.	.
+1	5	.	T	A,C	.	PASS	II2=.,-140	.	.	.
+1	6	.	T	A,C	.	PASS	II2=459,.	.	.	.
+1	7	.	T	A,C	.	PASS	II2=.,.	.	.	.
+1	8	.	A	A,G	.	PASS	IIA=294,130	.	.	.
+1	9	.	A	A,G	.	PASS	IIA=.,130	.	.	.
+1	10	.	A	A,G	.	PASS	IIA=294,.	.	.	.
+1	11	.	A	A,G	.	PASS	IIA=.,.	.	.	.
+1	12	.	A	A,G	.	PASS	IIR=95,724,44	.	.	.
+1	13	.	A	A,G	.	PASS	IIR=.,724,44	.	.	.
+1	14	.	A	A,G	.	PASS	IIR=95,.,44	.	.	.
+1	15	.	A	A,G	.	PASS	IIR=95,724,.	.	.	.
+1	16	.	A	A,G	.	PASS	IIR=.,.,.	.	.	.
+1	17	.	G	A,G	.	PASS	IID=-879,-534,238,-670,482,-913,396	.	.	.
+1	18	.	G	A,G	.	PASS	IID=.,-534,238,-670,482,-913,396	.	.	.
+1	19	.	G	A,G	.	PASS	IID=-879,.,238,-670,482,-913,396	.	.	.
+1	20	.	G	A,G	.	PASS	IID=-879,-534,.,-670,482,-913,396	.	.	.
+1	21	.	G	A,G	.	PASS	IID=-879,-534,238,.,482,-913,396	.	.	.
+1	22	.	G	A,G	.	PASS	IID=-879,-534,238,-670,.,-913,396	.	.	.
+1	23	.	G	A,G	.	PASS	IID=-879,-534,238,-670,482,.,396	.	.	.
+1	24	.	G	A,G	.	PASS	IID=-879,-534,238,-670,482,-913,.	.	.	.
+1	25	.	G	A,G	.	PASS	IID=.,.,.,.,.,.,.	.	.	.
+1	26	.	G	A,G	.	PASS	IID=-129,687,-870,685	.	.	.
+1	27	.	G	A,G	.	PASS	IID=.,687,-870,685	.	.	.
+1	28	.	G	A,G	.	PASS	IID=-129,.,-870,685	.	.	.
+1	29	.	G	A,G	.	PASS	IID=-129,687,.,685	.	.	.
+1	30	.	G	A,G	.	PASS	IID=-129,687,-870,.	.	.	.
+1	31	.	G	A,G	.	PASS	IID=.,.,.,.	.	.	.
+1	32	.	T	A,T	.	PASS	IF1=-887.177	.	.	.
+1	33	.	T	A,T	.	PASS	IF1=.	.	.	.
+1	34	.	G	C,A	.	PASS	IF2=443.998,877.105	.	.	.
+1	35	.	G	C,A	.	PASS	IF2=.,877.105	.	.	.
+1	36	.	G	C,A	.	PASS	IF2=443.998,.	.	.	.
+1	37	.	G	C,A	.	PASS	IF2=.,.	.	.	.
+1	38	.	T	C,A	.	PASS	IFA=-998.442,984.423	.	.	.
+1	39	.	T	C,A	.	PASS	IFA=.,984.423	.	.	.
+1	40	.	T	C,A	.	PASS	IFA=-998.442,.	.	.	.
+1	41	.	T	C,A	.	PASS	IFA=.,.	.	.	.
+1	42	.	A	T,G	.	PASS	IFR=234.963,223.306,-985.867	.	.	.
+1	43	.	A	T,G	.	PASS	IFR=.,223.306,-985.867	.	.	.
+1	44	.	A	T,G	.	PASS	IFR=234.963,.,-985.867	.	.	.
+1	45	.	A	T,G	.	PASS	IFR=234.963,223.306,.	.	.	.
+1	46	.	A	T,G	.	PASS	IFR=.,.,.	.	.	.
+1	47	.	T	G,G	.	PASS	IFD=-417.542,223.706,-721.012,-415.711,-267.276,-87.86,570.352,-600.652,28.4689	.	.	.
+1	48	.	T	G,G	.	PASS	IFD=.,223.706,-721.012,-415.711,-267.276,-87.86,570.352,-600.652,28.4689	.	.	.
+1	49	.	T	G,G	.	PASS	IFD=-417.542,.,-721.012,-415.711,-267.276,-87.86,570.352,-600.652,28.4689	.	.	.
+1	50	.	T	G,G	.	PASS	IFD=-417.542,223.706,.,-415.711,-267.276,-87.86,570.352,-600.652,28.4689	.	.	.
+1	51	.	T	G,G	.	PASS	IFD=-417.542,223.706,-721.012,.,-267.276,-87.86,570.352,-600.652,28.4689	.	.	.
+1	52	.	T	G,G	.	PASS	IFD=-417.542,223.706,-721.012,-415.711,.,-87.86,570.352,-600.652,28.4689	.	.	.
+1	53	.	T	G,G	.	PASS	IFD=-417.542,223.706,-721.012,-415.711,-267.276,.,570.352,-600.652,28.4689	.	.	.
+1	54	.	T	G,G	.	PASS	IFD=-417.542,223.706,-721.012,-415.711,-267.276,-87.86,.,-600.652,28.4689	.	.	.
+1	55	.	T	G,G	.	PASS	IFD=-417.542,223.706,-721.012,-415.711,-267.276,-87.86,570.352,.,28.4689	.	.	.
+1	56	.	T	G,G	.	PASS	IFD=-417.542,223.706,-721.012,-415.711,-267.276,-87.86,570.352,-600.652,.	.	.	.
+1	57	.	T	G,G	.	PASS	IFD=.,.,.,.,.,.,.,.,.	.	.	.
+1	58	.	T	G,G	.	PASS	IFD=-907.099,215.09,-658.952,-869.897,897.771,931.264,616.795,-390.772,-804.656	.	.	.
+1	59	.	T	G,G	.	PASS	IFD=.,215.09,-658.952,-869.897,897.771,931.264,616.795,-390.772,-804.656	.	.	.
+1	60	.	T	G,G	.	PASS	IFD=-907.099,.,-658.952,-869.897,897.771,931.264,616.795,-390.772,-804.656	.	.	.
+1	61	.	T	G,G	.	PASS	IFD=-907.099,215.09,.,-869.897,897.771,931.264,616.795,-390.772,-804.656	.	.	.
+1	62	.	T	G,G	.	PASS	IFD=-907.099,215.09,-658.952,.,897.771,931.264,616.795,-390.772,-804.656	.	.	.
+1	63	.	T	G,G	.	PASS	IFD=-907.099,215.09,-658.952,-869.897,.,931.264,616.795,-390.772,-804.656	.	.	.
+1	64	.	T	G,G	.	PASS	IFD=-907.099,215.09,-658.952,-869.897,897.771,.,616.795,-390.772,-804.656	.	.	.
+1	65	.	T	G,G	.	PASS	IFD=-907.099,215.09,-658.952,-869.897,897.771,931.264,.,-390.772,-804.656	.	.	.
+1	66	.	T	G,G	.	PASS	IFD=-907.099,215.09,-658.952,-869.897,897.771,931.264,616.795,.,-804.656	.	.	.
+1	67	.	T	G,G	.	PASS	IFD=-907.099,215.09,-658.952,-869.897,897.771,931.264,616.795,-390.772,.	.	.	.
+1	68	.	T	G,G	.	PASS	IFD=.,.,.,.,.,.,.,.,.	.	.	.
+1	69	.	T	C,G	.	PASS	IC1=f	.	.	.
+1	70	.	T	C,G	.	PASS	IC1=.	.	.	.
+1	71	.	G	T,G	.	PASS	IC2=e,a	.	.	.
+1	72	.	G	T,G	.	PASS	IC2=.,a	.	.	.
+1	73	.	G	T,G	.	PASS	IC2=e,.	.	.	.
+1	74	.	G	T,G	.	PASS	IC2=.,.	.	.	.
+1	75	.	A	C,A	.	PASS	ICA=b,a	.	.	.
+1	76	.	A	C,A	.	PASS	ICA=.,a	.	.	.
+1	77	.	A	C,A	.	PASS	ICA=b,.	.	.	.
+1	78	.	A	C,A	.	PASS	ICA=.,.	.	.	.
+1	79	.	C	G,C	.	PASS	ICR=c,b,b	.	.	.
+1	80	.	C	G,C	.	PASS	ICR=.,b,b	.	.	.
+1	81	.	C	G,C	.	PASS	ICR=c,.,b	.	.	.
+1	82	.	C	G,C	.	PASS	ICR=c,b,.	.	.	.
+1	83	.	C	G,C	.	PASS	ICR=.,.,.	.	.	.
+1	84	.	T	G,G	.	PASS	ICD=b,f,b,c	.	.	.
+1	85	.	T	G,G	.	PASS	ICD=.,f,b,c	.	.	.
+1	86	.	T	G,G	.	PASS	ICD=b,.,b,c	.	.	.
+1	87	.	T	G,G	.	PASS	ICD=b,f,.,c	.	.	.
+1	88	.	T	G,G	.	PASS	ICD=b,f,b,.	.	.	.
+1	89	.	T	G,G	.	PASS	ICD=.,.,.,.	.	.	.
+1	90	.	T	G,G	.	PASS	ICD=g,e,d,e,f,f,b	.	.	.
+1	91	.	T	G,G	.	PASS	ICD=.,e,d,e,f,f,b	.	.	.
+1	92	.	T	G,G	.	PASS	ICD=g,.,d,e,f,f,b	.	.	.
+1	93	.	T	G,G	.	PASS	ICD=g,e,.,e,f,f,b	.	.	.
+1	94	.	T	G,G	.	PASS	ICD=g,e,d,.,f,f,b	.	.	.
+1	95	.	T	G,G	.	PASS	ICD=g,e,d,e,.,f,b	.	.	.
+1	96	.	T	G,G	.	PASS	ICD=g,e,d,e,f,.,b	.	.	.
+1	97	.	T	G,G	.	PASS	ICD=g,e,d,e,f,f,.	.	.	.
+1	98	.	T	G,G	.	PASS	ICD=.,.,.,.,.,.,.	.	.	.
+1	99	.	A	C,C	.	PASS	IS1=bc	.	.	.
+1	100	.	A	C,C	.	PASS	IS1=.	.	.	.
+1	101	.	T	T,C	.	PASS	IS2=hij,d	.	.	.
+1	102	.	T	T,C	.	PASS	IS2=.,d	.	.	.
+1	103	.	T	T,C	.	PASS	IS2=hij,.	.	.	.
+1	104	.	T	T,C	.	PASS	IS2=.,.	.	.	.
+1	105	.	T	C,C	.	PASS	ISA=bc,efg	.	.	.
+1	106	.	T	C,C	.	PASS	ISA=.,efg	.	.	.
+1	107	.	T	C,C	.	PASS	ISA=bc,.	.	.	.
+1	108	.	T	C,C	.	PASS	ISA=.,.	.	.	.
+1	109	.	C	G,T	.	PASS	ISR=d,bc,op	.	.	.
+1	110	.	C	G,T	.	PASS	ISR=.,bc,op	.	.	.
+1	111	.	C	G,T	.	PASS	ISR=d,.,op	.	.	.
+1	112	.	C	G,T	.	PASS	ISR=d,bc,.	.	.	.
+1	113	.	C	G,T	.	PASS	ISR=.,.,.	.	.	.
+1	114	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,d,op,efg	.	.	.
+1	115	.	G	A,A	.	PASS	ISD=.,hij,klmn,d,ab,d,op,efg	.	.	.
+1	116	.	G	A,A	.	PASS	ISD=ab,.,klmn,d,ab,d,op,efg	.	.	.
+1	117	.	G	A,A	.	PASS	ISD=ab,hij,.,d,ab,d,op,efg	.	.	.
+1	118	.	G	A,A	.	PASS	ISD=ab,hij,klmn,.,ab,d,op,efg	.	.	.
+1	119	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,.,d,op,efg	.	.	.
+1	120	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,.,op,efg	.	.	.
+1	121	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,d,.,efg	.	.	.
+1	122	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,d,op,.	.	.	.
+1	123	.	G	A,A	.	PASS	ISD=.,.,.,.,.,.,.,.	.	.	.
+1	124	.	G	A,A	.	PASS	ISD=op,op,ab	.	.	.
+1	125	.	G	A,A	.	PASS	ISD=.,op,ab	.	.	.
+1	126	.	G	A,A	.	PASS	ISD=op,.,ab	.	.	.
+1	127	.	G	A,A	.	PASS	ISD=op,op,.	.	.	.
+1	128	.	G	A,A	.	PASS	ISD=.,.,.	.	.	.
+2	129	.	G	G,G	.	PASS	.	FI1	-795	.
+2	130	.	C	G,A	.	PASS	.	FI2	104,955	.,955
+2	131	.	C	G,A	.	PASS	.	FI2	104,.	.,.
+2	132	.	C	C,T	.	PASS	.	FIA	585,895	.,895
+2	133	.	C	C,T	.	PASS	.	FIA	585,.	.,.
+2	134	.	T	C,G	.	PASS	.	FIR	411,25,21	.,25,21
+2	135	.	T	C,G	.	PASS	.	FIR	411,.,21	411,25,.
+2	136	.	T	C,G	.	PASS	.	FIR	.,.,.	.,.,.
+2	137	.	A	T,T	.	PASS	.	FIG	413,-435,129,795,845,500	.,-435,129,795,845,500
+2	138	.	A	T,T	.	PASS	.	FIG	413,.,129,795,845,500	413,-435,.,795,845,500
+2	139	.	A	T,T	.	PASS	.	FIG	413,-435,129,.,845,500	413,-435,129,795,.,500
+2	140	.	A	T,T	.	PASS	.	FIG	413,-435,129,795,845,.	.,.,.,.,.,.
+2	141	.	C	G,G	.	PASS	.	FID	-271,579	.,579
+2	142	.	C	G,G	.	PASS	.	FID	-271,.	.,.
+2	143	.	C	G,G	.	PASS	.	FID	-799,981	.,981
+2	144	.	C	G,G	.	PASS	.	FID	-799,.	.,.
+2	145	.	A	T,G	.	PASS	.	FF1	853.318	.
+2	146	.	T	G,A	.	PASS	.	FF2	454.544,-346.918	.,-346.918
+2	147	.	T	G,A	.	PASS	.	FF2	454.544,.	.,.
+2	148	.	C	A,T	.	PASS	.	FFA	140.888,41.6685	.,41.6685
+2	149	.	C	A,T	.	PASS	.	FFA	140.888,.	.,.
+2	150	.	T	T,C	.	PASS	.	FFR	922.344,689.068,494.64	.,689.068,494.64
+2	151	.	T	T,C	.	PASS	.	FFR	922.344,.,494.64	922.344,689.068,.
+2	152	.	T	T,C	.	PASS	.	FFR	.,.,.	.,.,.
+2	153	.	A	T,T	.	PASS	.	FFG	79.3843,173.502,930.511,214.068,-448.002,-407.453	.,173.502,930.511,214.068,-448.002,-407.453
+2	154	.	A	T,T	.	PASS	.	FFG	79.3843,.,930.511,214.068,-448.002,-407.453	79.3843,173.502,.,214.068,-448.002,-407.453
+2	155	.	A	T,T	.	PASS	.	FFG	79.3843,173.502,930.511,.,-448.002,-407.453	79.3843,173.502,930.511,214.068,.,-407.453
+2	156	.	A	T,T	.	PASS	.	FFG	79.3843,173.502,930.511,214.068,-448.002,.	.,.,.,.,.,.
+2	157	.	A	C,A	.	PASS	.	FFD	-968.727	.
+2	158	.	A	C,A	.	PASS	.	FFD	544.49,-602.569,-988.956,630.923,413.715,458.014,542.541,-851.911,-283.069	.,-602.569,-988.956,630.923,413.715,458.014,542.541,-851.911,-283.069
+2	159	.	A	C,A	.	PASS	.	FFD	544.49,.,-988.956,630.923,413.715,458.014,542.541,-851.911,-283.069	544.49,-602.569,.,630.923,413.715,458.014,542.541,-851.911,-283.069
+2	160	.	A	C,A	.	PASS	.	FFD	544.49,-602.569,-988.956,.,413.715,458.014,542.541,-851.911,-283.069	544.49,-602.569,-988.956,630.923,.,458.014,542.541,-851.911,-283.069
+2	161	.	A	C,A	.	PASS	.	FFD	544.49,-602.569,-988.956,630.923,413.715,.,542.541,-851.911,-283.069	544.49,-602.569,-988.956,630.923,413.715,458.014,.,-851.911,-283.069
+2	162	.	A	C,A	.	PASS	.	FFD	544.49,-602.569,-988.956,630.923,413.715,458.014,542.541,.,-283.069	544.49,-602.569,-988.956,630.923,413.715,458.014,542.541,-851.911,.
+2	163	.	A	C,A	.	PASS	.	FFD	.,.,.,.,.,.,.,.,.	.,.,.,.,.,.,.,.,.
+2	164	.	T	T,A	.	PASS	.	FC1	d	.
+2	165	.	G	C,T	.	PASS	.	FC2	c,b	.,b
+2	166	.	G	C,T	.	PASS	.	FC2	c,.	.,.
+2	167	.	G	G,A	.	PASS	.	FCA	c,g	.,g
+2	168	.	G	G,A	.	PASS	.	FCA	c,.	.,.
+2	169	.	G	C,G	.	PASS	.	FCR	a,b,c	.,b,c
+2	170	.	G	C,G	.	PASS	.	FCR	a,.,c	a,b,.
+2	171	.	G	C,G	.	PASS	.	FCR	.,.,.	.,.,.
+2	172	.	G	A,A	.	PASS	.	FCG	a,e,b,g,g,a	.,e,b,g,g,a
+2	173	.	G	A,A	.	PASS	.	FCG	a,.,b,g,g,a	a,e,.,g,g,a
+2	174	.	G	A,A	.	PASS	.	FCG	a,e,b,.,g,a	a,e,b,g,.,a
+2	175	.	G	A,A	.	PASS	.	FCG	a,e,b,g,g,.	.,.,.,.,.,.
+2	176	.	A	G,A	.	PASS	.	FCD	a,g,d,d,f,f,b,a,d	.,g,d,d,f,f,b,a,d
+2	177	.	A	G,A	.	PASS	.	FCD	a,.,d,d,f,f,b,a,d	a,g,.,d,f,f,b,a,d
+2	178	.	A	G,A	.	PASS	.	FCD	a,g,d,.,f,f,b,a,d	a,g,d,d,.,f,b,a,d
+2	179	.	A	G,A	.	PASS	.	FCD	a,g,d,d,f,.,b,a,d	a,g,d,d,f,f,.,a,d
+2	180	.	A	G,A	.	PASS	.	FCD	a,g,d,d,f,f,b,.,d	a,g,d,d,f,f,b,a,.
+2	181	.	A	G,A	.	PASS	.	FCD	.,.,.,.,.,.,.,.,.	c,d,f,e,g,a,c
+2	182	.	A	G,A	.	PASS	.	FCD	.,d,f,e,g,a,c	c,.,f,e,g,a,c
+2	183	.	A	G,A	.	PASS	.	FCD	c,d,.,e,g,a,c	c,d,f,.,g,a,c
+2	184	.	A	G,A	.	PASS	.	FCD	c,d,f,e,.,a,c	c,d,f,e,g,.,c
+2	185	.	A	G,A	.	PASS	.	FCD	c,d,f,e,g,a,.	.,.,.,.,.,.,.
+2	186	.	C	T,A	.	PASS	.	FS1	bc	.
+2	187	.	C	C,C	.	PASS	.	FS2	bc,op	.,op
+2	188	.	C	C,C	.	PASS	.	FS2	bc,.	.,.
+2	189	.	C	T,G	.	PASS	.	FSA	ab,op	.,op
+2	190	.	C	T,G	.	PASS	.	FSA	ab,.	.,.
+2	191	.	T	T,T	.	PASS	.	FSR	klmn,bc,efg	.,bc,efg
+2	192	.	T	T,T	.	PASS	.	FSR	klmn,.,efg	klmn,bc,.
+2	193	.	T	T,T	.	PASS	.	FSR	.,.,.	.,.,.
+2	194	.	A	C,A	.	PASS	.	FSG	d,op,bc,klmn,efg,d	.,op,bc,klmn,efg,d
+2	195	.	A	C,A	.	PASS	.	FSG	d,.,bc,klmn,efg,d	d,op,.,klmn,efg,d
+2	196	.	A	C,A	.	PASS	.	FSG	d,op,bc,.,efg,d	d,op,bc,klmn,.,d
+2	197	.	A	C,A	.	PASS	.	FSG	d,op,bc,klmn,efg,.	.,.,.,.,.,.
+2	198	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,op,hij,efg,klmn,ab,hij	.,bc,d,op,hij,efg,klmn,ab,hij
+2	199	.	T	T,G	.	PASS	.	FSD	klmn,.,d,op,hij,efg,klmn,ab,hij	klmn,bc,.,op,hij,efg,klmn,ab,hij
+2	200	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,.,hij,efg,klmn,ab,hij	klmn,bc,d,op,.,efg,klmn,ab,hij
+2	201	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,op,hij,.,klmn,ab,hij	klmn,bc,d,op,hij,efg,.,ab,hij
+2	202	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,op,hij,efg,klmn,.,hij	klmn,bc,d,op,hij,efg,klmn,ab,.
+2	203	.	T	T,G	.	PASS	.	FSD	.,.,.,.,.,.,.,.,.	efg,klmn,bc,op,ab,bc,hij,hij
+2	204	.	T	T,G	.	PASS	.	FSD	.,klmn,bc,op,ab,bc,hij,hij	efg,.,bc,op,ab,bc,hij,hij
+2	205	.	T	T,G	.	PASS	.	FSD	efg,klmn,.,op,ab,bc,hij,hij	efg,klmn,bc,.,ab,bc,hij,hij
+2	206	.	T	T,G	.	PASS	.	FSD	efg,klmn,bc,op,.,bc,hij,hij	efg,klmn,bc,op,ab,.,hij,hij
+2	207	.	T	T,G	.	PASS	.	FSD	efg,klmn,bc,op,ab,bc,.,hij	efg,klmn,bc,op,ab,bc,hij,.
+2	208	.	T	T,G	.	PASS	.	FSD	.,.,.,.,.,.,.,.	.,.,.,.,.,.,.,.

--- a/sgkit/tests/io/vcf/test_vcf_generator.py
+++ b/sgkit/tests/io/vcf/test_vcf_generator.py
@@ -1,0 +1,10 @@
+from .vcf_generator import generate_vcf
+
+
+def test_generate_vcf(tmp_path):
+    out = tmp_path / "all_fields.vcf"
+
+    # uncomment the following to regenerate test file used in other tests
+    # out = "sgkit/tests/io/vcf/data/all_fields.vcf"
+
+    generate_vcf(out)

--- a/sgkit/tests/io/vcf/test_vcf_lossless_conversion.py
+++ b/sgkit/tests/io/vcf/test_vcf_lossless_conversion.py
@@ -1,0 +1,46 @@
+import pytest
+
+from sgkit.io.vcf.vcf_reader import vcf_to_zarr, zarr_array_sizes
+
+from .utils import path_for_test
+from .vcf_writer import canonicalize_vcf, zarr_to_vcf
+
+
+@pytest.mark.parametrize(
+    "vcf_file",
+    [
+        "sample.vcf.gz",
+        "mixed.vcf.gz",
+        "no_genotypes.vcf",
+        "CEUTrio.20.21.gatk3.4.g.vcf.bgz",
+        "all_fields.vcf",
+    ],
+)
+@pytest.mark.filterwarnings(
+    "ignore::sgkit.io.vcfzarr_reader.DimensionNameForFixedFormatFieldWarning",
+)
+def test_lossless_conversion(shared_datadir, tmp_path, vcf_file):
+    path = path_for_test(shared_datadir, vcf_file)
+    canonical = tmp_path.joinpath("canonical.vcf").as_posix()
+    intermediate = tmp_path.joinpath("intermediate.vcf.zarr").as_posix()
+    output = tmp_path.joinpath("output.vcf").as_posix()
+
+    canonicalize_vcf(path, canonical)
+
+    kwargs = zarr_array_sizes(path)
+    vcf_to_zarr(
+        path, intermediate, fields=["INFO/*", "FORMAT/*"], mixed_ploidy=True, **kwargs
+    )
+
+    zarr_to_vcf(intermediate, output)
+
+    with open(canonical) as f:
+        f1 = f.readlines()
+    with open(output) as f:
+        f2 = f.readlines()
+
+    if f1 != f2:
+        print("".join(f1))
+        print("".join(f2))
+
+    assert f1 == f2

--- a/sgkit/tests/io/vcf/test_vcf_writer.py
+++ b/sgkit/tests/io/vcf/test_vcf_writer.py
@@ -1,0 +1,17 @@
+import gzip
+
+from .utils import path_for_test
+from .vcf_writer import canonicalize_vcf
+
+
+def test_canonicalize_vcf(shared_datadir, tmp_path):
+    path = path_for_test(shared_datadir, "sample.vcf.gz")
+    output = tmp_path.joinpath("vcf.zarr").as_posix()
+
+    canonicalize_vcf(path, output)
+
+    # check INFO fields now are ordered correctly
+    with gzip.open(path, "rt") as f:
+        assert "NS=3;DP=9;AA=G;AN=6;AC=3,1" in f.read()
+    with open(output, "r") as f:
+        assert "NS=3;AN=6;AC=3,1;DP=9;AA=G" in f.read()

--- a/sgkit/tests/io/vcf/vcf_generator.py
+++ b/sgkit/tests/io/vcf/vcf_generator.py
@@ -1,0 +1,191 @@
+# Code to generate a test VCF file with all VCF Type/Number combinations
+
+import io
+import random
+from itertools import product
+from typing import Any, Dict, List
+
+import numpy as np
+from scipy.special import comb
+
+from sgkit.io.utils import str_is_int
+
+from .vcf_writer import VcfVariant, VcfWriter
+
+ploidy = 2
+max_alt_alleles = 2
+
+
+def generate_number(vcf_number, alt_alleles):
+    if vcf_number == ".":
+        return np.random.randint(1, 10)
+    elif str_is_int(vcf_number):
+        return int(vcf_number)
+    elif vcf_number == "A":
+        return alt_alleles
+    elif vcf_number == "R":
+        return alt_alleles + 1
+    elif vcf_number == "G":
+        n_alleles = alt_alleles + 1
+        return comb(n_alleles + ploidy - 1, ploidy, exact=True)
+    raise ValueError(f"Number '{vcf_number}' is not supported.")
+
+
+def generate_data(vcf_type, n):
+    if vcf_type == "Integer":
+        return np.random.randint(-1000, 1000, n).tolist()
+    elif vcf_type == "Float":
+        return np.random.uniform(-1000.0, 1000.0, n).tolist()
+    elif vcf_type == "Character":
+        return random.choices("abcdefg", k=n)
+    elif vcf_type == "String":
+        return random.choices(["ab", "bc", "d", "efg", "hij", "klmn", "op"], k=n)
+    raise ValueError(f"Type '{vcf_type}' is not supported.")
+
+
+def generate_alleles(alt_alleles):
+    return random.choices("ACGT", k=alt_alleles + 1)
+
+
+class Field:
+    def __init__(self, category, vcf_type, vcf_number, name=None):
+        assert category in ("INFO", "FORMAT")
+        self.category = category
+        self.name = name or f"{category[0]}{vcf_type[0]}{vcf_number[0]}".replace(
+            ".", "D"
+        )
+        self.vcf_type = vcf_type
+        self.vcf_number = vcf_number
+
+    def get_header(self):
+        return f'##{self.category}=<ID={self.name},Type={self.vcf_type},Number={self.vcf_number},Description="{self.category},Type={self.vcf_type},Number={self.vcf_number}">'
+
+    def generate_values(self, alt_alleles):
+        if self.vcf_type == "Flag":
+            yield True
+            return
+
+        repeat = 2 if self.vcf_number == "." else 1  # multiple lengths for Number=.
+        for _ in range(repeat):
+            n = generate_number(self.vcf_number, alt_alleles)
+            data = generate_data(self.vcf_type, n)
+            val = ",".join([str(x) for x in data])
+            yield f"{val}"
+            for i in range(n):
+                data_str = [str(x) for x in data]
+                data_str[i] = "."  # missing
+                val = ",".join(data_str)
+                yield f"{val}"
+            if n > 1:
+                val = ",".join(["."] * n)  # all missing
+                yield f"{val}"
+
+
+def generate_header(info_fields, format_fields, vcf_samples):
+
+    output = io.StringIO()
+
+    print("##fileformat=VCFv4.3", file=output)
+    print("##contig=<ID=1>", file=output)
+    print("##contig=<ID=2>", file=output)
+
+    for info_field in info_fields:
+        print(info_field.get_header(), file=output)
+
+    for format_field in format_fields:
+        print(format_field.get_header(), file=output)
+
+    print(
+        "#CHROM",
+        "POS",
+        "ID",
+        "REF",
+        "ALT",
+        "QUAL",
+        "FILTER",
+        "INFO",
+        "FORMAT",
+        "\t".join(vcf_samples),
+        sep="\t",
+        file=output,
+    )
+
+    return output.getvalue()
+
+
+def generate_vcf(output, seed=42):
+    random.seed(seed)
+    np.random.seed(seed)
+
+    info_fields = [
+        Field(*c)
+        for c in product(
+            ["INFO"],
+            ["Integer", "Float", "Character", "String"],
+            ["1", "2", "A", "R", "."],  # Number=G not allowed for INFO fields
+        )
+    ]
+    info_fields.insert(0, Field("INFO", "Flag", "0", "IB0"))
+
+    format_fields = [
+        Field(*c)
+        for c in product(
+            ["FORMAT"],
+            ["Integer", "Float", "Character", "String"],
+            ["1", "2", "A", "R", "G", "."],
+        )
+    ]
+
+    vcf_samples = ["s1", "s2"]
+
+    header_str = generate_header(info_fields, format_fields, vcf_samples)
+
+    with open(output, mode="w") as out:
+        vcf_writer = VcfWriter(out, header_str)
+
+        # only have a single field per variant
+
+        pos = 0
+
+        for info_field in info_fields:
+            alt_alleles = max_alt_alleles
+            alleles = generate_alleles(alt_alleles)
+            for val in info_field.generate_values(alt_alleles):
+                contig_id = "1"
+                pos = pos + 1
+                ref = alleles[0]
+                alt = alleles[1:]
+                info = {info_field.name: val}
+                samples: List[Dict[str, Any]] = [{}] * len(vcf_samples)
+
+                variant = VcfVariant(
+                    contig_id, pos, ".", ref, alt, None, ["PASS"], info, samples
+                )
+                vcf_writer.write(variant)
+
+        for format_field in format_fields:
+            alt_alleles = max_alt_alleles
+            alleles = generate_alleles(alt_alleles)
+            formats = list(format_field.generate_values(alt_alleles))
+            # group into samples
+            n_samples = len(vcf_samples)
+            formats_by_sample = [
+                formats[i : i + n_samples] for i in range(0, len(formats), n_samples)
+            ]
+
+            for sample_vals in formats_by_sample:
+                if len(sample_vals) < n_samples:
+                    sample_vals = sample_vals + [sample_vals[0]] * (
+                        n_samples - len(sample_vals)
+                    )  # pad with first val
+
+                contig_id = "2"
+                pos = pos + 1
+                ref = alleles[0]
+                alt = alleles[1:]
+                samples = [{format_field.name: val} for val in sample_vals]
+
+                variant = VcfVariant(
+                    contig_id, pos, ".", ref, alt, None, ["PASS"], None, samples
+                )
+                vcf_writer.write(variant)

--- a/sgkit/tests/io/vcf/vcf_writer.py
+++ b/sgkit/tests/io/vcf/vcf_writer.py
@@ -1,0 +1,338 @@
+import re
+import tempfile
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any, Dict, List, MutableMapping, Optional, Union
+
+import numpy as np
+from cyvcf2 import Writer
+
+from sgkit import load_dataset
+from sgkit.io.utils import (
+    CHAR_FILL,
+    CHAR_MISSING,
+    FLOAT32_FILL_AS_INT32,
+    FLOAT32_MISSING_AS_INT32,
+    INT_FILL,
+    INT_MISSING,
+    STR_FILL,
+    STR_MISSING,
+)
+from sgkit.io.vcf.vcf_reader import open_vcf
+from sgkit.typing import PathType
+
+
+@dataclass
+class VcfVariant:
+    chrom: str
+    pos: int
+    id: str
+    ref: str
+    alt: List[str]
+    qual: Optional[float]
+    filter: List[str]
+    info: Optional[Dict[str, Any]]
+    samples: List[Dict[str, Any]]
+
+    def __str__(self):
+        out = StringIO()
+
+        if self.info is None:
+            info = "."
+        else:
+            info_fields = [f"{format_field(k, v)}" for k, v in self.info.items()]
+            info = ";".join([field for field in info_fields if field != ""])
+            if len(info) == 0:
+                info = "."
+        if self.samples is None or len(self.samples) == 0:
+            format_ = "."
+        else:
+            format_ = format_empty_as_missing(":".join(self.samples[0].keys()))
+        print(
+            self.chrom,
+            self.pos,
+            "." if self.id is None else self.id,
+            self.ref,
+            "." if self.alt is None else ",".join(filter_none(self.alt)),
+            "." if self.qual is None else str(self.qual),
+            "." if self.filter is None else ";".join(self.filter),
+            info,
+            format_,
+            sep="\t",
+            end="\t",
+            file=out,
+        )
+
+        print(
+            "\t".join(
+                [
+                    format_empty_as_missing(
+                        ":".join([f"{format_value(v)}" for v in sample.values()])
+                    )
+                    for sample in self.samples
+                ]
+            ),
+            file=out,
+        )
+
+        return out.getvalue().strip()
+
+
+class VcfWriter:
+    def __init__(self, output, header_str):
+        self.output = output
+        self.header_str = header_str
+
+        # create a cyvcf2 file for formatting, not for writing the file
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".vcf")
+        self.vcf = Writer.from_string(tmp, self.header_str)
+
+        # print the header
+        print(self.header_str, end="", file=self.output)
+
+    def write(self, variant):
+        # use cyvcf2 to format the variant string - in particular floats
+        v = self.vcf.variant_from_string(str(variant))
+
+        # print the formatted variant string to the output
+        print(str(v), end="", file=self.output)
+
+
+def format_field(key, val):
+    if isinstance(val, bool):
+        return key if val else ""
+    return f"{key}={format_value(val)}"
+
+
+def format_value(val):
+    if val is None:
+        return "."
+    elif isinstance(val, str):
+        return val
+    elif isinstance(val, bytes):
+        return val.decode("utf-8")
+    try:
+        lst = [format_value(v) for v in val]
+        return ",".join(lst)
+    except TypeError:
+        return str(val)
+
+
+def format_empty_as_missing(val):
+    if val == "":
+        return "."
+    return val
+
+
+def filter_none(lst):
+    return [x for x in lst if x is not None]
+
+
+def zarr_to_vcf(
+    input: Union[PathType, MutableMapping[str, bytes]],
+    output: PathType,
+) -> None:
+    """Convert a Zarr file to VCF. For test purposes only."""
+    ds = load_dataset(input)
+    ds = ds.load()
+
+    header_str = ds.attrs["vcf_header"]
+    contigs = ds.attrs["contigs"]
+    filters = ds.attrs["filters"]
+
+    n_samples = ds.dims["samples"]
+
+    with open(output, mode="w") as out:
+        vcf_writer = VcfWriter(out, header_str)
+
+        info_fields = _info_fields(header_str)
+        format_fields = _format_fields(header_str)
+
+        for i in range(ds.dims["variants"]):
+            chrom = ds.variant_contig[i].values.item()
+            pos = ds.variant_position[i].values.item()
+            id = ds.variant_id[i].values.item()
+            _, ref_alt = array_to_values(ds.variant_allele[i].values)
+            ref = ref_alt[0]
+            alt = ref_alt[1:]
+            _, qual = array_to_values(ds.variant_quality[i].values)
+            _, filter_ = array_to_values(ds.variant_filter[i].values)
+            if isinstance(filter_, bool):
+                filter_ = np.array([filter_])
+            if np.all(~filter_):
+                filter_ = None
+            else:
+                filter_ = [filters[i] for i, f in enumerate(filter_) if f]
+
+            info = {}
+            samples = [{} for _ in range(n_samples)]  # type: ignore
+
+            for key in info_fields:
+                variable_name = f"variant_{key}"
+                if variable_name in ds:
+                    arr = ds[variable_name][i].values
+                    present, val = array_to_values(arr, variable_name)
+                    if present:
+                        info[key] = val
+
+            for key in format_fields:
+                if key == "GT":
+                    variable_name = "call_genotype"
+                else:
+                    variable_name = f"call_{key}"
+                if variable_name in ds:
+                    arr = ds[variable_name][i].values
+                    assert len(arr) == n_samples
+                    if key == "GT":
+                        phased = ds["call_genotype_phased"][i].values
+                    for j in range(len(arr)):
+                        present, val = array_to_values(arr[j], variable_name)
+                        if not present:
+                            break  # samples should all be present or none are
+                        if key == "GT":
+                            lst = [(str(v) if v is not None else ".") for v in val]
+                            val = ("|" if phased[j] else "/").join(lst)
+                        samples[j][key] = val
+
+            variant = VcfVariant(
+                contigs[chrom], pos, id, ref, alt, qual, filter_, info, samples
+            )
+
+            vcf_writer.write(variant)
+
+
+def array_to_values(arr, name="unknown"):
+    """Convert an array from cyvcf2 to a 'present' flag, and an array with fill removed."""
+    if isinstance(arr, str):  # this happens for the Type=String, Number=1 path
+        arr = np.array([arr], dtype="O")
+    if arr.dtype == np.bool_:
+        if arr.size == 1:
+            return True, arr.item()
+        else:
+            return True, arr
+    elif arr.dtype in (np.int8, np.int16, np.int32):
+        if name == "call_genotype":
+            missing, fill = -1, -2
+        else:
+            assert arr.dtype == np.int32
+            missing, fill = INT_MISSING, INT_FILL
+        if arr.size == 1:
+            val = arr
+            if val == missing:
+                return True, None
+            elif val != fill:
+                return True, val.item()
+        else:
+            arr = arr[arr != fill]  # remove fill padding
+            if arr.size > 0:
+                val = [x if x != missing else None for x in arr.tolist()]
+                return True, val
+        return False, None
+    elif arr.dtype == np.float32:
+        missing, fill = FLOAT32_MISSING_AS_INT32, FLOAT32_FILL_AS_INT32
+        if arr.size == 1:
+            val = arr
+            if val.view("i4") == missing:
+                return True, None
+            elif val.view("i4") != fill:
+                return True, val.item()
+        else:
+            arr = arr[arr.view("i4") != fill]  # remove fill padding
+            if arr.size > 0:
+                val = [x.item() if x.view("i4") != missing else None for x in arr]
+                return True, val
+        return False, None
+    elif arr.dtype == np.dtype("S1") or arr.dtype == np.dtype(
+        "S0"
+    ):  # S0 is some cases (e.g. FC1)
+        missing, fill = np.array([CHAR_MISSING, CHAR_FILL], dtype="S1")
+        if arr.size == 1:
+            val = arr
+            if val == missing:
+                return True, None
+            elif val != fill:
+                return True, val.item()
+        else:
+            arr = arr[arr != fill]  # remove fill padding
+            if arr.size > 0:
+                val = [x if x != missing else None for x in arr.tolist()]
+                return True, val
+        return False, None
+    elif arr.dtype == np.object_:
+        missing, fill = STR_MISSING, STR_FILL  # type: ignore
+        lst = arr.tolist()  # convert to list o/w comparisons don't work for np O type
+        if arr.size == 1:
+            val = lst[0] if isinstance(lst, list) else lst
+            if val == missing:
+                return True, None
+            elif val != fill:
+                return True, val
+        else:
+            arr = arr[arr != fill]  # remove fill padding
+            lst = [x for x in lst if x != fill]
+            if len(lst) > 0:
+                val = [x if x != missing else None for x in lst]
+                return True, val
+        return False, None
+    else:
+        raise ValueError(f"Unsupported dtype: {arr.dtype} {name}")
+
+
+def _info_fields(header_str):
+    p = re.compile("ID=([^,>]+)")
+    return [
+        p.findall(line)[0]
+        for line in header_str.split("\n")
+        if line.startswith("##INFO=")
+    ]
+
+
+def _format_fields(header_str):
+    p = re.compile("ID=([^,>]+)")
+    fields = [
+        p.findall(line)[0]
+        for line in header_str.split("\n")
+        if line.startswith("##FORMAT=")
+    ]
+    # GT must be the first field if present, per the spec (section 1.6.2)
+    if "GT" in fields:
+        fields.remove("GT")
+        fields.insert(0, "GT")
+    return fields
+
+
+def canonicalize_vcf(input: PathType, output: PathType) -> None:
+    """Canonicalize the fields in a VCF file by writing all INFO fields in the order that they appear in the header."""
+
+    with open_vcf(input) as vcf:
+
+        info_field_names = _info_fields(vcf.raw_header)
+
+        w = Writer(str(output), vcf)
+        for v in vcf:
+            v = _reorder_info_fields(w, v, info_field_names)
+            w.write_record(v)
+        w.close()
+
+
+def _reorder_info_fields(writer, variant, info_field_names):
+    # variant.INFO is readonly so we have to go via a string representation
+
+    variant_str = str(variant)[:-1]  # strip newline
+    fields = variant_str.split("\t")
+    info_field = fields[7]
+    if info_field == ".":
+        return variant
+    elif info_field != ".":
+        info_fields = {f.split("=")[0]: f for f in info_field.split(";")}
+
+        # sort info_fields in order of info_field_names
+        index_map = {v: i for i, v in enumerate(info_field_names)}
+        info_fields_reordered = sorted(
+            info_fields.items(), key=lambda pair: index_map[pair[0]]
+        )
+
+        # update the info field
+        fields[7] = ";".join([t[1] for t in info_fields_reordered])
+        new_variant_str = "\t".join(fields)
+        return writer.variant_from_string(new_variant_str)


### PR DESCRIPTION
Fixes #773 

There's quite a lot of code here, but most of it is test code, including:
* code to generate a VCF file (_all_fields.vcf_) with all the different possible field types
* code to canonicalise a VCF file to make text comparison possible
* code to write VCFs from VCF Zarr format

The non-test changes are fixes to handle edge cases in converting the different field types. 