### PR TITLE
Pin pandas < 1.4.0 since statsmodels doesn't support this version yet.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy < 1.22
 xarray
-dask[array] >= 2021.10.0
-distributed >= 2021.10.0
+dask[array] >= 2021.10.0, <= 2022.01.0
+distributed >= 2021.10.0, <= 2022.01.0
 dask-ml
 scipy
 typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numba
 zarr
 fsspec != 2021.6.*
 scikit-learn
+pandas < 1.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 install_requires =
     numpy < 1.22
     xarray
-    dask[array] >= 2021.10.0
-    distributed >= 2021.10.0
+    dask[array] >= 2021.10.0, <= 2022.01.0
+    distributed >= 2021.10.0, <= 2022.01.0
     dask-ml
     scipy
     zarr
@@ -37,6 +37,7 @@ install_requires =
     typing-extensions
     fsspec != 2021.6.*
     scikit-learn
+    pandas < 1.4.0
     setuptools >= 41.2  # For pkg_resources
 setup_requires =
     setuptools >= 41.2


### PR DESCRIPTION
Fixes #818