### PR TITLE
Remove unused max length calculations

### DIFF
--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -421,8 +421,6 @@ def vcf_to_zarr_sequential(
             filters.insert(0, "PASS")
 
         # Remember max lengths of variable-length strings
-        max_variant_id_length = 0
-        max_variant_allele_length = 0
         max_alt_alleles_seen = 0
 
         # Iterate through variants in batches of chunk_length
@@ -468,7 +466,6 @@ def vcf_to_zarr_sequential(
             for i, variant in enumerate(variants_chunk):
                 variant_id = variant.ID if variant.ID is not None else "."
                 variant_ids.append(variant_id)
-                max_variant_id_length = max(max_variant_id_length, len(variant_id))
                 try:
                     variant_contig[i] = variant_contig_names.index(variant.CHROM)
                 except ValueError:
@@ -484,9 +481,6 @@ def vcf_to_zarr_sequential(
                 elif len(alleles) < n_allele:
                     alleles = alleles + ([STR_FILL] * (n_allele - len(alleles)))
                 variant_alleles.append(alleles)
-                max_variant_allele_length = max(
-                    max_variant_allele_length, max(len(x) for x in alleles)
-                )
 
                 variant_quality[i] = (
                     variant.QUAL if variant.QUAL is not None else FLOAT32_MISSING

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -827,6 +827,19 @@ def test_vcf_to_zarr__parallel_with_fields(shared_datadir, tmp_path):
         variants=slice((0, 10001661), (0, 10001670))
     )
 
+    # check strings have not been truncated after concat_zarrs
+    assert_array_equal(
+        ds["variant_allele"],
+        np.array(
+            [
+                ["T", "C", "<NON_REF>", ""],
+                ["T", "<NON_REF>", "", ""],
+                ["T", "G", "<NON_REF>", ""],
+            ],
+            dtype="O",
+        ),
+    )
+
     # convert floats to ints to check nan type
     fill = FLOAT32_FILL
     assert_allclose(


### PR DESCRIPTION
I'm working with TB VCF files, some of which have ~2000 alt alleles, requiring a high `max_alt_alleles` argument to `vcf_to_zarr`. 
It seems VCF performance scales very poorly with this parameter.
Profiling showed that 40% of this time was spent running `max` in `vcf_to_zarr_sequential`, as `max` is called with a `max_alt_alleles` length array for each variant. However the result of this operation isn't used (as far as I could tell) so this PR removes those lines.