### PR TITLE
Remove scikit-learn pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy < 1.22
+numpy < 1.23
 xarray
 dask[array] >= 2022.01.0
 distributed >= 2022.01.0
@@ -8,5 +8,5 @@ typing-extensions
 numba
 zarr >= 2.10.0, != 2.11.0, != 2.11.1, != 2.11.2
 fsspec != 2021.6.*
-scikit-learn < 1.1.0
+scikit-learn
 pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    numpy < 1.22
+    numpy < 1.23
     xarray
     dask[array] >= 2022.01.0
     distributed >= 2022.01.0
@@ -38,7 +38,7 @@ install_requires =
     numba
     typing-extensions
     fsspec != 2021.6.*
-    scikit-learn < 1.1.0
+    scikit-learn
     pandas
     setuptools >= 41.2  # For pkg_resources
 setup_requires =


### PR DESCRIPTION
Change numpy pin now that numba supports numpy 1.22 (but not 1.23)

I'm hoping this will help with fixing the wheels build (https://github.com/pystatgen/sgkit/actions/runs/2816635903) by allowing a later version of cyvcf2 to be used that has Python 3.10 Mac wheels.

Fixes #857