### PR TITLE
Pin version of ablog to avoid build error

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -8,4 +8,4 @@ ipython
 matplotlib
 graphviz
 seaborn
-ablog
+ablog!=0.10.27


### PR DESCRIPTION
Fixes #876.

I managed to build this locally and view the new blog.