### PR TITLE
Handle variable name clashes in VCF reading

### DIFF
--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -60,6 +60,17 @@ except ImportError:  # pragma: no cover
     warnings.warn("Cannot import Blosc, falling back to no compression", RuntimeWarning)
     DEFAULT_COMPRESSOR = None
 
+# From VCF fixed fields
+RESERVED_VARIABLE_NAMES = [
+    "variant_contig",
+    "variant_position",
+    "variant_id",
+    "variant_id_mask",
+    "variant_allele",
+    "variant_quality",
+    "variant_filter",
+]
+
 
 class FloatFormatFieldWarning(UserWarning):
     """Warning for VCF FORMAT float fields, which can use a lot of storage."""
@@ -209,6 +220,10 @@ class VcfFieldHandler:
             dims = [DIM_VARIANT, DIM_SAMPLE]
             n_sample = len(vcf.samples)
             chunksize = (chunk_length, n_sample)
+        if variable_name in RESERVED_VARIABLE_NAMES:
+            raise ValueError(
+                f"Generated name for INFO field '{key}' clashes with '{variable_name}' from fixed VCF fields."
+            )
         if dimension is not None:
             dims.append(dimension)
             chunksize += (size,)

--- a/sgkit/tests/io/vcf/data/info_name_clash.vcf
+++ b/sgkit/tests/io/vcf/data/info_name_clash.vcf
@@ -1,0 +1,15 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20201009
+##source=.
+##reference=./simple.fasta
+##contig=<ID=CHR1,length=60>
+##contig=<ID=CHR2,length=60>
+##contig=<ID=CHR3,length=60>
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of samples with data">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Total number of alternate alleles in called genotypes">
+##INFO=<ID=id,Number=1,Type=Integer,Description="Clashes with ID fixed field">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
+CHR1	2	.	A	T	60	PASS	NS=3;AC=3	GT	0/0	0/0	0/0
+CHR1	7	.	A	C	60	PASS	NS=3;AC=4	GT	0/0	0/1	0/1

--- a/sgkit/tests/io/vcf/test_hypothesis_vcf.py
+++ b/sgkit/tests/io/vcf/test_hypothesis_vcf.py
@@ -47,7 +47,7 @@ def test_vcf_to_zarr(tmp_path, vcf_string):
     note(f"vcf:\n{vcf_string}")
 
     input = tmp_path.joinpath("input.vcf")
-    output = tmp_path.joinpath("output.zarr")
+    output = dict()  # in-memory Zarr is guaranteed to be case-sensitive
 
     with open(input, "w") as f:
         f.write(vcf_string)

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -792,6 +792,21 @@ def test_vcf_to_zarr__filter_not_defined_in_header(shared_datadir, tmp_path):
         vcf_to_zarr(path, output)
 
 
+def test_vcf_to_zarr__info_name_clash(shared_datadir, tmp_path):
+    # info_name_clash.vcf has an info field called 'id' which would be mapped to
+    # 'variant_id', clashing with the fixed field of the same name
+    path = path_for_test(shared_datadir, "info_name_clash.vcf")
+    output = tmp_path.joinpath("info_name_clash.zarr").as_posix()
+
+    vcf_to_zarr(path, output)  # OK if problematic field is ignored
+
+    with pytest.raises(
+        ValueError,
+        match=r"Generated name for INFO field 'id' clashes with 'variant_id' from fixed VCF fields.",
+    ):
+        vcf_to_zarr(path, output, fields=["INFO/id"])
+
+
 def test_vcf_to_zarr__large_number_of_contigs(shared_datadir, tmp_path):
     path = path_for_test(shared_datadir, "Homo_sapiens_assembly38.headerOnly.vcf.gz")
     output = tmp_path.joinpath("vcf.zarr").as_posix()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Fixes #989 
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`
- [ ] New functions are listed in `api.rst`
