### PR TITLE
Run upstream on Python 3.8, 3.9, 3.10 (and not 3.7, since Xarray has …

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
…removed support for it).

Related to #802 and #801 