### PR TITLE
Pedigree inbreeding

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -93,6 +93,7 @@ Methods
    maximal_independent_set
    observed_heterozygosity
    pbs
+   pedigree_inbreeding
    pedigree_kinship
    pedigree_relationship
    pc_relate
@@ -182,6 +183,7 @@ By convention, variable names are singular in sgkit. For example, ``genotype_cou
     variables.stat_inverse_additive_relationship_spec
     variables.stat_observed_heterozygosity_spec
     variables.stat_pbs_spec
+    variables.stat_pedigree_inbreeding_spec
     variables.stat_pedigree_kinship_spec
     variables.stat_pedigree_relationship_spec
     variables.stat_Tajimas_D_spec

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -35,6 +35,7 @@ from .stats.pca import pca
 from .stats.pedigree import (
     inverse_additive_relationships,
     parent_indices,
+    pedigree_inbreeding,
     pedigree_kinship,
     pedigree_relationship,
 )
@@ -87,6 +88,7 @@ __all__ = [
     "ld_prune",
     "maximal_independent_set",
     "parent_indices",
+    "pedigree_inbreeding",
     "pedigree_kinship",
     "pedigree_relationship",
     "sample_stats",

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -765,6 +765,18 @@ stat_pbs, stat_pbs_spec = SgkitVariables.register_variable(
     )
 )
 
+(
+    stat_pedigree_inbreeding,
+    stat_pedigree_inbreeding_spec,
+) = SgkitVariables.register_variable(
+    ArrayLikeSpec(
+        "stat_pedigree_inbreeding",
+        ndim=1,
+        kind="f",
+        __doc__="""Expected inbreeding coefficients of samples based on pedigree structure.""",
+    )
+)
+
 stat_pedigree_kinship, stat_pedigree_kinship_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_pedigree_kinship",


### PR DESCRIPTION
Fixes #858

This method computes the pedigree estimate of expected inbreeding without requiring computation of a full kinship matrix as an intermediate. This significantly reduces RAM usage and is (usually) faster than calculating the full kinship matrix. However, the exact difference in resource usage depends on pedigree complexity. There also seems to be some added overhead which I think stems from using dicts within numba. I chose to only implement the full Hamilton-Kerr method for both diploids and polyploids. This leaves some performance on the table for diploids, but I don't think it's significant enough to justify a specific implementation.

I did some simple benchmarking using randomly generated pedigrees which I'd expected to be close to the worst-case scenario for the new method (random choice of parents results in highly complex pedigrees). These results are compared to `pedigree_kinship` which computes the full kinship matrix (the diagonal of which can trivially be converted to inbreeding values).

| N-Samples | `pedigree_inbreeding` | `pedigree_kinship` |
| -----------| -----------------------| ------------------ |
| 100         | 3.61 ms                        | 2.61 ms               |
| 1000       | 7.89 ms                        | 5.6 ms                 |
| 10,000    | 193 ms                         | 357 ms                |
| 100,000  | 10.2 s                           | (out of RAM)        |


To get a a better idea of performance improvement with real pedigrees I used a couple of published pedigrees
| N-Samples | `pedigree_inbreeding` | `pedigree_kinship` | source |
| -----------| -----------------------| ------------------ | ------- |
| 6473         | 29 ms                         | 179 ms                | [Cleveland et al 2012](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3337471/#!po=7.14286) |
| 6740         | 13 ms                         | 175 ms                | [Bérénos et al 2014](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4149785/#!po=3.57143) |
