### PR TITLE
Generic functions for cohort sums and means

### DIFF
--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -134,7 +134,10 @@ def diversity(
 
 # c = cohorts, k = alleles
 @guvectorize(  # type: ignore
-    ["void(int64[:, :], float64[:,:])"], "(c, k)->(c,c)", nopython=True, cache=True
+    ["void(int64[:, :], float64[:,:])", "void(uint64[:, :], float64[:,:])"],
+    "(c, k)->(c,c)",
+    nopython=True,
+    cache=True,
 )
 def _divergence(ac: ArrayLike, out: ArrayLike) -> None:  # pragma: no cover
     """Generalized U-function for computing divergence.

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -24,6 +24,7 @@ from .aggregation import (
     count_variant_alleles,
     individual_heterozygosity,
 )
+from .utils import cohort_nanmean
 
 
 def diversity(
@@ -939,52 +940,6 @@ def Garud_H(
     return conditional_merge_datasets(ds, new_ds, merge)
 
 
-@guvectorize(  # type: ignore
-    [
-        "void(float64[:], int32[:], uint8[:], float64[:])",
-        "void(float64[:], int64[:], uint8[:], float64[:])",
-    ],
-    "(n),(n),(c)->(c)",
-    nopython=True,
-    cache=True,
-)
-def _cohort_observed_heterozygosity(
-    hi: ArrayLike, cohorts: ArrayLike, _: ArrayLike, out: ArrayLike
-) -> None:  # pragma: no cover
-    """Generalized U-function for computing cohort observed heterozygosity.
-
-    Parameters
-    ----------
-    hi
-        Individual sample heterozygosity of shape (samples,).
-    cohorts
-        Cohort indexes for samples of shape (samples,).
-    _
-        Dummy variable of type `uint8` and shape (cohorts,) used to
-        define the number of cohorts.
-    out
-        Observed heterozygosity with shape (cohorts,) and values corresponding
-        to the mean individual heterozygosity of each cohort.
-    """
-    out[:] = 0
-    _[:] = 0
-    n_samples = len(hi)
-    n_cohorts = len(out)
-    for i in range(n_samples):
-        h = hi[i]
-        if not np.isnan(h):
-            c = cohorts[i]
-            if c >= 0:
-                out[c] += h
-                _[c] += 1
-    for j in range(n_cohorts):
-        n = _[j]
-        if n != 0:
-            out[j] /= n
-        else:
-            out[j] = np.nan
-
-
 def observed_heterozygosity(
     ds: Dataset,
     *,
@@ -1060,20 +1015,9 @@ def observed_heterozygosity(
     )
     variables.validate(ds, {call_heterozygosity: variables.call_heterozygosity_spec})
     hi = da.asarray(ds[call_heterozygosity])
-    sc = da.asarray(ds[sample_cohort])
-    n_cohorts = sc.max().compute() + 1
-    shape = (hi.chunks[0], n_cohorts)
-    n = da.zeros(n_cohorts, dtype=np.uint8)
-    ho = da.map_blocks(
-        _cohort_observed_heterozygosity,
-        hi,
-        sc,
-        n,
-        chunks=shape,
-        drop_axis=1,
-        new_axis=1,
-        dtype=np.float64,
-    )
+    cohort = da.asarray(ds[sample_cohort])
+    n_cohorts = cohort.max().compute() + 1
+    ho = cohort_nanmean(hi, cohort, n_cohorts)
     if has_windows(ds):
         ho_sum = window_statistic(
             ho,

--- a/sgkit/stats/utils.py
+++ b/sgkit/stats/utils.py
@@ -144,6 +144,8 @@ def cohort_reduction(gufunc: Callable) -> Callable:
         "(float64[:], int64[:], int8[:], float64[:])",
     ],
     "(n),(n),(c)->(c)",
+    nopython=True,
+    cache=True,
 )
 def cohort_sum(
     x: ArrayLike, cohort: ArrayLike, _: ArrayLike, out: ArrayLike
@@ -189,6 +191,8 @@ def cohort_sum(
         "(float64[:], int64[:], int8[:], float64[:])",
     ],
     "(n),(n),(c)->(c)",
+    nopython=True,
+    cache=True,
 )
 def cohort_nansum(
     x: ArrayLike, cohort: ArrayLike, _: ArrayLike, out: ArrayLike
@@ -235,6 +239,8 @@ def cohort_nansum(
         "(float64[:], int64[:], int8[:], float64[:])",
     ],
     "(n),(n),(c)->(c)",
+    nopython=True,
+    cache=True,
 )
 def cohort_mean(
     x: ArrayLike, cohort: ArrayLike, _: ArrayLike, out: ArrayLike
@@ -285,6 +291,8 @@ def cohort_mean(
         "(float64[:], int64[:], int8[:], float64[:])",
     ],
     "(n),(n),(c)->(c)",
+    nopython=True,
+    cache=True,
 )
 def cohort_nanmean(
     x: ArrayLike, cohort: ArrayLike, _: ArrayLike, out: ArrayLike

--- a/sgkit/tests/test_popgen.py
+++ b/sgkit/tests/test_popgen.py
@@ -516,6 +516,7 @@ def test_Garud_h__raise_on_no_windows():
         Garud_H(ds)
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("chunks", [((4,), (6,), (4,)), ((2, 2), (3, 3), (2, 2))])
 def test_observed_heterozygosity(chunks):
     ds = simulate_genotype_call_dataset(
@@ -581,6 +582,7 @@ def test_observed_heterozygosity(chunks):
     )
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("chunks", [((4,), (6,), (4,)), ((2, 2), (3, 3), (2, 2))])
 @pytest.mark.parametrize(
     "cohorts,expectation",

--- a/sgkit/tests/test_stats_utils.py
+++ b/sgkit/tests/test_stats_utils.py
@@ -12,6 +12,10 @@ from sgkit.stats.utils import (
     assert_array_shape,
     assert_block_shape,
     assert_chunk_shape,
+    cohort_mean,
+    cohort_nanmean,
+    cohort_nansum,
+    cohort_sum,
     concat_2d,
     r2_score,
 )
@@ -164,3 +168,56 @@ def _col_shape_sum(ds: Dataset) -> int:
 
 def _rename_dim(ds: Dataset, prefix: str, name: str) -> Dataset:
     return ds.rename_dims({d: name for d in ds.dims if str(d).startswith(prefix)})
+
+
+def _random_cohort_data(chunks, n, axis, missing=0.0, scale=1, dtype=float, seed=0):
+    shape = tuple(np.sum(tup) for tup in chunks)
+    np.random.seed(seed)
+    x = np.random.rand(*shape) * scale
+    idx = np.random.choice([1, 0], shape, p=[missing, 1 - missing]).astype(bool)
+    x[idx] = np.nan
+    x = da.asarray(x, chunks=chunks, dtype=dtype)
+    cohort = np.random.randint(-1, n, size=shape[axis])
+    return x, cohort, n, axis
+
+
+def _cohort_reduction(func, x, cohort, n, axis=-1):
+    # reference implementation
+    out = []
+    for i in range(n):
+        idx = np.where(cohort == i)[0]
+        x_c = np.take(x, idx, axis=axis)
+        out.append(func(x_c, axis=axis))
+    out = np.swapaxes(np.array(out), 0, axis)
+    return out
+
+
+@pytest.mark.parametrize(
+    "x, cohort, n, axis",
+    [
+        _random_cohort_data((20,), n=3, axis=0),
+        _random_cohort_data((20, 20), n=2, axis=0, dtype=np.float32),
+        _random_cohort_data((10, 10), n=2, axis=-1, scale=30, dtype=np.int16),
+        _random_cohort_data((20, 20), n=3, axis=-1, missing=0.3),
+        _random_cohort_data((7, 103, 4), n=5, axis=1, scale=7, missing=0.3),
+        _random_cohort_data(
+            ((3, 4), (50, 50, 3), 4), n=5, axis=1, scale=7, dtype=np.uint8
+        ),
+        _random_cohort_data(
+            ((6, 6), (50, 50, 7), (3, 1)), n=5, axis=1, scale=7, missing=0.3
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "reduction, func",
+    [
+        (cohort_sum, np.sum),
+        (cohort_nansum, np.nansum),
+        (cohort_mean, np.mean),
+        (cohort_nanmean, np.nanmean),
+    ],
+)
+def test_cohort_reductions(reduction, func, x, cohort, n, axis):
+    expect = _cohort_reduction(func, x, cohort, n, axis=axis)
+    actual = reduction(x, cohort, n, axis=axis)
+    np.testing.assert_array_almost_equal(expect, actual)

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -339,7 +339,7 @@ call_ploidy, call_ploidy_spec = SgkitVariables.register_variable(
 
 cohort_allele_count, cohort_allele_count_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "cohort_allele_count", kind="i", ndim=3, __doc__="""Cohort allele counts."""
+        "cohort_allele_count", kind="u", ndim=3, __doc__="""Cohort allele counts."""
     )
 )
 


### PR DESCRIPTION
Fixes #730

Adds four generic cohort reductions `cohort_sum`, `cohort_nansum`, `cohort_mean` and `cohort_nanmean`. Also updates `count_cohort_alleles` and `observed_heterozygosity` to use these functions. These functions aim to mimic standard numpy functions with regard to return dtypes (on Linux)  which results in `count_cohort_alleles` returning `uitn64` rather than `int32`. The changes also makes `count_cohort_alleles` more flexible in terms of chunking of the input `call_allele_count` array and, based on some simple benchmarks, there is a moderate performance improvement.