### PR TITLE
Upgrade sphinx_autodoc_typehints to fix doc build

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,7 +1,7 @@
 myst_nb
 pydata-sphinx-theme
 sphinx>4,<=4.2.0
-sphinx_autodoc_typehints<1.13.0
+sphinx_autodoc_typehints>=1.14.0
 # Work around problem with autodoc_typehints
 # https://github.com/theislab/scanpydoc/pull/32
 git+https://github.com/theislab/scanpydoc.git#egg=scanpydoc


### PR DESCRIPTION
More churn in the doc packages (scanpydoc was upgraded to require latest sphinx_autodoc_typehints).