### PR TITLE
Remove cyvcf2 pin

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,10 +46,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        # see https://github.com/pystatgen/sgkit/issues/887
-        exclude:
-          - os: macos-latest
-            python-version: "3.10"
     runs-on: ${{ matrix.os }}
     steps:
       # checkout repo to subdirectory to get access to scripts

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ bed-reader
 rechunker
 cbgen; python_version<="3.7" or platform_system != "Windows"
 cbgen == 1.0.1; python_version>"3.7" and platform_system == "Windows"
-cyvcf2 < 0.30.15; platform_system != "Windows"
+cyvcf2; platform_system != "Windows"
 yarl
 matplotlib
 asv

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ plink =
     bed-reader
 vcf =
     aiohttp
-    cyvcf2 < 0.30.15
+    cyvcf2
     requests
     yarl
 bgen =


### PR DESCRIPTION
since https://github.com/brentp/cyvcf2/issues/248 is fixed and cyvcf2 0.30.17 has been released.

This fixes #887 and reverts #833.

I've tested that the wheels build successfully with these changes here: https://github.com/tomwhite/sgkit/actions/runs/3144967267/jobs/5111666983