### PR TITLE
Unpin rechunker now that version 0.5.0 is out

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ msprime>=1.0
 scikit-learn
 partd
 bed-reader
-rechunker == 0.3.3
+rechunker
 cbgen
 cyvcf2 < 0.30.15; platform_system != "Windows"
 yarl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy < 1.22
 xarray
-dask[array] >= 2021.10.0, <= 2022.01.0
-distributed >= 2021.10.0, <= 2022.01.0
+dask[array] >= 2021.10.0
+distributed >= 2021.10.0
 dask-ml
 scipy
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 install_requires =
     numpy < 1.22
     xarray
-    dask[array] >= 2021.10.0, <= 2022.01.0
-    distributed >= 2021.10.0, <= 2022.01.0
+    dask[array] >= 2021.10.0
+    distributed >= 2021.10.0
     dask-ml
     scipy
     zarr >= 2.10.0, < 2.11.0
@@ -64,7 +64,7 @@ vcf =
     requests
     yarl
 bgen =
-    rechunker == 0.3.3
+    rechunker
     cbgen
 
 [coverage:report]


### PR DESCRIPTION
Fixes #820.

Also remove the Dask pin as that was imposed by rechunker == 0.3.0.