### PR TITLE
Allow chunking in the samples dimention for identity_by_state

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy < 1.22
 xarray
-dask[array] >= 2021.10.0
-distributed >= 2021.10.0
+dask[array] >= 2022.01.0
+distributed >= 2022.01.0
 dask-ml
 scipy
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 install_requires =
     numpy < 1.22
     xarray
-    dask[array] >= 2021.10.0
-    distributed >= 2021.10.0
+    dask[array] >= 2022.01.0
+    distributed >= 2022.01.0
     dask-ml
     scipy
     zarr >= 2.10.0, < 2.11.0

--- a/sgkit/stats/ibs.py
+++ b/sgkit/stats/ibs.py
@@ -48,17 +48,6 @@ def identity_by_state(
     which is a matrix of pairwise IBS probabilities among all samples.
     The dimensions are named ``samples_0`` and ``samples_1``.
 
-    Raises
-    ------
-    NotImplementedError
-        If the variable holding call_allele_frequency is chunked along the
-        samples dimension.
-
-    Warnings
-    --------
-    This method does not currently support datasets that are chunked along the
-    samples dimension.
-
     Examples
     --------
 
@@ -84,10 +73,6 @@ def identity_by_state(
         ds, {call_allele_frequency: variables.call_allele_frequency_spec}
     )
     af = da.asarray(ds[call_allele_frequency])
-    if len(af.chunks[1]) > 1:
-        raise NotImplementedError(
-            "identity_by_state does not support chunking in the samples dimension"
-        )
     af0 = da.where(da.isnan(af), 0.0, af)
     num = da.einsum("ixj,iyj->xy", af0, af0)
     called = da.nansum(af, axis=-1)

--- a/sgkit/tests/test_ibs.py
+++ b/sgkit/tests/test_ibs.py
@@ -96,7 +96,8 @@ def test_identity_by_state__tetraploid_multiallelic(chunks):
     [
         ((7,), (5,), (2,)),
         ((2, 7, 3), (20,), (3,)),
-        ((20, 20, 11), (33,), (7, 7, 7)),
+        ((2, 7, 3), (5, 5, 5, 5), (3,)),
+        ((20, 20, 11), (20, 10, 3), (7, 7, 7)),
     ],
 )
 @pytest.mark.parametrize("ploidy", [2, 4])
@@ -123,19 +124,6 @@ def test_identity_by_state__reference_implementation(ploidy, chunks, seed):
         (AF[..., None, :, :] * AF[..., :, None, :]).sum(axis=-1), axis=0
     ).compute()
     np.testing.assert_array_almost_equal(expect, actual)
-
-
-def test_identity_by_state__chunked_sample_dimension():
-    ds = simulate_genotype_call_dataset(n_variant=20, n_sample=10, n_ploidy=2)
-    ds["call_genotype"] = ds.call_genotype.dims, da.asarray(
-        ds.call_genotype.data,
-        chunks=((20,), (5, 5), (2,)),
-    )
-    with pytest.raises(
-        NotImplementedError,
-        match="identity_by_state does not support chunking in the samples dimension",
-    ):
-        identity_by_state(ds)
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")


### PR DESCRIPTION
Fixes #836

AFAICT the upstream bug was fixed in dask version 2022.01.0, so the new tests will fail on older versions