### PR TITLE
Fix max str len for dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy < 1.23
 xarray
-dask[array] >= 2022.01.0, < 2022.8.1
-distributed >= 2022.01.0, < 2022.8.1
+dask[array] >= 2022.01.0
+distributed >= 2022.01.0
 dask-ml
 scipy
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,8 @@ python_requires = >=3.7
 install_requires =
     numpy < 1.23
     xarray
-    dask[array] >= 2022.01.0, < 2022.8.1
-    distributed >= 2022.01.0, < 2022.8.1
+    dask[array] >= 2022.01.0
+    distributed >= 2022.01.0
     dask-ml
     scipy
     zarr >= 2.10.0, != 2.11.0, != 2.11.1, != 2.11.2

--- a/sgkit/tests/test_utils.py
+++ b/sgkit/tests/test_utils.py
@@ -194,6 +194,16 @@ def test_max_str_len__invalid_dtype():
         max_str_len(np.array([1]))
 
 
+# track failure in https://github.com/pystatgen/sgkit/issues/890
+def test_max_str_len__dask_failure():
+    pytest.importorskip("dask", minversion="2022.8")
+    with pytest.raises(Exception):
+        x = np.array("hi")
+        d = da.array(x)
+        lens = np.frompyfunc(len, 1, 1)(d)
+        lens.max().compute()
+
+
 def test_split_array_chunks__raise_on_blocks_gt_n():
     with pytest.raises(
         ValueError,

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -306,7 +306,10 @@ def max_str_len(a: ArrayLike) -> ArrayLike:
     lens = np.frompyfunc(len, 1, 1)(a)  # type: ignore[no-untyped-call]
     if isinstance(a, np.ndarray):
         lens = np.asarray(lens)
-    return lens.max()
+    if a.ndim == 0:
+        return lens
+    else:
+        return lens.max()
 
 
 @numba_guvectorize(  # type: ignore


### PR DESCRIPTION
This fixes #890 by special casing zero-dimensional arrays.

BTW I'm not sure if there's a bug in Dask or not. Here's the shortest reproducible example I've found so far:

```
>>> import numpy as np
>>> import dask.array as da
>>> x = np.array("hi")
>>> d = da.array(x)
>>> lens = np.frompyfunc(len, 1, 1)(d)
>>> lens.compute()
2
>>> lens.max().compute()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/base.py", line 315, in compute
    (result,) = compute(self, traverse=False, **kwargs)
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/base.py", line 600, in compute
    results = schedule(dsk, keys, **kwargs)
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/threaded.py", line 89, in get
    results = get_async(
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/local.py", line 511, in get_async
    raise_exception(exc, tb)
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/local.py", line 319, in reraise
    raise exc
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/local.py", line 224, in execute_task
    result = _execute_task(task, data)
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/core.py", line 119, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/core.py", line 119, in <genexpr>
    return func(*(_execute_task(a, cache) for a in args))
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/core.py", line 119, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/optimization.py", line 990, in __call__
    return core.get(self.dsk, self.outkey, dict(zip(self.inkeys, args)))
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/core.py", line 149, in get
    result = _execute_task(task, cache)
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/core.py", line 119, in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/utils.py", line 71, in apply
    return func(*args, **kwargs)
  File "/Users/tom/miniconda3/envs/sgkit-dev-3.8/lib/python3.8/site-packages/dask/array/reductions.py", line 467, in chunk_max
    if x.size == 0:
AttributeError: 'int' object has no attribute 'size'
```