### PR TITLE
Remove Pandas pin on < 1.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ numba
 zarr >= 2.10.0, != 2.11.0, != 2.11.1, != 2.11.2
 fsspec != 2021.6.*
 scikit-learn
-pandas < 1.4.0
+pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     typing-extensions
     fsspec != 2021.6.*
     scikit-learn
-    pandas < 1.4.0
+    pandas
     setuptools >= 41.2  # For pkg_resources
 setup_requires =
     setuptools >= 41.2

--- a/sgkit/io/bgen/bgen_reader.py
+++ b/sgkit/io/bgen/bgen_reader.py
@@ -185,7 +185,7 @@ def read_metafile(path: PathType) -> dd.DataFrame:
             for i in range(mf.npartitions)
         ]
         meta = dd.utils.make_meta(METAFILE_DTYPE)
-        return dd.from_delayed(dfs, meta=meta, divisions=divisions)
+        return dd.from_delayed(dfs, meta=meta, divisions=divisions, verify_meta=False)
 
 
 def read_samples(path: PathType) -> pd.DataFrame:


### PR DESCRIPTION
This is related to #818 (following up now that statsmodels is fixed). I also needed to fix a call to `from_delayed`, discussed here: https://github.com/dask/dask/issues/5435.