### PR TITLE
Add asv benchmarks for VCF

### DIFF
--- a/benchmarks/benchmarks_vcf.py
+++ b/benchmarks/benchmarks_vcf.py
@@ -1,0 +1,78 @@
+"""Benchmark suite for VCF module."""
+import gzip
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from sgkit.io.vcf.vcf_reader import vcf_to_zarr
+from sgkit.io.vcf.vcf_writer import zarr_to_vcf
+
+
+class VcfSpeedSuite:
+    def setup(self) -> None:
+
+        asv_env_dir = os.environ["ASV_ENV_DIR"]
+        path = Path(
+            asv_env_dir,
+            "project/sgkit/tests/io/vcf/data/1000G.phase3.broad.withGenotypes.chr20.10100000.vcf.gz",
+        )
+        tmp_path = Path(tempfile.mkdtemp())
+        self.input_vcf = tmp_path.joinpath("1000G.in.vcf").as_posix()
+        self.input_zarr = tmp_path.joinpath("1000G.in.zarr").as_posix()
+        self.output_zarr = tmp_path.joinpath("1000G.out.zarr").as_posix()
+        self.output_vcf = tmp_path.joinpath("1000G.out.vcf").as_posix()
+
+        # decompress file into temp dir so we can measure speed of vcf_to_zarr for uncompressed text
+        _gunzip(path, self.input_vcf)
+
+        # create a zarr input file so we can measure zarr_to_vcf speed
+        self.field_defs = {
+            "FORMAT/AD": {"Number": "R"},
+        }
+        vcf_to_zarr(
+            self.input_vcf,
+            self.input_zarr,
+            fields=["INFO/*", "FORMAT/*"],
+            field_defs=self.field_defs,
+            chunk_length=1_000,
+            target_part_size=None,
+        )
+
+    # use track_* asv methods since we want to measure speed (MB/s) not time
+
+    def track_vcf_to_zarr_speed(self) -> None:
+        duration = _time_func(
+            vcf_to_zarr,
+            self.input_vcf,
+            self.output_zarr,
+            fields=["INFO/*", "FORMAT/*"],
+            field_defs=self.field_defs,
+            chunk_length=1_000,
+            target_part_size=None,
+        )
+        return _to_mb_per_s(os.path.getsize(self.input_vcf), duration)
+
+    def track_zarr_to_vcf_speed(self) -> None:
+        # throw away first run due to numba jit compilation
+        for _ in range(2):
+            duration = _time_func(zarr_to_vcf, self.input_zarr, self.output_vcf)
+        return _to_mb_per_s(os.path.getsize(self.output_vcf), duration)
+
+
+def _gunzip(input, output):
+    with gzip.open(input, "rb") as f_in:
+        with open(output, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+
+def _time_func(func, *args, **kwargs):
+    start = time.time()
+    func(*args, **kwargs)
+    end = time.time()
+    return end - start
+
+
+def _to_mb_per_s(bytes, duration):
+    return bytes / (1_000_000 * duration)

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 # Ignore VCF files during pytest collection, so it doesn't fail if cyvcf2 isn't installed.
-collect_ignore_glob = ["sgkit/io/vcf/*.py", ".github/scripts/*.py"]
+collect_ignore_glob = ["benchmarks/**", "sgkit/io/vcf/*.py", ".github/scripts/*.py"]
 
 
 def pytest_configure(config) -> None:  # type: ignore


### PR DESCRIPTION
This is an [`asv`](https://asv.readthedocs.io/) version of #944.

We discussed moving away from `asv` in #938, but alternatives like `pytest-benchmark` don't allow metrics that aren't time based. Given that we already publish `asv` benchmarks at https://pystatgen.github.io/sgkit-benchmarks-asv/, I had a go at re-purposing the VCF speed benchmarks in #944 as `asv` benchmarks. This wasn't too hard, and it's possible to run them locally if needed using `asv run` from the `benchmarks` directory.