### PR TITLE
Generic cohort_statistic function

### DIFF
--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -7,7 +7,7 @@ import numpy as np
 from numba import guvectorize
 from xarray import Dataset
 
-from sgkit.cohorts import _cohorts_to_array
+from sgkit.cohorts import _cohorts_to_array, cohort_statistic
 from sgkit.stats.utils import assert_array_shape
 from sgkit.typing import ArrayLike
 from sgkit.utils import (
@@ -939,52 +939,6 @@ def Garud_H(
     return conditional_merge_datasets(ds, new_ds, merge)
 
 
-@guvectorize(  # type: ignore
-    [
-        "void(float64[:], int32[:], uint8[:], float64[:])",
-        "void(float64[:], int64[:], uint8[:], float64[:])",
-    ],
-    "(n),(n),(c)->(c)",
-    nopython=True,
-    cache=True,
-)
-def _cohort_observed_heterozygosity(
-    hi: ArrayLike, cohorts: ArrayLike, _: ArrayLike, out: ArrayLike
-) -> None:  # pragma: no cover
-    """Generalized U-function for computing cohort observed heterozygosity.
-
-    Parameters
-    ----------
-    hi
-        Individual sample heterozygosity of shape (samples,).
-    cohorts
-        Cohort indexes for samples of shape (samples,).
-    _
-        Dummy variable of type `uint8` and shape (cohorts,) used to
-        define the number of cohorts.
-    out
-        Observed heterozygosity with shape (cohorts,) and values corresponding
-        to the mean individual heterozygosity of each cohort.
-    """
-    out[:] = 0
-    _[:] = 0
-    n_samples = len(hi)
-    n_cohorts = len(out)
-    for i in range(n_samples):
-        h = hi[i]
-        if not np.isnan(h):
-            c = cohorts[i]
-            if c >= 0:
-                out[c] += h
-                _[c] += 1
-    for j in range(n_cohorts):
-        n = _[j]
-        if n != 0:
-            out[j] /= n
-        else:
-            out[j] = np.nan
-
-
 def observed_heterozygosity(
     ds: Dataset,
     *,
@@ -1061,18 +1015,11 @@ def observed_heterozygosity(
     variables.validate(ds, {call_heterozygosity: variables.call_heterozygosity_spec})
     hi = da.asarray(ds[call_heterozygosity])
     sc = da.asarray(ds[sample_cohort])
-    n_cohorts = sc.max().compute() + 1
-    shape = (hi.chunks[0], n_cohorts)
-    n = da.zeros(n_cohorts, dtype=np.uint8)
-    ho = da.map_blocks(
-        _cohort_observed_heterozygosity,
-        hi,
-        sc,
-        n,
-        chunks=shape,
-        drop_axis=1,
-        new_axis=1,
-        dtype=np.float64,
+    ho = cohort_statistic(
+        values=hi,
+        statistic=np.nanmean,
+        cohorts=sc,
+        axis=1,
     )
     if has_windows(ds):
         ho_sum = window_statistic(

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -1015,6 +1015,11 @@ def observed_heterozygosity(
     variables.validate(ds, {call_heterozygosity: variables.call_heterozygosity_spec})
     hi = da.asarray(ds[call_heterozygosity])
     sc = da.asarray(ds[sample_cohort])
+    # NOTE: Performance of cohort_statistic is substantially slower than a numba
+    # JIT function which handles cohorts directly (i.e. avoids slicing the
+    # `hi` array by cohort).
+    # See commit 89da16e495315ed318a2d4dec92f70154cd2013d for an older implementation
+    # using numba.
     ho = cohort_statistic(
         values=hi,
         statistic=np.nanmean,

--- a/sgkit/tests/test_cohorts.py
+++ b/sgkit/tests/test_cohorts.py
@@ -1,8 +1,9 @@
+import dask.array as da
 import numpy as np
 import pandas as pd
 import pytest
 
-from sgkit.cohorts import _cohorts_to_array, _tuple_len
+from sgkit.cohorts import _cohorts_to_array, _tuple_len, cohort_statistic
 
 
 def test_tuple_len():
@@ -50,4 +51,54 @@ def test_cohorts_to_array__ids():
             [("c0", "c1", "c2"), ("c3", "c1", "c2")], pd.Index(["c0", "c1", "c2", "c3"])
         ),
         np.array([[0, 1, 2], [3, 1, 2]]),
+    )
+
+
+@pytest.mark.parametrize(
+    "statistic,expect",
+    [
+        (
+            np.mean,
+            [
+                [1.0, 0.75, 0.5],
+                [2 / 3, 0.25, 0.0],
+                [2 / 3, 0.75, 0.5],
+                [2 / 3, 0.5, 1.0],
+                [1 / 3, 0.5, 0.0],
+            ],
+        ),
+        (np.sum, [[3, 3, 1], [2, 1, 0], [2, 3, 1], [2, 2, 2], [1, 2, 0]]),
+    ],
+)
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        ((5,), (10,)),
+        ((3, 2), (10,)),
+        ((3, 2), (5, 5)),
+    ],
+)
+def test_cohort_statistic(statistic, expect, chunks):
+    variables = da.asarray(
+        [
+            [1, 1, 1, 0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 1, 0, 1, 0, 0, 0, 1, 0],
+            [0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+            [1, 1, 1, 1, 0, 0, 0, 0, 1, 1],
+            [0, 1, 0, 0, 1, 1, 1, 0, 0, 0],
+        ],
+        chunks=chunks,
+    )
+    cohorts = np.array([0, 1, 0, 2, 0, 1, -1, 1, 1, 2])
+    np.testing.assert_array_equal(
+        expect, cohort_statistic(variables, statistic, cohorts, axis=1)
+    )
+
+
+def test_cohort_statistic_axis0():
+    variables = da.asarray([2, 3, 2, 4, 3, 1, 4, 5, 3, 1])
+    cohorts = np.array([0, 0, 0, 0, 0, -1, 1, 1, 1, 2])
+    np.testing.assert_array_equal(
+        [2.8, 4.0, 1.0],
+        cohort_statistic(variables, np.mean, cohorts, sample_axis=0, axis=0),
     )


### PR DESCRIPTION
Fixes #730
This is inspired by the `window_statistic` function and assumes that it is reasonable to iterate over the number of cohorts in plain python.
Existing methods like `count_cohort_alleles` could also be simplified using `cohort_statistic` though there would probably be some reduction in performance.