### PR TITLE
Add dimension names to ArrayLikeSpec

### DIFF
--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -801,8 +801,8 @@ def Garud_H(
     """Compute the H1, H12, H123 and H2/H1 statistics for detecting signatures
     of soft sweeps, as defined in Garud et al. (2015).
 
-    By default, values of this statistic are calculated across all variants.
-    To compute values in windows, call :func:`window_by_position` or :func:`window_by_variant` before calling
+    This method requires a windowed dataset.
+    To window a dataset, call :func:`window_by_position` or :func:`window_by_variant` before calling
     this function.
 
     Parameters
@@ -846,6 +846,8 @@ def Garud_H(
     ------
     NotImplementedError
         If the dataset is not diploid.
+    ValueError
+        If the dataset is not windowed.
 
     Warnings
     --------

--- a/sgkit/tests/test_variables.py
+++ b/sgkit/tests/test_variables.py
@@ -1,8 +1,11 @@
+import re
+
 import numpy as np
 import pytest
 import xarray as xr
 
 from sgkit import variables
+from sgkit.utils import DimensionWarning
 from sgkit.variables import ArrayLikeSpec, SgkitVariables
 
 
@@ -104,3 +107,133 @@ def test_variables_in_multi_index(dummy_ds: xr.Dataset) -> None:
 
     spec = ArrayLikeSpec("foo", "foo doc", kind="i", ndim=1)
     variables.validate(ds, spec)
+
+
+def test_variables__validate_dims_optional():
+    spec = ArrayLikeSpec(
+        "foo",
+        "foo doc",
+        kind="i",
+        dims=({None, "windows", "variants"}, "samples", "ploidy"),
+    )
+    ds = xr.Dataset()
+    ds["valid_0"] = ("samples", "ploidy"), np.ones((2, 3), int)
+    ds["valid_1"] = ("windows", "samples", "ploidy"), np.ones((1, 2, 3), int)
+    ds["valid_2"] = ("variants", "samples", "ploidy"), np.ones((2, 2, 3), int)
+    # test cases that validate dim names not number of dims
+    ds["invalid_0"] = ("ploidy", "samples"), np.ones((3, 2), int)
+    ds["invalid_1"] = ("windows", "samples"), np.ones((1, 2), int)
+    ds["invalid_2"] = ("genome", "samples", "ploidy"), np.ones((1, 2, 3), int)
+    variables.validate(ds, {"valid_0": spec, "valid_1": spec, "valid_2": spec})
+    for variable in ["invalid_0", "invalid_1", "invalid_2"]:
+        with pytest.warns(DimensionWarning):
+            variables.validate(ds, {variable: spec})
+
+
+def test_variables__validate_dims_wildcard():
+    spec = ArrayLikeSpec("foo", "foo doc", kind="i", dims=({"*", None}, "*", "ploidy"))
+    ds = xr.Dataset()
+    ds["valid_0"] = ("inner_0", "ploidy"), np.ones((2, 3), int)
+    ds["valid_1"] = ("outer_0", "inner_0", "ploidy"), np.ones((1, 2, 3), int)
+    ds["valid_2"] = ("outer_1", "inner_1", "ploidy"), np.ones((2, 2, 3), int)
+    # test cases that validate dim names not number of dims
+    ds["invalid_0"] = ("ploidy", "inner_0"), np.ones((3, 2), int)
+    ds["invalid_1"] = ("outer_0", "inner_0", "alleles"), np.ones((1, 2, 3), int)
+    variables.validate(ds, {"valid_0": spec, "valid_1": spec, "valid_2": spec})
+    for variable in ["invalid_0", "invalid_1"]:
+        with pytest.warns(
+            DimensionWarning,
+            match=re.escape(f"Dimensions {ds[variable].dims} do not match {spec.dims}"),
+        ):
+            variables.validate(ds, {variable: spec})
+
+
+def test_variables__validate_dims_multiple_matches():
+    spec = ArrayLikeSpec(
+        "foo", "foo doc", kind="i", dims=({"variants", None}, "*", {"alleles", None})
+    )
+    ds = xr.Dataset()
+    ds["variable"] = ("variants", "alleles"), np.ones((2, 3), int)
+    with pytest.warns(
+        DimensionWarning,
+        match=re.escape(f"Dimensions {ds.variable.dims} match 2 ways to {spec.dims}"),
+    ):
+        variables.validate(ds, {"variable": spec})
+
+
+@pytest.mark.parametrize(
+    "ndim,dims,valid",
+    [
+        (1, ("dim0",), True),
+        (1, ({"dim0", "dim1"},), True),
+        (
+            2,
+            (
+                {"dim0", "dim1"},
+                "dim2",
+            ),
+            True,
+        ),
+        (
+            {1, 2},
+            (
+                {"dim0", None},
+                "dim1",
+            ),
+            True,
+        ),
+        (2, ("dim0",), False),
+        ({1, 2}, ({"dim0", "dim1"},), False),
+        (
+            {1, 2},
+            (
+                {"dim0", "dim1"},
+                "dim2",
+            ),
+            False,
+        ),
+        (
+            2,
+            (
+                {"dim0", None},
+                "dim1",
+            ),
+            False,
+        ),
+    ],
+)
+def test_ArrayLikeSpec__ndim_matches_dims(ndim, dims, valid):
+    if valid:
+        ArrayLikeSpec("foo", "foo doc", kind="i", ndim=ndim, dims=dims)
+    else:
+        message = re.escape(f"Specified ndim '{ndim}' does not match dims {dims}")
+        with pytest.raises(ValueError, match=message):
+            ArrayLikeSpec("foo", "foo doc", kind="i", ndim=ndim, dims=dims)
+
+
+@pytest.mark.parametrize(
+    "ndim,dims",
+    [
+        (1, ("dim0",)),
+        (1, ({"dim0", "dim1"},)),
+        (
+            2,
+            (
+                {"dim0", "dim1"},
+                "dim2",
+            ),
+        ),
+        (
+            {1, 2},
+            (
+                {"dim0", None},
+                "dim1",
+            ),
+        ),
+    ],
+)
+def test_ArrayLikeSpec__auto_fill_ndim(ndim, dims):
+    # create spec without ndim
+    spec = ArrayLikeSpec("foo", "foo doc", kind="i", dims=dims)
+    # check ndim calculated correctly
+    assert spec.ndim == ndim

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -21,10 +21,59 @@ class Spec:
 
 @dataclass(frozen=True, eq=False)
 class ArrayLikeSpec(Spec):
-    """ArrayLike type spec"""
+    """ArrayLike type spec.
+
+    Parameters
+    ----------
+    __doc__
+        Description of array.
+    kind
+        Array dtype kind following numpy conventions.
+        A set may be used to indicate multiple valid kinds.
+    ndim
+        Number of array dimensions.
+        A set may be used to indicate a variable number of dimensions.
+    dims
+        Tuple of expected dimension names.
+        A set may be used to indicate multiple valid names.
+        A set containing None may be used to indicate an optional dimension.
+        A wildcard ``"*"`` may be used to match any name.
+
+    Note
+    ----
+    If ndim is not specified and dims is specified then ndim will automatically
+    be calculated from the dims variable.
+
+    Raises
+    ------
+    ValueError
+        If conflicting ndim and dims are specified.
+    """
 
     kind: Union[None, str, Set[str]] = None
     ndim: Union[None, int, Set[int]] = None
+    dims: Union[None, Tuple[Union[Set[Union[None, str]], str]]] = None
+
+    def __post_init__(self):
+        if self.dims:
+            # calculate ndim from dims
+            maximum = len(self.dims)
+            optional = sum(
+                None in d if isinstance(d, set) else False for d in self.dims
+            )
+            if optional == 0:
+                ndim = maximum
+            else:
+                ndim = {maximum - i for i in range(optional + 1)}
+            if self.ndim:
+                # check correct
+                if ndim != self.ndim:
+                    raise ValueError(
+                        f"Specified ndim '{self.ndim}' does not match dims {self.dims}"
+                    )
+            else:
+                # use calculated ndim
+                object.__setattr__(self, "ndim", ndim)
 
 
 class SgkitVariables:
@@ -148,7 +197,12 @@ class SgkitVariables:
         try:
             arr = xr_dataset[field]
             try:
-                check_array_like(arr, kind=field_spec.kind, ndim=field_spec.ndim)
+                check_array_like(
+                    arr,
+                    kind=field_spec.kind,
+                    ndim=field_spec.ndim,
+                    dims=field_spec.dims,
+                )
                 if add_comment_attr and field_spec.__doc__ is not None:
                     arr.attrs["comment"] = field_spec.__doc__.strip()
             except (TypeError, ValueError) as e:
@@ -184,7 +238,7 @@ specific page.
 call_allele_count, call_allele_count_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_allele_count",
-        ndim=3,
+        dims=("variants", "samples", "alleles"),
         kind="u",
         __doc__="""
 Allele counts. With shape (variants, samples, alleles) and values
@@ -196,7 +250,7 @@ corresponding to the number of non-missing occurrences of each allele.
 call_allele_frequency, call_allele_frequency_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_allele_frequency",
-        ndim=3,
+        dims=("variants", "samples", "alleles"),
         kind="f",
         __doc__="""
 Allele frequencies. With shape (variants, samples, alleles) and values
@@ -209,7 +263,7 @@ call_dosage, call_dosage_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_dosage",
         kind="f",
-        ndim=2,
+        dims=("variants", "samples"),
         __doc__="""Dosages, encoded as floats, with NaN indicating a missing value.""",
     )
 )
@@ -218,7 +272,7 @@ call_dosage_mask, call_dosage_mask_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_dosage_mask",
         kind="b",
-        ndim=2,
+        dims=("variants", "samples"),
         __doc__="""A flag for each call indicating which values are missing.""",
     )
 )
@@ -227,7 +281,7 @@ call_genotype, call_genotype_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_genotype",
         kind="i",
-        ndim=3,
+        dims=("variants", "samples", "ploidy"),
         __doc__="""
 Call genotype. Encoded as allele values (0 for the reference, 1 for
 the first allele, 2 for the second allele), -1 to indicate a
@@ -240,7 +294,7 @@ call_genotype_mask, call_genotype_mask_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_genotype_mask",
         kind="b",
-        ndim=3,
+        dims=("variants", "samples", "ploidy"),
         __doc__="""A flag for each call indicating which values are missing.""",
     )
 )
@@ -249,7 +303,7 @@ call_genotype_mask, call_genotype_mask_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_genotype_fill",
         kind="b",
-        ndim=3,
+        dims=("variants", "samples", "ploidy"),
         __doc__="""
 A flag for each allele position within mixed ploidy call genotypes
 indicating fill (non-allele) values of lower ploidy calls.
@@ -261,7 +315,7 @@ call_genotype_phased, call_genotype_phased_spec = SgkitVariables.register_variab
     ArrayLikeSpec(
         "call_genotype_phased",
         kind="b",
-        ndim=2,
+        dims=("variants", "samples"),
         __doc__="""
 A flag for each call indicating if it is phased or not. If omitted
 all calls are unphased.
@@ -273,7 +327,7 @@ call_genotype_complete, call_genotype_complete_spec = SgkitVariables.register_va
     ArrayLikeSpec(
         "call_genotype_complete",
         kind="i",
-        ndim=3,
+        dims=("variants", "samples", "ploidy"),
         __doc__="""
 Call genotypes in which partial genotype calls are replaced with
 completely missing genotype calls.
@@ -288,7 +342,7 @@ completely missing genotype calls.
     ArrayLikeSpec(
         "call_genotype_complete_mask",
         kind="b",
-        ndim=3,
+        dims=("variants", "samples", "ploidy"),
         __doc__="""A flag for each call indicating which values are missing.""",
     )
 )
@@ -300,7 +354,7 @@ completely missing genotype calls.
     ArrayLikeSpec(
         "call_genotype_probability",
         kind="f",
-        ndim=3,
+        dims=("variants", "samples", "genotypes"),
         __doc__="""Genotype probabilities.""",
     )
 )
@@ -312,7 +366,7 @@ completely missing genotype calls.
     ArrayLikeSpec(
         "call_genotype_probability_mask",
         kind="b",
-        ndim=3,
+        dims=("variants", "samples", "genotypes"),
         __doc__="""A flag for each call indicating which values are missing.""",
     )
 )
@@ -321,7 +375,7 @@ call_heterozygosity, call_heterozygosity_spec = SgkitVariables.register_variable
     ArrayLikeSpec(
         "call_heterozygosity",
         kind="f",
-        ndim=2,
+        dims=("variants", "samples"),
         __doc__="""
 Observed heterozygosity of each call genotype.
 """,
@@ -332,14 +386,17 @@ call_ploidy, call_ploidy_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_ploidy",
         kind="i",
-        ndim=2,
+        dims=("variants", "samples"),
         __doc__="Call genotype ploidy.",
     )
 )
 
 cohort_allele_count, cohort_allele_count_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "cohort_allele_count", kind="u", ndim=3, __doc__="""Cohort allele counts."""
+        "cohort_allele_count",
+        kind="u",
+        dims=("variants", "cohorts", "alleles"),
+        __doc__="""Cohort allele counts.""",
     )
 )
 
@@ -349,7 +406,7 @@ cohort_allele_count, cohort_allele_count_spec = SgkitVariables.register_variable
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "cohort_allele_frequency",
-        ndim=3,
+        dims=("variants", "cohorts", "alleles"),
         kind="f",
         __doc__="""
 Cohort Allele frequencies. With shape (variants, cohorts, alleles) and values
@@ -401,7 +458,7 @@ across all samples for a variant.
 stat_identity_by_state, stat_identity_by_state_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_identity_by_state",
-        ndim=2,
+        dims=("samples_0", "samples_1"),
         kind="f",
         __doc__="""
 Pairwise IBS probabilities among all samples.
@@ -423,7 +480,7 @@ Variant indexes to drop for LD prune.
 parent, parent_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "parent",
-        ndim=2,
+        dims=("samples", "parents"),
         kind="i",
         __doc__="""
 Indices of parent samples with negative values indicating unknown parents.
@@ -434,7 +491,7 @@ Indices of parent samples with negative values indicating unknown parents.
 parent_id, parent_id_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "parent_id",
-        ndim=2,
+        dims=("samples", "parents"),
         kind={"S", "U", "O"},
         __doc__="""
 Unique identifiers of parent samples matching those in
@@ -449,7 +506,7 @@ Unique identifiers of parent samples matching those in
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "regenie_base_prediction",
-        ndim=4,
+        dims=("blocks", "alphas", "samples", "outcomes"),
         kind="f",
         __doc__="""
 REGENIE's base prediction (blocks, alphas, samples, outcomes). Stage 1
@@ -464,7 +521,7 @@ predictions from ridge regression reduction.
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "regenie_loco_prediction",
-        ndim=3,
+        dims=("contigs", "samples", "outcomes"),
         kind="f",
         __doc__="""
 REGENIE's regenie_loco_prediction (contigs, samples, outcomes). LOCO predictions
@@ -481,7 +538,7 @@ at least 2 contigs.
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "regenie_meta_prediction",
-        ndim=2,
+        dims=("samples", "outcomes"),
         kind="f",
         __doc__="""
 REGENIE's regenie_meta_prediction (samples, outcomes). Stage 2 predictions from
@@ -493,7 +550,7 @@ the best meta estimator trained on the out-of-sample Stage 1 predictions.
 pc_relate_phi, pc_relate_phi_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "pc_relate_phi",
-        ndim=2,
+        dims=("samples_0", "samples_1"),
         kind="f",
         __doc__="""PC Relate kinship coefficient matrix.""",
     )
@@ -502,7 +559,7 @@ pc_relate_phi, pc_relate_phi_spec = SgkitVariables.register_variable(
 sample_call_rate, sample_call_rate_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_call_rate",
-        ndim=1,
+        dims=("samples",),
         kind="f",
         __doc__="""The fraction of variants with called genotypes.""",
     )
@@ -511,7 +568,7 @@ sample_call_rate, sample_call_rate_spec = SgkitVariables.register_variable(
 sample_cohort, sample_cohort_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_cohort",
-        ndim=1,
+        dims=("samples",),
         kind="i",
         __doc__="""The index of the cohort that each sample belongs to.
 A negative value indicates a sample is not a member of any cohort.""",
@@ -522,7 +579,7 @@ sample_id, sample_id_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_id",
         kind={"S", "U", "O"},
-        ndim=1,
+        dims=("samples",),
         __doc__="""The unique identifier of the sample.""",
     )
 )
@@ -530,7 +587,7 @@ sample_id, sample_id_spec = SgkitVariables.register_variable(
 sample_n_called, sample_n_called_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_n_called",
-        ndim=1,
+        dims=("samples",),
         kind="i",
         __doc__="""The number of variants with called genotypes.""",
     )
@@ -539,7 +596,7 @@ sample_n_called, sample_n_called_spec = SgkitVariables.register_variable(
 sample_n_het, sample_n_het_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_n_het",
-        ndim=1,
+        dims=("samples",),
         kind="i",
         __doc__="""The number of variants with heterozygous calls.""",
     )
@@ -548,7 +605,7 @@ sample_n_het, sample_n_het_spec = SgkitVariables.register_variable(
 sample_n_hom_alt, sample_n_hom_alt_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_n_hom_alt",
-        ndim=1,
+        dims=("samples",),
         kind="i",
         __doc__="""The number of variants with homozygous alternate calls.""",
     )
@@ -557,7 +614,7 @@ sample_n_hom_alt, sample_n_hom_alt_spec = SgkitVariables.register_variable(
 sample_n_hom_ref, sample_n_hom_ref_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_n_hom_ref",
-        ndim=1,
+        dims=("samples",),
         kind="i",
         __doc__="""The number of variants with homozygous reference calls.""",
     )
@@ -566,7 +623,7 @@ sample_n_hom_ref, sample_n_hom_ref_spec = SgkitVariables.register_variable(
 sample_n_non_ref, sample_n_non_ref_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_n_non_ref",
-        ndim=1,
+        dims=("samples",),
         kind="i",
         __doc__="""The number of variants that are not homozygous reference calls.""",
     )
@@ -575,7 +632,7 @@ sample_n_non_ref, sample_n_non_ref_spec = SgkitVariables.register_variable(
 sample_pca_component, sample_pca_component_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_pca_component",
-        ndim=2,
+        dims=("variants", "components"),
         kind="f",
         __doc__="""Principal axes defined as eigenvectors for sample covariance matrix.
 In the context of SVD, these are equivalent to the right singular vectors in
@@ -589,7 +646,7 @@ the decomposition of a (N, M) matrix., i.e. ``dask_ml.decomposition.TruncatedSVD
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_pca_explained_variance",
-        ndim=1,
+        dims=("components",),
         kind="f",
         __doc__="""Variance explained by each principal component. These values are equivalent
 to eigenvalues that result from the eigendecomposition of a (N, M) matrix,
@@ -603,7 +660,7 @@ i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_``.""",
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_pca_explained_variance_ratio",
-        ndim=1,
+        dims=("components",),
         kind="f",
         __doc__="""Ratio of variance explained to total variance for each principal component,
 i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_ratio_``.""",
@@ -613,7 +670,7 @@ i.e. ``dask_ml.decomposition.TruncatedSVD.explained_variance_ratio_``.""",
 sample_pca_loading, sample_pca_loading_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_pca_loading",
-        ndim=2,
+        dims=("variants", "components"),
         kind="f",
         __doc__="""PCA loadings defined as principal axes scaled by square root of eigenvalues.
 These values  can also be interpreted  as the correlation between the original variables
@@ -624,7 +681,7 @@ and unit-scaled principal axes.""",
 sample_pca_projection, sample_pca_projection_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_pca_projection",
-        ndim=2,
+        dims=("samples", "components"),
         kind="f",
         __doc__="""Projection of samples onto principal axes. This array is commonly
 referred to as "scores" or simply "principal components (PCs)" for a set of samples.""",
@@ -635,7 +692,7 @@ sample_ploidy, sample_ploidy_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "sample_ploidy",
         kind="i",
-        ndim=1,
+        dims=("samples",),
         __doc__="""Ploidy of each sample calculated from call genotypes across all variants
 with -1 indicating variable ploidy.""",
     )
@@ -644,7 +701,7 @@ with -1 indicating variable ploidy.""",
 stat_Fst, stat_Fst_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Fst",
-        ndim=3,
+        dims=({"windows", "variants"}, "cohorts_0", "cohorts_1"),
         kind="f",
         __doc__="""Fixation index (Fst) between pairs of cohorts.""",
     )
@@ -653,7 +710,7 @@ stat_Fst, stat_Fst_spec = SgkitVariables.register_variable(
 stat_divergence, stat_divergence_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_divergence",
-        ndim=3,
+        dims=({"windows", "variants"}, "cohorts_0", "cohorts_1"),
         kind="f",
         __doc__="""Genetic divergence between pairs of cohorts.""",
     )
@@ -662,7 +719,7 @@ stat_divergence, stat_divergence_spec = SgkitVariables.register_variable(
 stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_diversity",
-        ndim=2,
+        dims=({"windows", "variants"}, "cohorts"),
         kind="f",
         __doc__="""Genetic diversity (also known as "Tajima’s pi") for cohorts.""",
     )
@@ -671,7 +728,7 @@ stat_diversity, stat_diversity_spec = SgkitVariables.register_variable(
 stat_Garud_h1, stat_Garud_h1_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Garud_h1",
-        ndim={1, 2},
+        dims=("windows", "cohorts"),
         kind="f",
         __doc__="""Garud H1 statistic for cohorts.""",
     )
@@ -680,7 +737,7 @@ stat_Garud_h1, stat_Garud_h1_spec = SgkitVariables.register_variable(
 stat_Garud_h12, stat_Garud_h12_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Garud_h12",
-        ndim={1, 2},
+        dims=("windows", "cohorts"),
         kind="f",
         __doc__="""Garud H12 statistic for cohorts.""",
     )
@@ -689,7 +746,7 @@ stat_Garud_h12, stat_Garud_h12_spec = SgkitVariables.register_variable(
 stat_Garud_h123, stat_Garud_h123_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Garud_h123",
-        ndim={1, 2},
+        dims=("windows", "cohorts"),
         kind="f",
         __doc__="""Garud H123 statistic for cohorts.""",
     )
@@ -698,7 +755,7 @@ stat_Garud_h123, stat_Garud_h123_spec = SgkitVariables.register_variable(
 stat_Garud_h2_h1, stat_Garud_h2_h1_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Garud_h2_h1",
-        ndim={1, 2},
+        dims=("windows", "cohorts"),
         kind="f",
         __doc__="""Garud H2/H1 statistic for cohorts.""",
     )
@@ -710,7 +767,7 @@ stat_Garud_h2_h1, stat_Garud_h2_h1_spec = SgkitVariables.register_variable(
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_genomic_relationship",
-        ndim=2,
+        dims=("samples_0", "samples_1"),
         kind="f",
         __doc__="""
 Genomic relationship matrix (GRM).
@@ -722,7 +779,7 @@ Genomic relationship matrix (GRM).
 stat_Hamilton_Kerr_tau, stat_Hamilton_Kerr_tau_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Hamilton_Kerr_tau",
-        ndim=2,
+        dims=("samples", "parents"),
         kind="u",
         __doc__="""
 Numerical contribution of each parent, for each individual, which must sum to the
@@ -743,7 +800,7 @@ See also: :data:`sgkit.variables.stat_Hamilton_Kerr_lambda_spec`.
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Hamilton_Kerr_lambda",
-        ndim=2,
+        dims=("samples", "parents"),
         kind="f",
         __doc__="""
 The probability that two (randomly chosen without replacement) homologues, inherited
@@ -763,7 +820,7 @@ See also: :data:`sgkit.variables.stat_Hamilton_Kerr_tau_spec`.
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_pedigree_inverse_relationship",
-        ndim=2,
+        dims=("samples_0", "samples_1"),
         kind="f",
         __doc__="""Inverse of a relationship matrix calculated from pedigree structure.""",
     )
@@ -776,7 +833,7 @@ See also: :data:`sgkit.variables.stat_Hamilton_Kerr_tau_spec`.
     ArrayLikeSpec(
         "stat_observed_heterozygosity",
         kind="f",
-        ndim=2,
+        dims=({"windows", "variants"}, "cohorts"),
         __doc__="""
 Observed heterozygosity for cohorts.
 """,
@@ -786,7 +843,7 @@ Observed heterozygosity for cohorts.
 stat_pbs, stat_pbs_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_pbs",
-        ndim=4,
+        dims=({"windows", "variants"}, "cohorts_0", "cohorts_1", "cohorts_2"),
         kind="f",
         __doc__="""Population branching statistic for cohort triples.""",
     )
@@ -798,7 +855,7 @@ stat_pbs, stat_pbs_spec = SgkitVariables.register_variable(
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_pedigree_inbreeding",
-        ndim=1,
+        dims=("samples",),
         kind="f",
         __doc__="""Expected inbreeding coefficients of samples based on pedigree structure.""",
     )
@@ -807,7 +864,7 @@ stat_pbs, stat_pbs_spec = SgkitVariables.register_variable(
 stat_pedigree_kinship, stat_pedigree_kinship_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_pedigree_kinship",
-        ndim=2,
+        dims=("samples_0", "samples_1"),
         kind="f",
         __doc__="""
 Pairwise estimates of expected kinship among samples based on pedigree structure
@@ -822,7 +879,7 @@ with self-kinship values on the diagonal.
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_pedigree_relationship",
-        ndim=2,
+        dims=("samples_0", "samples_1"),
         kind="f",
         __doc__="""Relationship matrix derived from pedigree structure.""",
     )
@@ -830,14 +887,17 @@ with self-kinship values on the diagonal.
 
 stat_Tajimas_D, stat_Tajimas_D_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "stat_Tajimas_D", ndim=2, kind="f", __doc__="""Tajima’s D for cohorts."""
+        "stat_Tajimas_D",
+        dims=({"windows", "variants"}, "cohorts"),
+        kind="f",
+        __doc__="""Tajima’s D for cohorts.""",
     )
 )
 
 stat_Weir_Goudet_beta, stat_Weir_Goudet_beta_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "stat_Weir_Goudet_beta",
-        ndim=2,
+        dims=("samples_0", "samples_1"),
         kind="f",
         __doc__="""Pairwise Weir Goudet beta statistic among all samples.""",
     )
@@ -846,7 +906,7 @@ stat_Weir_Goudet_beta, stat_Weir_Goudet_beta_spec = SgkitVariables.register_vari
 traits, traits_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "traits",
-        ndim={1, 2},
+        dims=("samples", {"*", None}),
         __doc__="""
 Trait (for example phenotype) variable names. Must all be continuous and
 correspond to 1 or 2D dataset variables of shape (samples[, traits]).
@@ -860,7 +920,7 @@ variant_allele, variant_allele_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_allele",
         kind={"S", "O"},
-        ndim=2,
+        dims=("variants", "alleles"),
         __doc__="""The possible alleles for the variant.""",
     )
 )
@@ -868,7 +928,7 @@ variant_allele, variant_allele_spec = SgkitVariables.register_variable(
 variant_allele_count, variant_allele_count_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_allele_count",
-        ndim=2,
+        dims=("variants", "alleles"),
         kind="u",
         __doc__="""
 Variant allele counts. With shape (variants, alleles) and values
@@ -883,7 +943,7 @@ corresponding to the number of non-missing occurrences of each allele.
 ) = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_allele_frequency",
-        ndim=2,
+        dims=("variants", "alleles"),
         kind="f",
         __doc__="""The frequency of the occurrence of each allele.""",
     )
@@ -892,7 +952,7 @@ corresponding to the number of non-missing occurrences of each allele.
 variant_allele_total, variant_allele_total_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_allele_total",
-        ndim=1,
+        dims=("variants",),
         kind="i",
         __doc__="""The number of occurrences of all alleles.""",
     )
@@ -901,6 +961,7 @@ variant_allele_total, variant_allele_total_spec = SgkitVariables.register_variab
 variant_linreg_beta, variant_linreg_beta_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_linreg_beta",
+        dims=("variants", "traits"),
         __doc__="""Beta values associated with each variant and trait.""",
     )
 )
@@ -915,7 +976,7 @@ variant_linreg_effect, variant_linreg_effect_spec = SgkitVariables.register_vari
 variant_call_rate, variant_call_rate_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_call_rate",
-        ndim=1,
+        dims=("variants",),
         kind="f",
         __doc__="""The fraction of samples with called genotypes.""",
     )
@@ -925,7 +986,7 @@ variant_contig, variant_contig_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_contig",
         kind={"i", "u"},
-        ndim=1,
+        dims=("variants",),
         __doc__="""
 Index corresponding to contig name for each variant. In some less common
 scenarios, this may also be equivalent to the contig names if the data
@@ -938,6 +999,7 @@ variant_hwe_p_value, variant_hwe_p_value_spec = SgkitVariables.register_variable
     ArrayLikeSpec(
         "variant_hwe_p_value",
         kind="f",
+        dims=("variants",),
         __doc__="""P values from HWE test for each variant as float in [0, 1].""",
     )
 )
@@ -946,7 +1008,7 @@ variant_id, variant_id_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_id",
         kind={"S", "U", "O"},
-        ndim=1,
+        dims=("variants",),
         __doc__="""The unique identifier of the variant.""",
     )
 )
@@ -954,8 +1016,8 @@ variant_id, variant_id_spec = SgkitVariables.register_variable(
 variant_n_called, variant_n_called_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_n_called",
-        ndim=1,
         kind="i",
+        dims=("variants",),
         __doc__="""The number of samples with called genotypes.""",
     )
 )
@@ -963,7 +1025,7 @@ variant_n_called, variant_n_called_spec = SgkitVariables.register_variable(
 variant_n_het, variant_n_het_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_n_het",
-        ndim=1,
+        dims=("variants",),
         kind="i",
         __doc__="""The number of samples with heterozygous calls.""",
     )
@@ -972,7 +1034,7 @@ variant_n_het, variant_n_het_spec = SgkitVariables.register_variable(
 variant_n_hom_alt, variant_n_hom_alt_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_n_hom_alt",
-        ndim=1,
+        dims=("variants",),
         kind="i",
         __doc__="""The number of samples with homozygous alternate calls.""",
     )
@@ -981,7 +1043,7 @@ variant_n_hom_alt, variant_n_hom_alt_spec = SgkitVariables.register_variable(
 variant_n_hom_ref, variant_n_hom_ref_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_n_hom_ref",
-        ndim=1,
+        dims=("variants",),
         kind="i",
         __doc__="""The number of samples with homozygous reference calls.""",
     )
@@ -990,7 +1052,7 @@ variant_n_hom_ref, variant_n_hom_ref_spec = SgkitVariables.register_variable(
 variant_n_non_ref, variant_n_non_ref_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_n_non_ref",
-        ndim=1,
+        dims=("variants",),
         kind="i",
         __doc__="""The number of samples that are not homozygous reference calls.""",
     )
@@ -998,7 +1060,10 @@ variant_n_non_ref, variant_n_non_ref_spec = SgkitVariables.register_variable(
 
 variant_linreg_p_value, variant_linreg_p_value_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
-        "variant_linreg_p_value", kind="f", __doc__="""P values as float in [0, 1]."""
+        "variant_linreg_p_value",
+        kind="f",
+        dims=("variants", "traits"),
+        __doc__="""P values as float in [0, 1].""",
     )
 )
 
@@ -1006,19 +1071,23 @@ variant_position, variant_position_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_position",
         kind="i",
-        ndim=1,
+        dims=("variants",),
         __doc__="""The reference position of the variant.""",
     )
 )
 variant_linreg_t_value, variant_linreg_t_value_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec("variant_linreg_t_value", __doc__="""T statistics for each beta.""")
+    ArrayLikeSpec(
+        "variant_linreg_t_value",
+        dims=("variants", "traits"),
+        __doc__="""T statistics for each beta.""",
+    )
 )
 
 variant_ploidy, variant_ploidy_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_ploidy",
         kind="i",
-        ndim=1,
+        dims=("variants",),
         __doc__="""Ploidy of each variant calculated from call genotypes across all samples
 with -1 indicating variable ploidy.""",
     )
@@ -1027,7 +1096,7 @@ with -1 indicating variable ploidy.""",
 variant_score, variant_score_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_score",
-        ndim=1,
+        dims=("variants",),
         kind="f",
         __doc__="""
 Scores to prioritize variant selection when constructing an LD matrix.
@@ -1039,7 +1108,7 @@ window_contig, window_contig_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "window_contig",
         kind="i",
-        ndim=1,
+        dims=("windows",),
         __doc__="""The contig index of each window.""",
     )
 )
@@ -1048,7 +1117,7 @@ window_start, window_start_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "window_start",
         kind="i",
-        ndim=1,
+        dims=("windows",),
         __doc__="""The index values of window start positions along the ``variants`` dimension.""",
     )
 )
@@ -1057,7 +1126,7 @@ window_stop, window_stop_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "window_stop",
         kind="i",
-        ndim=1,
+        dims=("windows",),
         __doc__="""The index values of window stop positions along the ``variants`` dimension.""",
     )
 )

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -966,13 +966,6 @@ variant_linreg_beta, variant_linreg_beta_spec = SgkitVariables.register_variable
     )
 )
 
-variant_linreg_effect, variant_linreg_effect_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec(
-        "variant_linreg_effect",
-        __doc__="""Effect size estimate for each variant and trait.""",
-    )
-)
-
 variant_call_rate, variant_call_rate_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "variant_call_rate",


### PR DESCRIPTION
This is a proof of concept for #904.

It adds the option of named dimensions to `ArrayLikeSpec`. Individual dims can be optional, have multiple valid names, or be unnamed using a wildcard ("*"). 

If `dims` is specified without `ndim` then `ndim` will be calculated from `dims`. If they are both specified then they are checked for congruence. Dimension names are checked as part of variable validation and a `DimensionWarning` is given if the observed `dims` don't match the spec. A `DimensionWarning`  is also given if a spec is so vague that there is more than one possible mapping of array dims to spec dims (this is only possible with multiple optional dims and isn't an issue for any current variables).

I've possibly been a bit heavy handed with adding named dimensions to variables and some of these could be rolled back. I also identified a few slightly inconsistent variables that may be worth altering (possible breaking changes):

- `genotype_count` could have "genotypes" as second dimension but we should consider resolving  #911 first.
- `ld_prune_index_to_drop` has a unique dimension "variant_indexes" and holds integer indices for a subset of variants,
  I wonder if this could be replaced with a length "variants" array of booleans to avoid adding a new dimension?
- `variant_linreg_effect` doesn't appear to be used, can it be removed?

It would also be nice to automatically add the `ndim` and `dims` field to the `__doc__` string, is there a more elegant way to do this than just appending within the `__post_init__` method?