### PR TITLE
Replace inverse_additive_relationships with pedigree_inverse_relationship

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -87,13 +87,13 @@ Methods
    hardy_weinberg_test
    identity_by_state
    individual_heterozygosity
-   inverse_additive_relationships
    ld_matrix
    ld_prune
    maximal_independent_set
    observed_heterozygosity
    pbs
    pedigree_inbreeding
+   pedigree_inverse_relationship
    pedigree_kinship
    pedigree_relationship
    pc_relate
@@ -180,10 +180,10 @@ By convention, variable names are singular in sgkit. For example, ``genotype_cou
     variables.stat_Hamilton_Kerr_lambda_spec
     variables.stat_Hamilton_Kerr_tau_spec
     variables.stat_identity_by_state_spec
-    variables.stat_inverse_additive_relationship_spec
     variables.stat_observed_heterozygosity_spec
     variables.stat_pbs_spec
     variables.stat_pedigree_inbreeding_spec
+    variables.stat_pedigree_inverse_relationship_spec
     variables.stat_pedigree_kinship_spec
     variables.stat_pedigree_relationship_spec
     variables.stat_Tajimas_D_spec

--- a/sgkit/__init__.py
+++ b/sgkit/__init__.py
@@ -33,9 +33,9 @@ from .stats.ld import ld_matrix, ld_prune, maximal_independent_set
 from .stats.pc_relate import pc_relate
 from .stats.pca import pca
 from .stats.pedigree import (
-    inverse_additive_relationships,
     parent_indices,
     pedigree_inbreeding,
+    pedigree_inverse_relationship,
     pedigree_kinship,
     pedigree_relationship,
 )
@@ -83,12 +83,12 @@ __all__ = [
     "infer_call_ploidy",
     "infer_sample_ploidy",
     "infer_variant_ploidy",
-    "inverse_additive_relationships",
     "ld_matrix",
     "ld_prune",
     "maximal_independent_set",
     "parent_indices",
     "pedigree_inbreeding",
+    "pedigree_inverse_relationship",
     "pedigree_kinship",
     "pedigree_relationship",
     "sample_stats",

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -731,14 +731,14 @@ Probability of IBD among gamete alleles resulting from meiotic processes.
 )
 
 (
-    stat_inverse_additive_relationship,
-    stat_inverse_additive_relationship_spec,
+    stat_pedigree_inverse_relationship,
+    stat_pedigree_inverse_relationship_spec,
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "stat_inverse_additive_relationship",
+        "stat_pedigree_inverse_relationship",
         ndim=2,
         kind="f",
-        __doc__="""Inverse of the additive relationship matrix.""",
+        __doc__="""Inverse of a relationship matrix calculated from pedigree structure.""",
     )
 )
 


### PR DESCRIPTION
Fixes #897

This method uses the same approach as `pedigree_inbreeding` to calculate only a minimal subset of kinship values required for the inverse relationship matrix. Currently this method is still returning a dense matrix (as opposed to a sparse matrix), so the potential memory reduction isn't realized. However, it should be simple to generalize this code to a sparse encoding if/when required.

With some simple benchmarking using real pedigrees of approx 6500 samples (mentioned in #891) I'm seeing approximately a 3x speed up relative to the `pedigree_kinship` method which was a dependency of the old `inverse_additive_relationships` method. However, this speed up will depend on pedigree structure.

One of the changes in this PR is that the internal `inbreeding_Hamilton_Kerr` method now returns a `parent_kinship` array in addition to the `inbreeding` array. This is close to free and I don't see a noticeable slowdown in benchmarks.

I did consider having the public  `pedigree_inbreeding` method also return a `parent_kinship` array (i.e., add it to the schema), and then have the new `pedigree_inverse_relationship` consume both of these arrays. However, I chose to avoid this (at least for now) as we may want to add alternative methods of calculating inverse relationships that wouldn't consume those arrays.