### PR TITLE
Exclude wheels test on macOS Python 3.10

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,6 +46,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # see https://github.com/pystatgen/sgkit/issues/887
+        exclude:
+          - os: macos-latest
+            python-version: "3.10"
     runs-on: ${{ matrix.os }}
     steps:
       # checkout repo to subdirectory to get access to scripts


### PR DESCRIPTION
Fixes #887 by excluding the test, until the upstream cyvcf2 issue is fixed.