### PR TITLE
Improve default VCF compression

### DIFF
--- a/sgkit/io/vcf/__init__.py
+++ b/sgkit/io/vcf/__init__.py
@@ -3,6 +3,7 @@ import platform
 try:
     from .vcf_partition import partition_into_regions
     from .vcf_reader import (
+        FloatFormatFieldWarning,
         MaxAltAllelesExceededWarning,
         concat_zarrs,
         vcf_to_zarr,
@@ -10,6 +11,7 @@ try:
     )
 
     __all__ = [
+        "FloatFormatFieldWarning",
         "MaxAltAllelesExceededWarning",
         "concat_zarrs",
         "partition_into_regions",

--- a/sgkit/io/vcf/utils.py
+++ b/sgkit/io/vcf/utils.py
@@ -196,7 +196,7 @@ def get_default_vcf_encoding(ds, chunk_length, chunk_width, compressor):
 
         # Position is monotonically increasing (within a contig) so benefits from delta encoding
         if var == "variant_position":
-            default_encoding[var]["filters"] = [Delta(dtype="i4", astype="i4")]
+            default_encoding[var]["filters"] = [Delta(ds[var].dtype)]
 
     return default_encoding
 

--- a/sgkit/io/vcf/utils.py
+++ b/sgkit/io/vcf/utils.py
@@ -168,3 +168,32 @@ def temporary_directory(
     finally:
         # Remove the temporary directory on exiting the context manager
         fs.rm(tempdir, recursive=True)
+
+
+def merge_encodings(
+    default_encoding: Dict[str, Dict[str, Any]], overrides: Dict[str, Dict[str, Any]]
+) -> Dict[str, Dict[str, Any]]:
+    """Merge a dictionary of dictionaries specifying encodings with another dictionary of dictionaries of overriding encodings.
+
+    Parameters
+    ----------
+    default_encoding : Dict[str, Dict[str, Any]]
+        The default encoding dictionary.
+    overrides : Dict[str, Dict[str, Any]]
+        A dictionary containing selective overrides.
+
+    Returns
+    -------
+    Dict[str, Dict[str, Any]]
+        The merged encoding dictionary
+    """
+    merged = {}
+    for var, d in default_encoding.items():
+        if var in overrides:
+            merged[var] = {**d, **overrides[var]}
+        else:
+            merged[var] = d
+    for var, d in overrides.items():
+        if var not in merged:
+            merged[var] = d
+    return merged

--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -37,7 +37,13 @@ from sgkit.io.utils import (
     STR_MISSING,
 )
 from sgkit.io.vcf import partition_into_regions
-from sgkit.io.vcf.utils import build_url, chunks, temporary_directory, url_filename
+from sgkit.io.vcf.utils import (
+    build_url,
+    chunks,
+    merge_encodings,
+    temporary_directory,
+    url_filename,
+)
 from sgkit.io.vcfzarr_reader import (
     concat_zarrs_optimized,
     vcf_number_to_dimension_and_size,
@@ -556,7 +562,7 @@ def vcf_to_zarr_sequential(
 
                 # values from function args (encoding) take precedence over default_encoding
                 encoding = encoding or {}
-                merged_encoding = {**default_encoding, **encoding}
+                merged_encoding = merge_encodings(default_encoding, encoding)
 
                 ds.to_zarr(output, mode="w", encoding=merged_encoding)
                 first_variants_chunk = False

--- a/sgkit/tests/io/vcf/test_utils.py
+++ b/sgkit/tests/io/vcf/test_utils.py
@@ -6,7 +6,7 @@ import fsspec
 import pytest
 from callee.strings import StartsWith
 
-from sgkit.io.vcf.utils import build_url, chunks, temporary_directory
+from sgkit.io.vcf.utils import build_url, chunks, merge_encodings, temporary_directory
 from sgkit.io.vcf.vcf_reader import get_region_start
 
 
@@ -118,3 +118,14 @@ def test_chunks(x, n, expected_values):
 )
 def test_get_region_start(region: str, expected: int):
     assert get_region_start(region) == expected
+
+
+def test_merge_encodings():
+    default_encoding = dict(a=dict(a1=1, a2=2), b=dict(b1=5))
+    overrides = dict(a=dict(a1=0, a3=3), c=dict(c1=7))
+    assert merge_encodings(default_encoding, overrides) == dict(
+        a=dict(a1=0, a2=2, a3=3), b=dict(b1=5), c=dict(c1=7)
+    )
+
+    assert merge_encodings(default_encoding, {}) == default_encoding
+    assert merge_encodings({}, overrides) == overrides

--- a/sgkit/tests/io/vcf/test_vcf_lossless_conversion.py
+++ b/sgkit/tests/io/vcf/test_vcf_lossless_conversion.py
@@ -17,6 +17,7 @@ from .vcf_writer import canonicalize_vcf, zarr_to_vcf
     ],
 )
 @pytest.mark.filterwarnings(
+    "ignore::sgkit.io.vcf.FloatFormatFieldWarning",
     "ignore::sgkit.io.vcfzarr_reader.DimensionNameForFixedFormatFieldWarning",
 )
 def test_lossless_conversion(shared_datadir, tmp_path, vcf_file):

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -14,7 +14,7 @@ from sgkit.io.vcf import (
     partition_into_regions,
     vcf_to_zarr,
 )
-from sgkit.io.vcf.vcf_reader import zarr_array_sizes
+from sgkit.io.vcf.vcf_reader import FloatFormatFieldWarning, zarr_array_sizes
 from sgkit.tests.io.test_dataset import assert_identical
 
 from .utils import path_for_test
@@ -297,6 +297,20 @@ def test_vcf_to_zarr__parallel_compressor_and_filters(
     assert z["variant_position"].filters == [
         Delta(dtype="i4", astype="i4")
     ]  # sgkit default
+
+
+def test_vcf_to_zarr__float_format_field_warning(shared_datadir, tmp_path):
+    path = path_for_test(shared_datadir, "simple.output.mixed_depth.likelihoods.vcf")
+    output = tmp_path.joinpath("vcf.zarr").as_posix()
+
+    with pytest.warns(FloatFormatFieldWarning):
+        vcf_to_zarr(
+            path,
+            output,
+            ploidy=4,
+            max_alt_alleles=3,
+            fields=["FORMAT/GL"],
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This implements some of the findings in #925

* Adds Delta encoding (filter) for VCF POS fields
* Issue a warning if there are float FORMAT fields with no filters set
* Adds a section of documention to the VCF covering compression, and giving an example of how to truncate float fields to 2dp. 
* 0efd28a7826aac6b14f74bedd41ab880338eb8f2 is a fix for a bug where if you specify the filters for a dataset variable then the default sgkit compressor is ignored since the dictionaries weren't being merged correctly.

I considered always rounding FORMAT float fields to 2dp, but there are problems with NaN (can't use FixedScaleOffset since it doesn't preserve NaNs) and precision (which integer type to use for FixedScaleOffset depends on the range of the values).

Quantize and Bitround do better here (both support NaN), but they are not as compact as FixedScaleOffset. It's probably worth doing more investigation into them (another PR?), but so far in this PR I have just added a warning that suggests setting filters, which is a good start.