### PR TITLE
VCF writer using numba

### DIFF
--- a/sgkit/io/vcf/vcf_writer.py
+++ b/sgkit/io/vcf/vcf_writer.py
@@ -1,0 +1,312 @@
+import re
+from contextlib import ExitStack
+from pathlib import Path
+from typing import MutableMapping, TextIO, Union
+
+import numpy as np
+from xarray import Dataset
+
+from sgkit import load_dataset
+from sgkit.io.vcf.vcf_writer_utils import (
+    byte_buf_to_str,
+    create_mask,
+    interleave,
+    vcf_fixed_to_byte_buf,
+    vcf_fixed_to_byte_buf_size,
+    vcf_format_missing_to_byte_buf,
+    vcf_format_names_to_byte_buf,
+    vcf_format_names_to_byte_buf_size,
+    vcf_genotypes_to_byte_buf,
+    vcf_genotypes_to_byte_buf_size,
+    vcf_info_to_byte_buf,
+    vcf_info_to_byte_buf_size,
+    vcf_values_to_byte_buf,
+    vcf_values_to_byte_buf_size,
+)
+from sgkit.typing import PathType
+
+
+def dataset_to_vcf(
+    input: Dataset,
+    output: Union[PathType, TextIO],
+) -> None:
+    """Convert a dataset to a VCF file.
+
+    Warnings
+    --------
+    This function requires the dataset to have a ``vcf_header`` attribute
+    containing the VCF header. VCF files converted to Zarr using :func:`vcf_to_zarr`
+    will contain this attribute, but datasets loaded from other sources will not.
+
+    The current implementation loads the entire dataset into memory, so it should
+    only be used on suitably-sized datasets.
+
+    Parameters
+    ----------
+    input
+        Dataset to convert to VCF.
+    output
+        A path or text file object that the output VCF should be written to.
+    """
+
+    ds = input.load()
+
+    header_str = ds.attrs["vcf_header"]
+
+    n_variants = ds.dims["variants"]
+    n_samples = ds.dims["samples"]
+
+    with ExitStack() as stack:
+        if isinstance(output, str) or isinstance(output, Path):
+            output = stack.enter_context(open(output, mode="w"))
+
+        print(header_str, end="", file=output)
+
+        header_info_fields = _info_fields(header_str)
+        header_format_fields = _format_fields(header_str)
+
+        # fixed fields
+
+        contigs = np.array(ds.attrs["contigs"], dtype="S")
+        filters = np.array(ds.attrs["filters"], dtype="S")
+
+        chrom = ds.variant_contig.values
+        pos = ds.variant_position.values
+        id = ds.variant_id.values.astype("S")
+        alleles = ds.variant_allele.values.astype("S")
+        qual = ds.variant_quality.values
+        filter_ = ds.variant_filter.values
+
+        # info fields
+
+        # preconvert all info fields to byte representations
+        info_bufs = []
+        info_mask = np.full((len(header_info_fields), n_variants), False, dtype=bool)
+        info_indexes = np.zeros(
+            (len(header_info_fields), n_variants + 1), dtype=np.int32
+        )
+
+        k = 0
+        info_prefixes = []  # field names followed by '=' (except for flag/bool types)
+        for key in header_info_fields:
+            var = f"variant_{key}"
+            if var not in ds:
+                continue
+            if ds[var].dtype == np.bool:
+                values = ds[var].values
+                info_mask[k] = create_mask(values)
+                info_bufs.append(np.zeros(0, dtype=np.uint8))
+                # info_indexes contains zeros so nothing is written for flag/bool
+                info_prefixes.append(key)
+                k += 1
+            else:
+                values = ds[var].values
+                if values.dtype.kind == "O":
+                    values = values.astype("S")  # convert to fixed-length strings
+                info_mask[k] = create_mask(values)
+                info_bufs.append(
+                    np.empty(vcf_values_to_byte_buf_size(values), dtype=np.uint8)
+                )
+                vcf_values_to_byte_buf(info_bufs[k], 0, values, info_indexes[k])
+                info_prefixes.append(key + "=")
+                k += 1
+
+        info_mask = info_mask[:k]
+        info_indexes = info_indexes[:k]
+
+        info_prefixes = np.array(info_prefixes, dtype="S")
+
+        # format fields
+
+        # these can have different sizes for different fields, so store in sequences
+        format_values = []
+        format_bufs = []
+
+        format_mask = np.full(
+            (len(header_format_fields), n_variants), False, dtype=bool
+        )
+
+        k = 0
+        format_fields = []
+        has_gt = False
+        for key in header_format_fields:
+            var = "call_genotype" if key == "GT" else f"call_{key}"
+            if var not in ds:
+                continue
+            if key == "GT":
+                values = ds[var].values
+                format_mask[k] = create_mask(values)
+                format_values.append(values)
+                format_bufs.append(
+                    np.empty(vcf_genotypes_to_byte_buf_size(values[0]), dtype=np.uint8)
+                )
+                format_fields.append(key)
+                has_gt = True
+                k += 1
+            else:
+                values = ds[var].values
+                if values.dtype.kind == "O":
+                    values = values.astype("S")  # convert to fixed-length strings
+                format_mask[k] = create_mask(values)
+                format_values.append(values)
+                format_bufs.append(
+                    np.empty(vcf_values_to_byte_buf_size(values[0]), dtype=np.uint8)
+                )
+                format_fields.append(key)
+                k += 1
+
+        format_mask = format_mask[:k]
+
+        # indexes are all the same size (number of samples) so store in a single array
+        format_indexes = np.empty((len(format_values), n_samples + 1), dtype=np.int32)
+
+        if "call_genotype_phased" in ds:
+            call_genotype_phased = ds["call_genotype_phased"].values
+
+        format_names = np.array(format_fields, dtype="S")
+
+        n_header_format_fields = len(header_format_fields)
+
+        buf_size = (
+            vcf_fixed_to_byte_buf_size(contigs, id, alleles, filters)
+            + vcf_info_to_byte_buf_size(info_prefixes, info_bufs)
+            + vcf_format_names_to_byte_buf_size(format_names)
+            + sum(len(format_buf) for format_buf in format_bufs)
+        )
+
+        buf = np.empty(buf_size, dtype=np.uint8)
+
+        for i in range(n_variants):
+            # fixed fields
+            p = vcf_fixed_to_byte_buf(
+                buf, 0, i, contigs, chrom, pos, id, alleles, qual, filters, filter_
+            )
+
+            # info fields
+            p = vcf_info_to_byte_buf(
+                buf,
+                p,
+                i,
+                info_indexes,
+                info_mask,
+                info_prefixes,
+                *info_bufs,
+            )
+
+            # format fields
+            # convert each format field to bytes separately (for a variant), then interleave
+            # note that we can't numba jit this logic since format_values has different types, and
+            # we can't pass non-homogeneous tuples of format_values to numba
+            if n_header_format_fields > 0:
+                p = vcf_format_names_to_byte_buf(buf, p, i, format_mask, format_names)
+
+                n_format_fields = np.sum(~format_mask[:, i])
+
+                if n_format_fields == 0:  # all samples are missing
+                    p = vcf_format_missing_to_byte_buf(buf, p, n_samples)
+                elif n_format_fields == 1:  # fast path if only one format field
+                    for k in range(len(format_values)):
+                        # if format k is not present for variant i, then skip it
+                        if format_mask[k, i]:
+                            continue
+                        if k == 0 and has_gt:
+                            p = vcf_genotypes_to_byte_buf(
+                                buf,
+                                p,
+                                format_values[0][i],
+                                call_genotype_phased[i],
+                                format_indexes[0],
+                                ord("\t"),
+                            )
+                        else:
+                            p = vcf_values_to_byte_buf(
+                                buf,
+                                p,
+                                format_values[k][i],
+                                format_indexes[k],
+                                ord("\t"),
+                            )
+                        break
+                else:
+                    for k in range(len(format_values)):
+                        # if format k is not present for variant i, then skip it
+                        if format_mask[k, i]:
+                            continue
+                        if k == 0 and has_gt:
+                            vcf_genotypes_to_byte_buf(
+                                format_bufs[0],
+                                0,
+                                format_values[0][i],
+                                call_genotype_phased[i],
+                                format_indexes[0],
+                            )
+                        else:
+                            vcf_values_to_byte_buf(
+                                format_bufs[k],
+                                0,
+                                format_values[k][i],
+                                format_indexes[k],
+                            )
+
+                    p = interleave(
+                        buf,
+                        p,
+                        format_indexes,
+                        format_mask[:, i],
+                        ord(":"),
+                        ord("\t"),
+                        *format_bufs,
+                    )
+
+            s = byte_buf_to_str(buf[:p])
+            print(s, file=output)
+
+
+def zarr_to_vcf(
+    input: Union[PathType, MutableMapping[str, bytes]],
+    output: Union[PathType, TextIO],
+) -> None:
+    """Convert a Zarr file to a VCF file.
+
+    Warnings
+    --------
+    This function requires the input Zarr file to have a ``vcf_header`` attribute
+    containing the VCF header. VCF files converted to Zarr using :func:`vcf_to_zarr`
+    will contain this attribute, but datasets loaded from other sources will not.
+
+    The current implementation loads the entire dataset into memory, so it should
+    only be used on suitably-sized datasets.
+
+    Parameters
+    ----------
+    input
+        Zarr store or path to directory in file system.
+    output
+        A path or text file object that the output VCF should be written to.
+    """
+
+    ds = load_dataset(input)
+    dataset_to_vcf(ds, output)
+
+
+def _info_fields(header_str):
+    p = re.compile("ID=([^,>]+)")
+    return [
+        p.findall(line)[0]
+        for line in header_str.split("\n")
+        if line.startswith("##INFO=")
+    ]
+
+
+def _format_fields(header_str):
+    p = re.compile("ID=([^,>]+)")
+    fields = [
+        p.findall(line)[0]
+        for line in header_str.split("\n")
+        if line.startswith("##FORMAT=")
+    ]
+    # GT must be the first field if present, per the spec (section 1.6.2)
+    if "GT" in fields:
+        fields.remove("GT")
+        fields.insert(0, "GT")
+    return fields

--- a/sgkit/io/vcf/vcf_writer_utils.py
+++ b/sgkit/io/vcf/vcf_writer_utils.py
@@ -1,0 +1,632 @@
+"""Utility numba-jitted functions for converting array values to their VCF representations.
+
+Many functions in this module take a bytes buffer argument, ``buf``, which should be a NumPy array of type ``uint8``,
+and an integer index into the buffer, ``p``.
+"""
+import numpy as np
+
+from sgkit.accelerate import numba_jit
+from sgkit.io.utils import (
+    FLOAT32_FILL_AS_INT32,
+    FLOAT32_MISSING_AS_INT32,
+    INT_FILL,
+    INT_MISSING,
+)
+
+COLON = ord(":")
+COMMA = ord(",")
+DOT = ord(".")
+EQUALS = ord("=")
+MINUS = ord("-")
+SEMICOLON = ord(";")
+TAB = ord("\t")
+ZERO = ord("0")
+
+PHASED = ord("|")
+UNPHASED = ord("/")
+
+INT32_BUF_SIZE = len(str(np.iinfo(np.int32).min))
+FLOAT32_BUF_SIZE = INT32_BUF_SIZE + 4  # integer followed by '.' and 3 decimal places
+
+STR_MISSING_BYTE = b"."
+STR_FILL_BYTE = b""
+
+
+@numba_jit(boundscheck=True)
+def itoa(buf, p, value):
+    """Convert an int32 value to its decimal representation.
+
+    Parameters
+    ----------
+    buf
+        A 1D NumPy array to write to.
+    p
+        The index in the array to start writing at.
+    value
+        The integer value to convert.
+
+    Returns
+    -------
+    The position in the buffer after the last byte written.
+    """
+    if value < 0:
+        buf[p] = MINUS
+        p += 1
+        value = -value
+    # special case small values
+    if value < 10:
+        buf[p] = value + ZERO
+        p += 1
+    else:
+        # this is significantly faster than `k = math.floor(math.log10(value))`
+        if value < 100:
+            k = 1
+        elif value < 1000:
+            k = 2
+        elif value < 10000:
+            k = 3
+        elif value < 100000:
+            k = 4
+        elif value < 1000000:
+            k = 5
+        elif value < 10000000:
+            k = 6
+        elif value < 100000000:
+            k = 7
+        elif value < 1000000000:
+            k = 8
+        elif value < 10000000000:
+            k = 9
+        else:
+            # exceeds int32
+            raise ValueError("itoa only supports 32-bit integers")
+
+        # iterate backwards in buf
+        p += k
+        buf[p] = (value % 10) + ZERO
+        for _ in range(k):
+            p -= 1
+            value = value // 10
+            buf[p] = (value % 10) + ZERO
+        p += k + 1
+
+    return p
+
+
+@numba_jit(boundscheck=True)
+def ftoa(buf, p, value):
+    """Convert a float32 value to its decimal representation, with up to 3 decimal places.
+
+    Parameters
+    ----------
+    buf
+        A 1D NumPy array to write to.
+    p
+        The index in the array to start writing at.
+    value
+        The integer value to convert.
+
+    Returns
+    -------
+    The position in the buffer after the last byte written.
+    """
+    if value < 0:
+        buf[p] = MINUS
+        p += 1
+        value = -value
+
+    # integer part
+    p = itoa(buf, p, int(value))
+
+    # fractional part
+    i = int(np.around(value * 1000))
+    d3 = i % 10
+    d2 = (i / 10) % 10
+    d1 = (i / 100) % 10
+    if d1 + d2 + d3 > 0:
+        buf[p] = DOT
+        p += 1
+        buf[p] = d1 + ZERO
+        p += 1
+        if d2 + d3 > 0:
+            buf[p] = d2 + ZERO
+            p += 1
+            if d3 > 0:
+                buf[p] = d3 + ZERO
+                p += 1
+
+    return p
+
+
+@numba_jit(boundscheck=True)
+def copy(buf, p, value):
+    """Copy the values from one array to another.
+
+    Parameters
+    ----------
+    buf
+        A 1D NumPy array to write to.
+    p
+        The index in the array to start writing at.
+    value
+        The byte values to copy.
+
+    Returns
+    -------
+    The position in the buffer after the last byte written.
+    """
+    for i in range(len(value)):
+        buf[p] = value[i]
+        p += 1
+    return p
+
+
+def byte_buf_to_str(a):
+    """Convert a NumPy array of bytes to a Python string"""
+    return memoryview(a).tobytes().decode()
+
+
+@numba_jit(boundscheck=True)
+def vcf_fixed_to_byte_buf(
+    buf, p, i, contigs, chrom, pos, id, alleles, qual, filters, filter_
+):
+    # CHROM
+    contig = contigs[chrom[i]]
+    p = copy(buf, p, contig)
+    buf[p] = TAB
+    p += 1
+
+    # POS
+    p = itoa(buf, p, pos[i])
+    buf[p] = TAB
+    p += 1
+
+    # ID
+    p = copy(buf, p, id[i])
+    buf[p] = TAB
+    p += 1
+
+    # REF
+    ref = alleles[i][0]
+    p = copy(buf, p, ref)
+    buf[p] = TAB
+    p += 1
+
+    # ALT
+    n_alt = 0
+    for k, alt in enumerate(alleles[i][1:]):
+        if len(alt) > 0:
+            p = copy(buf, p, alt)
+            buf[p] = COMMA
+            p += 1
+            n_alt += 1
+    if n_alt > 0:
+        p -= 1  # remove last alt separator
+    else:
+        buf[p] = DOT
+        p += 1
+    buf[p] = TAB
+    p += 1
+
+    # QUAL
+    if np.array(qual[i], dtype=np.float32).view(np.int32) == FLOAT32_MISSING_AS_INT32:
+        buf[p] = DOT
+        p += 1
+    else:
+        p = ftoa(buf, p, qual[i])
+    buf[p] = TAB
+    p += 1
+
+    # FILTER
+    if np.all(~filter_[i]):
+        buf[p] = DOT
+        p += 1
+    else:
+        n_filter = 0
+        for k, present in enumerate(filter_[i]):
+            if present:
+                p = copy(buf, p, filters[k])
+                buf[p] = SEMICOLON
+                p += 1
+                n_filter += 1
+        if n_filter > 0:
+            p -= 1  # remove last filter separator
+    buf[p] = TAB
+    p += 1
+
+    return p
+
+
+def vcf_fixed_to_byte_buf_size(contigs, id, alleles, filters):
+    buf_size = 0
+
+    # CHROM
+    buf_size += contigs.dtype.itemsize
+    buf_size += 1  # TAB
+
+    # POS
+    buf_size += INT32_BUF_SIZE
+    buf_size += 1  # TAB
+
+    # ID
+    buf_size += id.dtype.itemsize
+    buf_size += 1  # TAB
+
+    # REF ALT
+    buf_size += len(alleles) * (alleles.dtype.itemsize + 1)
+    buf_size += 1  # TAB
+
+    # QUAL
+    buf_size += FLOAT32_BUF_SIZE
+    buf_size += 1  # TAB
+
+    # FILTER
+    buf_size += len(filters) * (filters.dtype.itemsize + 1)
+    buf_size += 1  # TAB
+
+    return buf_size
+
+
+def vcf_values_to_byte_buf(buf, p, a, indexes, separator=-1):
+    """Convert an array of VCF values to their string representations.
+
+    Parameters
+    ----------
+    buf
+        A 1D NumPy array to write to.
+    p
+        The index in the array to start writing at.
+    a
+        The 1D or 2D array of values, which must have an integer, float or string dtype.
+        Missing and fill values are converted appropriately.
+    indexes
+        An integer array that is updated to contain the start positions of each value
+        written to the buffer, plus the end position after the last character written.
+        This is used in the ``interleave`` function. It must have size ``a.size + 1``.
+    separator
+        For a 1D array, values are separated by the optional ``separator`` (default empty).
+        For a 2D array, values in each row are separated by commas, and rows are separated
+        by the optional ``separator`` (default empty).
+
+    Returns
+    -------
+    The position in the buffer after the last byte written.
+    """
+    if a.dtype in (np.int8, np.int16, np.int32):
+        return vcf_ints_to_byte_buf(buf, p, a, indexes, separator=separator)
+    elif a.dtype == np.float32:
+        return vcf_floats_to_byte_buf(buf, p, a, indexes, separator=separator)
+    elif a.dtype.kind == "S":
+        return vcf_strings_to_byte_buf(buf, p, a, indexes, separator=separator)
+    else:
+        raise ValueError(f"Unsupported dtype: {a.dtype}")
+
+
+def vcf_values_to_byte_buf_size(a):
+    if a.dtype in (np.int8, np.int16, np.int32):
+        # values + separators
+        return a.size * INT32_BUF_SIZE + a.size
+    elif a.dtype == np.float32:
+        # values + separators
+        return a.size * FLOAT32_BUF_SIZE + a.size
+    elif a.dtype.kind == "S":
+        # values + separators
+        return a.size * a.dtype.itemsize + a.size
+    else:
+        raise ValueError(f"Unsupported dtype: {a.dtype}")
+
+
+@numba_jit(boundscheck=True)
+def vcf_ints_to_byte_buf(buf, p, a, indexes, separator=-1):
+    n = 0  # total number of strings
+    if a.ndim == 1:
+        for i in range(a.shape[0]):
+            indexes[n] = p
+            if a[i] == INT_MISSING:
+                buf[p] = DOT
+                p += 1
+            else:
+                p = itoa(buf, p, a[i])
+            if separator != -1:
+                buf[p] = separator
+                p += 1
+            n += 1
+    elif a.ndim == 2:
+        for i in range(a.shape[0]):
+            indexes[n] = p
+            for j in range(a.shape[1]):
+                if a[i, j] == INT_MISSING:
+                    buf[p] = DOT
+                    p += 1
+                elif a[i, j] == INT_FILL:
+                    if j == 0:  # virtual comma that will be erased
+                        p += 1
+                    break
+                else:
+                    p = itoa(buf, p, a[i, j])
+                buf[p] = COMMA
+                p += 1
+            p -= 1
+            n += 1
+            if separator != -1:
+                buf[p] = separator
+                p += 1
+    else:
+        raise ValueError("Array must have dimension 1 or 2")
+    if separator != -1:  # remove last separator
+        p -= 1
+    indexes[n] = p  # add index for end
+    return p
+
+
+@numba_jit(boundscheck=True)
+def vcf_floats_to_byte_buf(buf, p, a, indexes, separator=-1):
+    n = 0  # total number of strings
+    ai = a.view(np.int32)
+    if a.ndim == 1:
+        for i in range(a.shape[0]):
+            indexes[n] = p
+            if ai[i] == FLOAT32_MISSING_AS_INT32:
+                buf[p] = DOT
+                p += 1
+            else:
+                p = ftoa(buf, p, a[i])
+            if separator != -1:
+                buf[p] = separator
+                p += 1
+            n += 1
+    elif a.ndim == 2:
+        for i in range(a.shape[0]):
+            indexes[n] = p
+            for j in range(a.shape[1]):
+                if ai[i, j] == FLOAT32_MISSING_AS_INT32:
+                    buf[p] = DOT
+                    p += 1
+                elif ai[i, j] == FLOAT32_FILL_AS_INT32:
+                    if j == 0:  # virtual comma that will be erased
+                        p += 1
+                    break
+                else:
+                    p = ftoa(buf, p, a[i, j])
+                buf[p] = COMMA
+                p += 1
+            p -= 1
+            n += 1
+            if separator != -1:
+                buf[p] = separator
+                p += 1
+    else:
+        raise ValueError("Array must have dimension 1 or 2")
+    if separator != -1:  # remove last separator
+        p -= 1
+    indexes[n] = p  # add index for end
+    return p
+
+
+@numba_jit(boundscheck=True)
+def vcf_strings_to_byte_buf(buf, p, a, indexes, separator=-1):
+    n = 0  # total number of strings
+    if a.ndim == 1:
+        for i in range(a.shape[0]):
+            indexes[n] = p
+            if a[i] == STR_MISSING_BYTE:
+                buf[p] = DOT
+                p += 1
+            else:
+                p = copy(buf, p, a[i])
+            if separator != -1:
+                buf[p] = separator
+                p += 1
+            n += 1
+    elif a.ndim == 2:
+        for i in range(a.shape[0]):
+            indexes[n] = p
+            for j in range(a.shape[1]):
+                if a[i, j] == STR_MISSING_BYTE:
+                    buf[p] = DOT
+                    p += 1
+                elif a[i, j] == STR_FILL_BYTE:
+                    if j == 0:  # virtual comma that will be erased
+                        p += 1
+                    break
+                else:
+                    p = copy(buf, p, a[i, j])
+                buf[p] = COMMA
+                p += 1
+            p -= 1
+            n += 1
+            if separator != -1:
+                buf[p] = separator
+                p += 1
+    else:
+        raise ValueError("Array must have dimension 1 or 2")
+    if separator != -1:  # remove last separator
+        p -= 1
+    indexes[n] = p  # add index for end
+    return p
+
+
+@numba_jit(boundscheck=True)
+def vcf_genotypes_to_byte_buf(
+    buf, p, call_genotype, call_genotype_phased, indexes, separator=-1
+):
+    n = 0
+    for i in range(call_genotype.shape[0]):
+        indexes[n] = p
+        phased = call_genotype_phased[i]
+        for j in range(call_genotype.shape[1]):
+            gt = call_genotype[i, j]
+            if gt == INT_MISSING:
+                buf[p] = DOT
+                p += 1
+            elif gt == INT_FILL:
+                break
+            else:
+                buf[p] = gt + ZERO
+                p += 1
+            if phased:
+                buf[p] = PHASED
+                p += 1
+            else:
+                buf[p] = UNPHASED
+                p += 1
+        p -= 1
+        n += 1
+        if separator != -1:
+            buf[p] = separator
+            p += 1
+    if separator != -1:  # remove last separator
+        p -= 1
+    indexes[n] = p  # add index for end
+    return p
+
+
+def vcf_genotypes_to_byte_buf_size(call_genotype):
+    # allele values (0, 1, etc) + separators
+    return call_genotype.size + call_genotype.size
+
+
+def create_mask(arr):
+    """Return a mask array of shape ``arr.shape[0]` for masking out fill values."""
+    axis = tuple(range(1, len(arr.shape)))
+    if arr.dtype == np.bool:
+        return ~arr
+    elif arr.dtype in (np.int8, np.int16, np.int32):
+        return np.all(arr == INT_FILL, axis=axis)
+    elif arr.dtype == np.float32:
+        return np.all(arr.view("i4") == FLOAT32_FILL_AS_INT32, axis=axis)
+    elif arr.dtype.kind == "S":
+        return np.all(arr == STR_FILL_BYTE, axis=axis)
+    else:
+        raise ValueError(f"Unsupported dtype: {arr.dtype}")
+
+
+@numba_jit(boundscheck=True)
+def vcf_info_to_byte_buf(buf, p, j, indexes, mask, info_prefixes, *arrays):
+    if len(arrays) == 0 or np.all(mask[:, j]):
+        buf[p] = DOT
+        p += 1
+        return p
+    n = indexes.shape[0]
+    assert n == len(arrays)
+    assert n == len(mask)
+    assert n == len(info_prefixes)
+    for i in range(n):
+        if mask[i, j]:
+            continue
+        p = copy(buf, p, info_prefixes[i])
+        arr = arrays[i]
+        sub = arr[indexes[i, j] : indexes[i, j + 1]]
+        len_sub = sub.shape[0]
+        buf[p : p + len_sub] = sub
+        p = p + len_sub
+        buf[p] = SEMICOLON
+        p += 1
+    p -= 1  # remove last separator
+    return p
+
+
+def vcf_info_to_byte_buf_size(info_prefixes, *arrays):
+    buf_size = 0
+
+    buf_size += len(info_prefixes) * info_prefixes.dtype.itemsize  # prefixes
+    buf_size += len(info_prefixes)  # separators
+    buf_size += sum(len(a) for a in arrays)  # values
+
+    return buf_size
+
+
+@numba_jit(boundscheck=True)
+def vcf_format_names_to_byte_buf(buf, p, i, format_mask, format_names):
+    buf[p] = TAB
+    p += 1
+    if len(format_names) == 0 or np.all(format_mask[:, i]):
+        buf[p] = DOT
+        p += 1
+        buf[p] = TAB
+        p += 1
+        return p
+    for k in range(len(format_names)):
+        if format_mask[k, i]:
+            continue
+        p = copy(buf, p, format_names[k])
+        buf[p] = COLON
+        p += 1
+    p -= 1  # remove last separator
+    buf[p] = TAB
+    p += 1
+    return p
+
+
+def vcf_format_names_to_byte_buf_size(format_names):
+    if len(format_names) == 0:
+        # TAB + DOT + TAB
+        return 3
+    # TAB + names + separators
+    return 1 + len(format_names) * format_names.dtype.itemsize + len(format_names)
+
+
+@numba_jit(boundscheck=True)
+def vcf_format_missing_to_byte_buf(buf, p, n_samples):
+    for _ in range(n_samples):
+        buf[p] = DOT
+        p += 1
+        buf[p] = TAB
+        p += 1
+    p -= 1  # remove last tab
+    return p
+
+
+@numba_jit(boundscheck=True)
+def interleave(buf, p, indexes, mask, separator, group_separator, *arrays):
+    """Interleave byte buffers into groups.
+
+    Each array must contain the same number of entries - this is the number of groups
+    formed. Each group will contain ``len(arrays)`` entries.
+
+    Parameters
+    ----------
+    buf
+        A 1D NumPy array to write to.
+    p
+        The index in the array to start writing at.
+    indexes
+        An array that has one row for each array, containing the start index for each
+        separate string value in the array.
+    mask
+        A boolean array with one entry for each array, indicating if the array should
+        be masked out.
+    separator
+        The separator to use between values within a group.
+    group_separator
+        The separator to use between each group.
+    arrays
+        The byte buffer arrays to interleave.
+
+    Returns
+    -------
+    The position in the buffer after the last byte written.
+    """
+    n = indexes.shape[0]
+    assert n == len(arrays)
+    assert n == len(mask)
+    for j in range(indexes.shape[1] - 1):
+        for i in range(n):
+            if mask[i]:
+                continue
+            arr = arrays[i]
+            sub = arr[indexes[i, j] : indexes[i, j + 1]]
+            len_sub = sub.shape[0]
+            buf[p : p + len_sub] = sub
+            p = p + len_sub
+            buf[p] = separator
+            p += 1
+        buf[p - 1] = group_separator
+    p -= 1  # remove last separator
+    return p
+
+
+def interleave_buf_size(indexes, *arrays):
+    """Return the buffer size needed by ``interleave``."""
+    # array buffers + separators
+    return sum(len(a) for a in arrays) + indexes.size

--- a/sgkit/tests/io/vcf/data/min_fields.vcf
+++ b/sgkit/tests/io/vcf/data/min_fields.vcf
@@ -1,0 +1,196 @@
+##fileformat=VCFv4.3
+##contig=<ID=1>
+##contig=<ID=2>
+##INFO=<ID=IB0,Type=Flag,Number=0,Description="INFO,Type=Flag,Number=0">
+##INFO=<ID=II1,Type=Integer,Number=1,Description="INFO,Type=Integer,Number=1">
+##INFO=<ID=II2,Type=Integer,Number=2,Description="INFO,Type=Integer,Number=2">
+##INFO=<ID=IIA,Type=Integer,Number=A,Description="INFO,Type=Integer,Number=A">
+##INFO=<ID=IIR,Type=Integer,Number=R,Description="INFO,Type=Integer,Number=R">
+##INFO=<ID=IID,Type=Integer,Number=.,Description="INFO,Type=Integer,Number=.">
+##INFO=<ID=IC1,Type=Character,Number=1,Description="INFO,Type=Character,Number=1">
+##INFO=<ID=IC2,Type=Character,Number=2,Description="INFO,Type=Character,Number=2">
+##INFO=<ID=ICA,Type=Character,Number=A,Description="INFO,Type=Character,Number=A">
+##INFO=<ID=ICR,Type=Character,Number=R,Description="INFO,Type=Character,Number=R">
+##INFO=<ID=ICD,Type=Character,Number=.,Description="INFO,Type=Character,Number=.">
+##INFO=<ID=IS1,Type=String,Number=1,Description="INFO,Type=String,Number=1">
+##INFO=<ID=IS2,Type=String,Number=2,Description="INFO,Type=String,Number=2">
+##INFO=<ID=ISA,Type=String,Number=A,Description="INFO,Type=String,Number=A">
+##INFO=<ID=ISR,Type=String,Number=R,Description="INFO,Type=String,Number=R">
+##INFO=<ID=ISD,Type=String,Number=.,Description="INFO,Type=String,Number=.">
+##FORMAT=<ID=FI1,Type=Integer,Number=1,Description="FORMAT,Type=Integer,Number=1">
+##FORMAT=<ID=FI2,Type=Integer,Number=2,Description="FORMAT,Type=Integer,Number=2">
+##FORMAT=<ID=FIA,Type=Integer,Number=A,Description="FORMAT,Type=Integer,Number=A">
+##FORMAT=<ID=FIR,Type=Integer,Number=R,Description="FORMAT,Type=Integer,Number=R">
+##FORMAT=<ID=FIG,Type=Integer,Number=G,Description="FORMAT,Type=Integer,Number=G">
+##FORMAT=<ID=FID,Type=Integer,Number=.,Description="FORMAT,Type=Integer,Number=.">
+##FORMAT=<ID=FF1,Type=Float,Number=1,Description="FORMAT,Type=Float,Number=1">
+##FORMAT=<ID=FF2,Type=Float,Number=2,Description="FORMAT,Type=Float,Number=2">
+##FORMAT=<ID=FFA,Type=Float,Number=A,Description="FORMAT,Type=Float,Number=A">
+##FORMAT=<ID=FFR,Type=Float,Number=R,Description="FORMAT,Type=Float,Number=R">
+##FORMAT=<ID=FFG,Type=Float,Number=G,Description="FORMAT,Type=Float,Number=G">
+##FORMAT=<ID=FFD,Type=Float,Number=.,Description="FORMAT,Type=Float,Number=.">
+##FORMAT=<ID=FC1,Type=Character,Number=1,Description="FORMAT,Type=Character,Number=1">
+##FORMAT=<ID=FC2,Type=Character,Number=2,Description="FORMAT,Type=Character,Number=2">
+##FORMAT=<ID=FCA,Type=Character,Number=A,Description="FORMAT,Type=Character,Number=A">
+##FORMAT=<ID=FCR,Type=Character,Number=R,Description="FORMAT,Type=Character,Number=R">
+##FORMAT=<ID=FCG,Type=Character,Number=G,Description="FORMAT,Type=Character,Number=G">
+##FORMAT=<ID=FCD,Type=Character,Number=.,Description="FORMAT,Type=Character,Number=.">
+##FORMAT=<ID=FS1,Type=String,Number=1,Description="FORMAT,Type=String,Number=1">
+##FORMAT=<ID=FS2,Type=String,Number=2,Description="FORMAT,Type=String,Number=2">
+##FORMAT=<ID=FSA,Type=String,Number=A,Description="FORMAT,Type=String,Number=A">
+##FORMAT=<ID=FSR,Type=String,Number=R,Description="FORMAT,Type=String,Number=R">
+##FORMAT=<ID=FSG,Type=String,Number=G,Description="FORMAT,Type=String,Number=G">
+##FORMAT=<ID=FSD,Type=String,Number=.,Description="FORMAT,Type=String,Number=.">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s1	s2
+1	1	.	G	A,C	.	PASS	IB0	.	.	.
+1	2	.	A	G,G	.	PASS	II1=126	.	.	.
+1	3	.	A	G,G	.	PASS	II1=.	.	.	.
+1	4	.	T	A,C	.	PASS	II2=459,-140	.	.	.
+1	5	.	T	A,C	.	PASS	II2=.,-140	.	.	.
+1	6	.	T	A,C	.	PASS	II2=459,.	.	.	.
+1	7	.	T	A,C	.	PASS	II2=.,.	.	.	.
+1	8	.	A	A,G	.	PASS	IIA=294,130	.	.	.
+1	9	.	A	A,G	.	PASS	IIA=.,130	.	.	.
+1	10	.	A	A,G	.	PASS	IIA=294,.	.	.	.
+1	11	.	A	A,G	.	PASS	IIA=.,.	.	.	.
+1	12	.	A	A,G	.	PASS	IIR=95,724,44	.	.	.
+1	13	.	A	A,G	.	PASS	IIR=.,724,44	.	.	.
+1	14	.	A	A,G	.	PASS	IIR=95,.,44	.	.	.
+1	15	.	A	A,G	.	PASS	IIR=95,724,.	.	.	.
+1	16	.	A	A,G	.	PASS	IIR=.,.,.	.	.	.
+1	17	.	G	A,G	.	PASS	IID=-879,-534,238,-670,482,-913,396	.	.	.
+1	18	.	G	A,G	.	PASS	IID=.,-534,238,-670,482,-913,396	.	.	.
+1	19	.	G	A,G	.	PASS	IID=-879,.,238,-670,482,-913,396	.	.	.
+1	20	.	G	A,G	.	PASS	IID=-879,-534,.,-670,482,-913,396	.	.	.
+1	21	.	G	A,G	.	PASS	IID=-879,-534,238,.,482,-913,396	.	.	.
+1	22	.	G	A,G	.	PASS	IID=-879,-534,238,-670,.,-913,396	.	.	.
+1	23	.	G	A,G	.	PASS	IID=-879,-534,238,-670,482,.,396	.	.	.
+1	24	.	G	A,G	.	PASS	IID=-879,-534,238,-670,482,-913,.	.	.	.
+1	25	.	G	A,G	.	PASS	IID=.,.,.,.,.,.,.	.	.	.
+1	26	.	G	A,G	.	PASS	IID=-129,687,-870,685	.	.	.
+1	27	.	G	A,G	.	PASS	IID=.,687,-870,685	.	.	.
+1	28	.	G	A,G	.	PASS	IID=-129,.,-870,685	.	.	.
+1	29	.	G	A,G	.	PASS	IID=-129,687,.,685	.	.	.
+1	30	.	G	A,G	.	PASS	IID=-129,687,-870,.	.	.	.
+1	31	.	G	A,G	.	PASS	IID=.,.,.,.	.	.	.
+1	69	.	T	C,G	.	PASS	IC1=f	.	.	.
+1	70	.	T	C,G	.	PASS	IC1=.	.	.	.
+1	71	.	G	T,G	.	PASS	IC2=e,a	.	.	.
+1	72	.	G	T,G	.	PASS	IC2=.,a	.	.	.
+1	73	.	G	T,G	.	PASS	IC2=e,.	.	.	.
+1	74	.	G	T,G	.	PASS	IC2=.,.	.	.	.
+1	75	.	A	C,A	.	PASS	ICA=b,a	.	.	.
+1	76	.	A	C,A	.	PASS	ICA=.,a	.	.	.
+1	77	.	A	C,A	.	PASS	ICA=b,.	.	.	.
+1	78	.	A	C,A	.	PASS	ICA=.,.	.	.	.
+1	79	.	C	G,C	.	PASS	ICR=c,b,b	.	.	.
+1	80	.	C	G,C	.	PASS	ICR=.,b,b	.	.	.
+1	81	.	C	G,C	.	PASS	ICR=c,.,b	.	.	.
+1	82	.	C	G,C	.	PASS	ICR=c,b,.	.	.	.
+1	83	.	C	G,C	.	PASS	ICR=.,.,.	.	.	.
+1	84	.	T	G,G	.	PASS	ICD=b,f,b,c	.	.	.
+1	85	.	T	G,G	.	PASS	ICD=.,f,b,c	.	.	.
+1	86	.	T	G,G	.	PASS	ICD=b,.,b,c	.	.	.
+1	87	.	T	G,G	.	PASS	ICD=b,f,.,c	.	.	.
+1	88	.	T	G,G	.	PASS	ICD=b,f,b,.	.	.	.
+1	89	.	T	G,G	.	PASS	ICD=.,.,.,.	.	.	.
+1	90	.	T	G,G	.	PASS	ICD=g,e,d,e,f,f,b	.	.	.
+1	91	.	T	G,G	.	PASS	ICD=.,e,d,e,f,f,b	.	.	.
+1	92	.	T	G,G	.	PASS	ICD=g,.,d,e,f,f,b	.	.	.
+1	93	.	T	G,G	.	PASS	ICD=g,e,.,e,f,f,b	.	.	.
+1	94	.	T	G,G	.	PASS	ICD=g,e,d,.,f,f,b	.	.	.
+1	95	.	T	G,G	.	PASS	ICD=g,e,d,e,.,f,b	.	.	.
+1	96	.	T	G,G	.	PASS	ICD=g,e,d,e,f,.,b	.	.	.
+1	97	.	T	G,G	.	PASS	ICD=g,e,d,e,f,f,.	.	.	.
+1	98	.	T	G,G	.	PASS	ICD=.,.,.,.,.,.,.	.	.	.
+1	99	.	A	C,C	.	PASS	IS1=bc	.	.	.
+1	100	.	A	C,C	.	PASS	IS1=.	.	.	.
+1	101	.	T	T,C	.	PASS	IS2=hij,d	.	.	.
+1	102	.	T	T,C	.	PASS	IS2=.,d	.	.	.
+1	103	.	T	T,C	.	PASS	IS2=hij,.	.	.	.
+1	104	.	T	T,C	.	PASS	IS2=.,.	.	.	.
+1	105	.	T	C,C	.	PASS	ISA=bc,efg	.	.	.
+1	106	.	T	C,C	.	PASS	ISA=.,efg	.	.	.
+1	107	.	T	C,C	.	PASS	ISA=bc,.	.	.	.
+1	108	.	T	C,C	.	PASS	ISA=.,.	.	.	.
+1	109	.	C	G,T	.	PASS	ISR=d,bc,op	.	.	.
+1	110	.	C	G,T	.	PASS	ISR=.,bc,op	.	.	.
+1	111	.	C	G,T	.	PASS	ISR=d,.,op	.	.	.
+1	112	.	C	G,T	.	PASS	ISR=d,bc,.	.	.	.
+1	113	.	C	G,T	.	PASS	ISR=.,.,.	.	.	.
+1	114	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,d,op,efg	.	.	.
+1	115	.	G	A,A	.	PASS	ISD=.,hij,klmn,d,ab,d,op,efg	.	.	.
+1	116	.	G	A,A	.	PASS	ISD=ab,.,klmn,d,ab,d,op,efg	.	.	.
+1	117	.	G	A,A	.	PASS	ISD=ab,hij,.,d,ab,d,op,efg	.	.	.
+1	118	.	G	A,A	.	PASS	ISD=ab,hij,klmn,.,ab,d,op,efg	.	.	.
+1	119	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,.,d,op,efg	.	.	.
+1	120	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,.,op,efg	.	.	.
+1	121	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,d,.,efg	.	.	.
+1	122	.	G	A,A	.	PASS	ISD=ab,hij,klmn,d,ab,d,op,.	.	.	.
+1	123	.	G	A,A	.	PASS	ISD=.,.,.,.,.,.,.,.	.	.	.
+1	124	.	G	A,A	.	PASS	ISD=op,op,ab	.	.	.
+1	125	.	G	A,A	.	PASS	ISD=.,op,ab	.	.	.
+1	126	.	G	A,A	.	PASS	ISD=op,.,ab	.	.	.
+1	127	.	G	A,A	.	PASS	ISD=op,op,.	.	.	.
+1	128	.	G	A,A	.	PASS	ISD=.,.,.	.	.	.
+2	129	.	G	G,G	.	PASS	.	FI1	-795	.
+2	130	.	C	G,A	.	PASS	.	FI2	104,955	.,955
+2	131	.	C	G,A	.	PASS	.	FI2	104,.	.,.
+2	132	.	C	C,T	.	PASS	.	FIA	585,895	.,895
+2	133	.	C	C,T	.	PASS	.	FIA	585,.	.,.
+2	134	.	T	C,G	.	PASS	.	FIR	411,25,21	.,25,21
+2	135	.	T	C,G	.	PASS	.	FIR	411,.,21	411,25,.
+2	136	.	T	C,G	.	PASS	.	FIR	.,.,.	.,.,.
+2	137	.	A	T,T	.	PASS	.	FIG	413,-435,129,795,845,500	.,-435,129,795,845,500
+2	138	.	A	T,T	.	PASS	.	FIG	413,.,129,795,845,500	413,-435,.,795,845,500
+2	139	.	A	T,T	.	PASS	.	FIG	413,-435,129,.,845,500	413,-435,129,795,.,500
+2	140	.	A	T,T	.	PASS	.	FIG	413,-435,129,795,845,.	.,.,.,.,.,.
+2	141	.	C	G,G	.	PASS	.	FID	-271,579	.,579
+2	142	.	C	G,G	.	PASS	.	FID	-271,.	.,.
+2	143	.	C	G,G	.	PASS	.	FID	-799,981	.,981
+2	144	.	C	G,G	.	PASS	.	FID	-799,.	.,.
+2	164	.	T	T,A	.	PASS	.	FC1	d	.
+2	165	.	G	C,T	.	PASS	.	FC2	c,b	.,b
+2	166	.	G	C,T	.	PASS	.	FC2	c,.	.,.
+2	167	.	G	G,A	.	PASS	.	FCA	c,g	.,g
+2	168	.	G	G,A	.	PASS	.	FCA	c,.	.,.
+2	169	.	G	C,G	.	PASS	.	FCR	a,b,c	.,b,c
+2	170	.	G	C,G	.	PASS	.	FCR	a,.,c	a,b,.
+2	171	.	G	C,G	.	PASS	.	FCR	.,.,.	.,.,.
+2	172	.	G	A,A	.	PASS	.	FCG	a,e,b,g,g,a	.,e,b,g,g,a
+2	173	.	G	A,A	.	PASS	.	FCG	a,.,b,g,g,a	a,e,.,g,g,a
+2	174	.	G	A,A	.	PASS	.	FCG	a,e,b,.,g,a	a,e,b,g,.,a
+2	175	.	G	A,A	.	PASS	.	FCG	a,e,b,g,g,.	.,.,.,.,.,.
+2	176	.	A	G,A	.	PASS	.	FCD	a,g,d,d,f,f,b,a,d	.,g,d,d,f,f,b,a,d
+2	177	.	A	G,A	.	PASS	.	FCD	a,.,d,d,f,f,b,a,d	a,g,.,d,f,f,b,a,d
+2	178	.	A	G,A	.	PASS	.	FCD	a,g,d,.,f,f,b,a,d	a,g,d,d,.,f,b,a,d
+2	179	.	A	G,A	.	PASS	.	FCD	a,g,d,d,f,.,b,a,d	a,g,d,d,f,f,.,a,d
+2	180	.	A	G,A	.	PASS	.	FCD	a,g,d,d,f,f,b,.,d	a,g,d,d,f,f,b,a,.
+2	181	.	A	G,A	.	PASS	.	FCD	.,.,.,.,.,.,.,.,.	c,d,f,e,g,a,c
+2	182	.	A	G,A	.	PASS	.	FCD	.,d,f,e,g,a,c	c,.,f,e,g,a,c
+2	183	.	A	G,A	.	PASS	.	FCD	c,d,.,e,g,a,c	c,d,f,.,g,a,c
+2	184	.	A	G,A	.	PASS	.	FCD	c,d,f,e,.,a,c	c,d,f,e,g,.,c
+2	185	.	A	G,A	.	PASS	.	FCD	c,d,f,e,g,a,.	.,.,.,.,.,.,.
+2	186	.	C	T,A	.	PASS	.	FS1	bc	.
+2	187	.	C	C,C	.	PASS	.	FS2	bc,op	.,op
+2	188	.	C	C,C	.	PASS	.	FS2	bc,.	.,.
+2	189	.	C	T,G	.	PASS	.	FSA	ab,op	.,op
+2	190	.	C	T,G	.	PASS	.	FSA	ab,.	.,.
+2	191	.	T	T,T	.	PASS	.	FSR	klmn,bc,efg	.,bc,efg
+2	192	.	T	T,T	.	PASS	.	FSR	klmn,.,efg	klmn,bc,.
+2	193	.	T	T,T	.	PASS	.	FSR	.,.,.	.,.,.
+2	194	.	A	C,A	.	PASS	.	FSG	d,op,bc,klmn,efg,d	.,op,bc,klmn,efg,d
+2	195	.	A	C,A	.	PASS	.	FSG	d,.,bc,klmn,efg,d	d,op,.,klmn,efg,d
+2	196	.	A	C,A	.	PASS	.	FSG	d,op,bc,.,efg,d	d,op,bc,klmn,.,d
+2	197	.	A	C,A	.	PASS	.	FSG	d,op,bc,klmn,efg,.	.,.,.,.,.,.
+2	198	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,op,hij,efg,klmn,ab,hij	.,bc,d,op,hij,efg,klmn,ab,hij
+2	199	.	T	T,G	.	PASS	.	FSD	klmn,.,d,op,hij,efg,klmn,ab,hij	klmn,bc,.,op,hij,efg,klmn,ab,hij
+2	200	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,.,hij,efg,klmn,ab,hij	klmn,bc,d,op,.,efg,klmn,ab,hij
+2	201	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,op,hij,.,klmn,ab,hij	klmn,bc,d,op,hij,efg,.,ab,hij
+2	202	.	T	T,G	.	PASS	.	FSD	klmn,bc,d,op,hij,efg,klmn,.,hij	klmn,bc,d,op,hij,efg,klmn,ab,.
+2	203	.	T	T,G	.	PASS	.	FSD	.,.,.,.,.,.,.,.,.	efg,klmn,bc,op,ab,bc,hij,hij
+2	204	.	T	T,G	.	PASS	.	FSD	.,klmn,bc,op,ab,bc,hij,hij	efg,.,bc,op,ab,bc,hij,hij
+2	205	.	T	T,G	.	PASS	.	FSD	efg,klmn,.,op,ab,bc,hij,hij	efg,klmn,bc,.,ab,bc,hij,hij
+2	206	.	T	T,G	.	PASS	.	FSD	efg,klmn,bc,op,.,bc,hij,hij	efg,klmn,bc,op,ab,.,hij,hij
+2	207	.	T	T,G	.	PASS	.	FSD	efg,klmn,bc,op,ab,bc,.,hij	efg,klmn,bc,op,ab,bc,hij,.
+2	208	.	T	T,G	.	PASS	.	FSD	.,.,.,.,.,.,.,.	.,.,.,.,.,.,.,.

--- a/sgkit/tests/io/vcf/test_vcf_lossless_conversion_new.py
+++ b/sgkit/tests/io/vcf/test_vcf_lossless_conversion_new.py
@@ -1,0 +1,87 @@
+from io import StringIO
+
+import pytest
+
+from sgkit.io.vcf.vcf_reader import vcf_to_zarr, zarr_array_sizes
+from sgkit.io.vcf.vcf_writer import zarr_to_vcf
+
+from .utils import path_for_test
+from .vcf_writer import canonicalize_vcf
+
+# from numcodecs import FixedScaleOffset
+
+
+@pytest.mark.parametrize(
+    "vcf_file, encoding, output_is_path",
+    [
+        ("sample.vcf.gz", None, True),
+        ("sample.vcf.gz", None, False),
+        ("mixed.vcf.gz", None, True),
+        ("no_genotypes.vcf", None, True),
+        # ("CEUTrio.20.21.gatk3.4.g.vcf.bgz", None, True),
+        # (
+        #     "1kg_target_chr20_38_imputed_chr20_1000.vcf",
+        #     {
+        #         "variant_AF": {
+        #             "filters": [
+        #                 FixedScaleOffset(offset=0, scale=10000, dtype="f4", astype="u2")
+        #             ],
+        #         },
+        #         "call_DS": {
+        #             "filters": [
+        #                 FixedScaleOffset(offset=0, scale=100, dtype="f4", astype="u1")
+        #             ],
+        #         },
+        #         "variant_DR2": {
+        #             "filters": [
+        #                 FixedScaleOffset(offset=0, scale=100, dtype="f4", astype="u1")
+        #             ],
+        #         },
+        #     },
+        # ),
+        ("min_fields.vcf", None, True),
+        # ("all_fields.vcf", None, True),
+    ],
+)
+@pytest.mark.filterwarnings(
+    "ignore::sgkit.io.vcf.FloatFormatFieldWarning",
+    "ignore::sgkit.io.vcfzarr_reader.DimensionNameForFixedFormatFieldWarning",
+)
+def test_lossless_conversion(
+    shared_datadir, tmp_path, vcf_file, encoding, output_is_path
+):
+    path = path_for_test(shared_datadir, vcf_file)
+    canonical = tmp_path.joinpath("canonical.vcf").as_posix()
+    intermediate = tmp_path.joinpath("intermediate.vcf.zarr").as_posix()
+    if output_is_path:
+        output = tmp_path.joinpath("output.vcf").as_posix()
+    else:
+        output = StringIO()
+
+    canonicalize_vcf(path, canonical)
+
+    kwargs = zarr_array_sizes(path)
+    vcf_to_zarr(
+        path,
+        intermediate,
+        fields=["INFO/*", "FORMAT/*"],
+        mixed_ploidy=True,
+        encoding=encoding,
+        **kwargs
+    )
+
+    zarr_to_vcf(intermediate, output)
+
+    with open(canonical) as f:
+        f1 = f.readlines()
+    if output_is_path:
+        with open(output) as f:
+            f2 = f.readlines()
+    else:
+        f2 = output.getvalue().splitlines(True)
+
+    if f1 != f2:
+        print("".join(f1))
+        print("".join(f2))
+
+    assert f1 == f2

--- a/sgkit/tests/io/vcf/test_vcf_writer.py
+++ b/sgkit/tests/io/vcf/test_vcf_writer.py
@@ -1,7 +1,15 @@
 import gzip
 
+import pytest
+from cyvcf2 import VCF
+from numpy.testing import assert_array_equal
+
+from sgkit.io.dataset import load_dataset
+from sgkit.io.vcf.vcf_reader import vcf_to_zarr, zarr_array_sizes
+from sgkit.io.vcf.vcf_writer import dataset_to_vcf
+
 from .utils import path_for_test
-from .vcf_writer import canonicalize_vcf
+from .vcf_writer import canonicalize_vcf, zarr_to_vcf
 
 
 def test_canonicalize_vcf(shared_datadir, tmp_path):
@@ -15,3 +23,71 @@ def test_canonicalize_vcf(shared_datadir, tmp_path):
         assert "NS=3;DP=9;AA=G;AN=6;AC=3,1" in f.read()
     with open(output, "r") as f:
         assert "NS=3;AN=6;AC=3,1;DP=9;AA=G" in f.read()
+
+
+@pytest.mark.filterwarnings(
+    "ignore::sgkit.io.vcfzarr_reader.DimensionNameForFixedFormatFieldWarning",
+)
+def test_zarr_to_vcf(shared_datadir, tmp_path):
+    path = path_for_test(shared_datadir, "sample.vcf.gz")
+    intermediate = tmp_path.joinpath("intermediate.vcf.zarr").as_posix()
+    output = tmp_path.joinpath("output.vcf").as_posix()
+
+    kwargs = zarr_array_sizes(path)
+    vcf_to_zarr(
+        path, intermediate, fields=["INFO/*", "FORMAT/*"], mixed_ploidy=True, **kwargs
+    )
+
+    zarr_to_vcf(intermediate, output)
+
+    v = VCF(output)
+
+    assert v.samples == ["NA00001", "NA00002", "NA00003"]
+
+    variant = next(v)
+
+    assert variant.CHROM == "19"
+    assert variant.POS == 111
+    assert variant.ID is None
+    assert variant.REF == "A"
+    assert variant.ALT == ["C"]
+    assert variant.QUAL == pytest.approx(9.6)
+    assert variant.FILTER is None
+
+    assert variant.genotypes == [[0, 0, True], [0, 0, True], [0, 1, False]]
+
+    assert_array_equal(
+        variant.format("HQ"),
+        [[10, 15], [10, 10], [3, 3]],
+    )
+
+
+@pytest.mark.filterwarnings(
+    "ignore::sgkit.io.vcfzarr_reader.DimensionNameForFixedFormatFieldWarning",
+)
+def test_dataset_to_vcf__drop_fields(shared_datadir, tmp_path):
+    path = path_for_test(shared_datadir, "sample.vcf.gz")
+    intermediate = tmp_path.joinpath("intermediate.vcf.zarr").as_posix()
+    output = tmp_path.joinpath("output.vcf").as_posix()
+
+    kwargs = zarr_array_sizes(path)
+    vcf_to_zarr(
+        path, intermediate, fields=["INFO/*", "FORMAT/*"], mixed_ploidy=True, **kwargs
+    )
+
+    ds = load_dataset(intermediate)
+
+    # drop an INFO field and a FORMAT field
+    ds = ds.drop_vars(["variant_NS", "call_HQ"])
+
+    dataset_to_vcf(ds, output)
+
+    # check dropped fields are not present in VCF
+    v = VCF(output)
+    count = 0
+    for variant in v:
+        assert "NS" not in variant.INFO
+        assert variant.format("HQ") is None
+        assert variant.genotypes is not None
+        count += 1
+    assert count == 9

--- a/sgkit/tests/io/vcf/test_vcf_writer_utils.py
+++ b/sgkit/tests/io/vcf/test_vcf_writer_utils.py
@@ -1,0 +1,490 @@
+import numpy as np
+import pytest
+
+from sgkit.io.utils import (
+    FLOAT32_FILL,
+    FLOAT32_MISSING,
+    INT_FILL,
+    INT_MISSING,
+    STR_FILL,
+    STR_MISSING,
+)
+from sgkit.io.vcf.vcf_writer_utils import (
+    FLOAT32_BUF_SIZE,
+    INT32_BUF_SIZE,
+    byte_buf_to_str,
+    create_mask,
+    ftoa,
+    interleave,
+    interleave_buf_size,
+    itoa,
+    vcf_fixed_to_byte_buf,
+    vcf_fixed_to_byte_buf_size,
+    vcf_format_names_to_byte_buf,
+    vcf_format_names_to_byte_buf_size,
+    vcf_genotypes_to_byte_buf,
+    vcf_genotypes_to_byte_buf_size,
+    vcf_info_to_byte_buf,
+    vcf_info_to_byte_buf_size,
+    vcf_ints_to_byte_buf,
+    vcf_values_to_byte_buf,
+    vcf_values_to_byte_buf_size,
+)
+
+
+@pytest.mark.parametrize(
+    "i",
+    [pow(10, i) - 1 for i in range(10)]
+    + [pow(10, i) for i in range(10)]
+    + [pow(10, i) + 1 for i in range(10)]
+    + [np.iinfo(np.int32).max, np.iinfo(np.int32).min],
+)
+def test_itoa(i):
+    buf = np.empty(INT32_BUF_SIZE, dtype=np.uint8)
+
+    a = str(i)
+    p = itoa(buf, 0, i)
+    assert byte_buf_to_str(buf[:p]) == a
+    assert p == len(a)
+
+    if i > 0:
+        i = -i
+        a = str(i)
+        p = itoa(buf, 0, i)
+        assert byte_buf_to_str(buf[:p]) == a
+        assert p == len(a)
+
+
+def test_itoa_out_of_range():
+    buf = np.empty(INT32_BUF_SIZE * 2, dtype=np.uint8)
+    with pytest.raises(ValueError, match=r"itoa only supports 32-bit integers"):
+        itoa(buf, 0, np.iinfo(np.int32).max * 10)
+
+
+@pytest.mark.parametrize(
+    "f, a",
+    [
+        (0.0, "0"),
+        (0.3, "0.3"),
+        (0.32, "0.32"),
+        (0.329, "0.329"),
+        (0.3217, "0.322"),
+        (8.0, "8"),
+        (8.3, "8.3"),
+        (8.32, "8.32"),
+        (8.329, "8.329"),
+        (8.3217, "8.322"),
+        (443.998, "443.998"),
+        (1028.0, "1028"),
+        (1028.3, "1028.3"),
+        (1028.32, "1028.32"),
+        (1028.329, "1028.329"),
+        (1028.3217, "1028.322"),
+    ],
+)
+def test_ftoa(f, a):
+    f = np.array([f], dtype=np.float32)[0]
+    buf = np.empty(FLOAT32_BUF_SIZE, dtype=np.uint8)
+
+    p = ftoa(buf, 0, f)
+    assert byte_buf_to_str(buf[:p]) == a
+    assert p == len(a)
+
+    if f > 0:
+        f = -f
+        a = f"-{a}"
+        p = ftoa(buf, 0, f)
+        assert byte_buf_to_str(buf[:p]) == a
+        assert p == len(a)
+
+
+def _check_indexes(buf, indexes, separator):
+    if separator == ord(" "):
+        s = byte_buf_to_str(buf)
+        words = []
+        for i in range(len(indexes) - 1):
+            words.append(s[indexes[i] : indexes[i + 1]].strip())
+        assert words == s.split(" ")
+
+
+def test_vcf_fixed_to_byte_buf():
+    contigs = np.array(["chr1", "chr2"], dtype="S")
+    chrom = np.array([0, 1], dtype="i4")
+    pos = np.array([110, 1430], dtype="i4")
+    id = np.array([".", "id1"], dtype="S")
+    alleles = np.array([["A", "AC", "T"], ["G", "", ""]], dtype="S")
+    qual = np.array([29, FLOAT32_MISSING], dtype="f4")
+    filters = np.array(["PASS", "q10", "s50"], dtype="S")
+    filter_ = np.array([[True, False, False], [False, True, True]], dtype="bool")
+
+    buf_size = vcf_fixed_to_byte_buf_size(contigs, id, alleles, filters)
+    assert buf_size == 60
+
+    buf = np.empty(buf_size, dtype=np.uint8)
+    p = vcf_fixed_to_byte_buf(
+        buf, 0, 0, contigs, chrom, pos, id, alleles, qual, filters, filter_
+    )
+    buf = buf[:p]
+    assert byte_buf_to_str(buf) == "chr1\t110\t.\tA\tAC,T\t29\tPASS\t"
+
+    buf = np.empty(buf_size, dtype=np.uint8)
+    p = vcf_fixed_to_byte_buf(
+        buf, 0, 1, contigs, chrom, pos, id, alleles, qual, filters, filter_
+    )
+    buf = buf[:p]
+    assert byte_buf_to_str(buf) == "chr2\t1430\tid1\tG\t.\t.\tq10;s50\t"
+
+
+@pytest.mark.parametrize(
+    "a, separator, result",
+    [
+        # int
+        (np.array([10, 8, INT_MISSING, 41, 5], dtype=np.int32), -1, "108.415"),
+        (
+            np.array([10, 8, INT_MISSING, 41, 5], dtype=np.int32),
+            ord(" "),
+            "10 8 . 41 5",
+        ),
+        (
+            np.array(
+                [
+                    [INT_FILL, INT_FILL, INT_FILL],
+                    [0, 21, 43],
+                    [INT_MISSING, 1, INT_FILL],
+                    [1, INT_FILL, INT_FILL],
+                ],
+                dtype=np.int32,
+            ),
+            -1,
+            "0,21,43.,11",
+        ),
+        (
+            np.array(
+                [
+                    [INT_FILL, INT_FILL, INT_FILL],
+                    [0, 21, 43],
+                    [INT_MISSING, 1, INT_FILL],
+                    [1, INT_FILL, INT_FILL],
+                ],
+                dtype=np.int32,
+            ),
+            ord(" "),
+            " 0,21,43 .,1 1",
+        ),
+        # float
+        (
+            np.array([5, 5.5, 6, FLOAT32_MISSING, 7, 7.5], dtype=np.float32),
+            -1,
+            "55.56.77.5",
+        ),
+        (
+            np.array([5, 5.5, 6, FLOAT32_MISSING, 7, 7.5], dtype=np.float32),
+            ord(" "),
+            "5 5.5 6 . 7 7.5",
+        ),
+        (
+            np.array(
+                [
+                    [FLOAT32_FILL, FLOAT32_FILL, FLOAT32_FILL],
+                    [0, 1.5, 2],
+                    [FLOAT32_MISSING, 1.5, FLOAT32_FILL],
+                    [1.5, FLOAT32_FILL, FLOAT32_FILL],
+                ],
+                dtype=np.float32,
+            ),
+            -1,
+            "0,1.5,2.,1.51.5",
+        ),
+        (
+            np.array(
+                [
+                    [FLOAT32_FILL, FLOAT32_FILL, FLOAT32_FILL],
+                    [0, 1.5, 2],
+                    [FLOAT32_MISSING, 1.5, FLOAT32_FILL],
+                    [1.5, FLOAT32_FILL, FLOAT32_FILL],
+                ],
+                dtype=np.float32,
+            ),
+            ord(" "),
+            " 0,1.5,2 .,1.5 1.5",
+        ),
+        # string
+        (np.array(["ab", "cd", STR_MISSING, "ef", "ghi"], dtype="S"), -1, "abcd.efghi"),
+        (
+            np.array(["ab", "cd", STR_MISSING, "ef", "ghi"], dtype="S"),
+            ord(" "),
+            "ab cd . ef ghi",
+        ),
+        (
+            np.array(
+                [
+                    [STR_FILL, STR_FILL, STR_FILL],
+                    ["ab", "cd", "ef"],
+                    [STR_MISSING, "ghi", STR_FILL],
+                    ["j", STR_FILL, STR_FILL],
+                ],
+                dtype="S",
+            ),
+            -1,
+            "ab,cd,ef.,ghij",
+        ),
+        (
+            np.array(
+                [
+                    [STR_FILL, STR_FILL, STR_FILL],
+                    ["ab", "cd", "ef"],
+                    [STR_MISSING, "ghi", STR_FILL],
+                    ["j", STR_FILL, STR_FILL],
+                ],
+                dtype="S",
+            ),
+            ord(" "),
+            " ab,cd,ef .,ghi j",
+        ),
+    ],
+)
+def test_vcf_values_to_byte_buf(a, separator, result):
+    buf = np.empty(vcf_values_to_byte_buf_size(a), dtype=np.uint8)
+    indexes = np.empty(a.shape[0] + 1, dtype=np.int32)
+    p = vcf_values_to_byte_buf(buf, 0, a, indexes, separator=separator)
+    buf = buf[:p]
+
+    assert byte_buf_to_str(buf) == result
+    _check_indexes(buf, indexes, separator)
+
+
+def test_vcf_values_to_byte_buf__dtype_errors():
+    a = np.ones((2, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match="Unsupported dtype: float64"):
+        vcf_values_to_byte_buf_size(a)
+
+    buf = np.empty(1000, dtype=np.uint8)
+    indexes = np.empty(a.shape[0] + 1, dtype=np.int32)
+    with pytest.raises(ValueError, match="Unsupported dtype: float64"):
+        vcf_values_to_byte_buf(buf, 0, a, indexes)
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.float32, "S"])
+def test_vcf_values_to_byte_buf__dimension_errors(dtype):
+    a = np.ones((2, 2, 2), dtype=dtype)
+    buf = np.empty(vcf_values_to_byte_buf_size(a), dtype=np.uint8)
+    indexes = np.empty(a.shape[0] + 1, dtype=np.int32)
+    with pytest.raises(ValueError, match="Array must have dimension 1 or 2"):
+        vcf_values_to_byte_buf(buf, 0, a, indexes)
+
+
+@pytest.mark.parametrize(
+    "separator, result",
+    [
+        (-1, "0/10|2."),
+        (ord(" "), "0/1 0|2 ."),
+    ],
+)
+def test_vcf_genotypes_to_byte_buf(separator, result):
+    call_genotype = np.array([[0, 1], [0, 2], [-1, -2]], dtype="i1")
+    call_genotype_phased = np.array([False, True, False], dtype=bool)
+
+    buf_size = vcf_genotypes_to_byte_buf_size(call_genotype)
+    buf = np.empty(buf_size, dtype=np.uint8)
+    indexes = np.empty(call_genotype.shape[0] + 1, dtype=np.int32)
+    p = vcf_genotypes_to_byte_buf(
+        buf, 0, call_genotype, call_genotype_phased, indexes, separator=separator
+    )
+    buf = buf[:p]
+
+    assert byte_buf_to_str(buf) == result
+    _check_indexes(buf, indexes, separator)
+
+
+def test_create_mask__dtype_errors():
+    a = np.ones((2, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match="Unsupported dtype: float64"):
+        create_mask(a)
+
+
+def test_vcf_info_to_byte_buf():
+    a = np.arange(6)
+    b = np.arange(6, 12)
+    c = np.arange(12, 18)
+
+    assert a.shape[0] == b.shape[0] == c.shape[0]
+
+    n = a.shape[0]
+
+    a_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    b_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    c_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+
+    indexes = np.empty((3, n + 1), dtype=np.int32)
+
+    a_p = vcf_ints_to_byte_buf(a_buf, 0, a, indexes[0])
+    b_p = vcf_ints_to_byte_buf(b_buf, 0, b, indexes[1])
+    c_p = vcf_ints_to_byte_buf(c_buf, 0, c, indexes[2])
+
+    a_ch = a_buf[:a_p]
+    b_ch = b_buf[:b_p]
+    c_ch = c_buf[:c_p]
+
+    assert byte_buf_to_str(a_ch) == "012345"
+    assert byte_buf_to_str(b_ch) == "67891011"
+    assert byte_buf_to_str(c_ch) == "121314151617"
+
+    mask = np.full((3, n), False, dtype=bool)
+    info_prefixes = np.array(["A=", "B=", "C="], dtype="S")
+
+    buf_size = vcf_info_to_byte_buf_size(info_prefixes, a_buf, b_buf, c_buf)
+    assert buf_size == 207
+    buf = np.empty(buf_size, dtype=np.uint8)
+
+    p = 0
+    for j in range(6):
+        p = vcf_info_to_byte_buf(
+            buf, p, j, indexes, mask, info_prefixes, a_buf, b_buf, c_buf
+        )
+    buf = buf[:p]
+
+    assert (
+        byte_buf_to_str(buf)
+        == "A=0;B=6;C=12A=1;B=7;C=13A=2;B=8;C=14A=3;B=9;C=15A=4;B=10;C=16A=5;B=11;C=17"
+    )
+
+
+@pytest.mark.parametrize(
+    "format_names, result",
+    [
+        ([], "\t.\t"),
+        (["AB"], "\tAB\t"),
+        (["AB", "CD", "EF"], "\tAB:CD:EF\t"),
+    ],
+)
+def test_vcf_format_names_to_byte_buf(format_names, result):
+    mask = np.full((len(format_names), 1), False, dtype=bool)
+    format_names = np.array(format_names, dtype="S")
+    buf_size = vcf_format_names_to_byte_buf_size(format_names)
+    assert buf_size == len(result)
+    buf = np.empty(buf_size, dtype=np.uint8)
+
+    p = vcf_format_names_to_byte_buf(buf, 0, 0, mask, format_names)
+    assert byte_buf_to_str(buf[:p]) == result
+
+
+def test_interleave():
+    a = np.arange(6)
+    b = np.arange(6, 12)
+    c = np.arange(12, 18)
+
+    assert a.shape[0] == b.shape[0] == c.shape[0]
+
+    n = a.shape[0]
+
+    a_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    b_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    c_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+
+    indexes = np.empty((3, n + 1), dtype=np.int32)
+
+    a_p = vcf_ints_to_byte_buf(a_buf, 0, a, indexes[0])
+    b_p = vcf_ints_to_byte_buf(b_buf, 0, b, indexes[1])
+    c_p = vcf_ints_to_byte_buf(c_buf, 0, c, indexes[2])
+
+    a_ch = a_buf[:a_p]
+    b_ch = b_buf[:b_p]
+    c_ch = c_buf[:c_p]
+
+    assert byte_buf_to_str(a_ch) == "012345"
+    assert byte_buf_to_str(b_ch) == "67891011"
+    assert byte_buf_to_str(c_ch) == "121314151617"
+
+    buf_size = interleave_buf_size(indexes, a_buf, b_buf, c_buf)
+    buf = np.empty(buf_size, dtype=np.uint8)
+
+    mask = np.array([False, False, False])
+
+    p = interleave(buf, 0, indexes, mask, ord(":"), ord(" "), a_buf, b_buf, c_buf)
+    buf = buf[:p]
+
+    assert byte_buf_to_str(buf) == "0:6:12 1:7:13 2:8:14 3:9:15 4:10:16 5:11:17"
+
+
+def test_interleave_with_mask():
+    a = np.arange(6)
+    b = np.arange(6, 12)
+    c = np.arange(12, 18)
+
+    assert a.shape[0] == b.shape[0] == c.shape[0]
+
+    n = a.shape[0]
+
+    a_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    b_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    c_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+
+    indexes = np.empty((3, n + 1), dtype=np.int32)
+
+    a_p = vcf_ints_to_byte_buf(a_buf, 0, a, indexes[0])
+    b_p = vcf_ints_to_byte_buf(b_buf, 0, b, indexes[1])
+    c_p = vcf_ints_to_byte_buf(c_buf, 0, c, indexes[2])
+
+    a_ch = a_buf[:a_p]
+    b_ch = b_buf[:b_p]
+    c_ch = c_buf[:c_p]
+
+    assert byte_buf_to_str(a_ch) == "012345"
+    assert byte_buf_to_str(b_ch) == "67891011"
+    assert byte_buf_to_str(c_ch) == "121314151617"
+
+    buf_size = interleave_buf_size(indexes, a_buf, b_buf, c_buf)
+    buf = np.empty(buf_size, dtype=np.uint8)
+
+    mask = np.array([False, True, False])
+
+    p = interleave(buf, 0, indexes, mask, ord(":"), ord(" "), a_buf, b_buf, c_buf)
+    buf = buf[:p]
+
+    assert byte_buf_to_str(buf) == "0:12 1:13 2:14 3:15 4:16 5:17"
+
+
+@pytest.mark.skip
+def test_interleave_speed():
+    n_samples = 100000
+    a = np.arange(0, n_samples)
+    b = np.arange(1, n_samples + 1)
+    c = np.arange(2, n_samples + 2)
+
+    assert a.shape[0] == b.shape[0] == c.shape[0]
+
+    n = a.shape[0]
+
+    a_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    b_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+    c_buf = np.empty(n * INT32_BUF_SIZE, dtype=np.uint8)
+
+    indexes = np.empty((3, n + 1), dtype=np.int32)
+
+    buf_size = interleave_buf_size(indexes, a_buf, b_buf, c_buf)
+    buf = np.empty(buf_size, dtype=np.uint8)
+
+    mask = np.array([False, False, False])
+
+    import time
+
+    start = time.time()
+
+    reps = 200
+    bytes_written = 0
+    for _ in range(reps):
+
+        print(".", end="")
+
+        vcf_ints_to_byte_buf(a_buf, 0, a, indexes[0])
+        vcf_ints_to_byte_buf(b_buf, 0, b, indexes[1])
+        vcf_ints_to_byte_buf(c_buf, 0, c, indexes[2])
+
+        p = interleave(buf, 0, indexes, mask, ord(":"), ord(" "), a_buf, b_buf, c_buf)
+
+        bytes_written += len(byte_buf_to_str(buf[:p]))
+
+    end = time.time()
+    print(f"bytes written: {bytes_written}")
+    print(f"duration: {end-start}")
+    print(f"speed: {bytes_written/(1000000*(end-start))} MB/s")


### PR DESCRIPTION
This is a first draft of a `zarr_to_vcf` function that uses numba to get good performance (#924).

- I can get ~100MB/s write speed for the benchmark in https://github.com/pystatgen/sgkit/pull/944 which uses a real VCF file.
- Relies on the VCF header stored as a Zarr attribute, so really only useful for roundtripping VCF -> Zarr -> VCF at the moment.
- It passes some, but not all, of the "lossless" tests that check VCF -> Zarr -> VCF is unchanged.
- Float values are written using the `ftoa` function, which does not have the same output as the htslib implementation in some cases. For example, it has different rules around number of decimal places, and doesn't support exponential notation. This could be improved, but it will be hard to make it match exactly. This is why some of the "lossless" tests are not passing.
-  This is a big PR. The best way to approach it is probably to look at `vcf_writer.py` to get the high-level flow, and `vcf_writer_utils.py` for the smaller numba functions. It would be useful to have a high-level review at least before I do much more on it as a sanity check about some of the design choices and general direction. 