### PR TITLE
Deduplicate dosage variables

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -159,7 +159,6 @@ By convention, variable names are singular in sgkit. For example, ``genotype_cou
     variables.cohort_allele_count_spec
     variables.cohort_allele_frequency_spec
     variables.covariates_spec
-    variables.dosage_spec
     variables.genotype_count_spec
     variables.interval_contig_name_spec
     variables.interval_start_spec

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,12 @@ Breaking changes
   defaulted to ``True`` but now defaults to ``False``. Furthermore, ``True``
   is no longer supported since it is not clear how it should behave.
   (:user:`tomwhite`, :pr:`952`, :issue:`947`)
+- The ``dosage`` variable specification has been removed and all references
+  to it have been replaced with :data:`sgkit.variables.call_dosage_spec`
+  which has been generalized to include integer encodings. Additionally,
+  the default value for the ``dosage`` parameter in :func:`ld_matrix` and
+  :func:`ld_prune` has been changed from ``'dosage'`` to ``'call_dosage'``.
+  (:user:`timothymillar`, :pr:`995`, :issue:`875`)
 
 .. Deprecations
 .. ~~~~~~~~~~~~

--- a/sgkit/io/bgen/bgen_reader.py
+++ b/sgkit/io/bgen/bgen_reader.py
@@ -26,17 +26,17 @@ from cbgen import bgen_file, bgen_metafile
 from rechunker import api as rechunker_api
 from xarray import Dataset
 
-from sgkit import create_genotype_dosage_dataset
+from sgkit import create_genotype_dosage_dataset, variables
 from sgkit.io.utils import dataframe_to_dict, encode_contigs
 from sgkit.typing import ArrayLike, DType, NDArray, PathType
 
 logger = logging.getLogger(__name__)
 
 GT_DATA_VARS = [
-    "call_genotype_probability",
-    "call_genotype_probability_mask",
-    "call_dosage",
-    "call_dosage_mask",
+    variables.call_genotype_probability,
+    variables.call_genotype_probability_mask,
+    variables.call_dosage,
+    variables.call_dosage_mask,
 ]
 
 METAFILE_DTYPE = dict(

--- a/sgkit/stats/association.py
+++ b/sgkit/stats/association.py
@@ -143,7 +143,7 @@ def gwas_linear_regression(
         Dataset containing necessary dependent and independent variables.
     dosage
         Name of genetic dosage variable.
-        Defined by :data:`sgkit.variables.dosage_spec`.
+        Defined by :data:`sgkit.variables.call_dosage_spec`.
     covariates
         Names of covariate variables (1D or 2D).
         Defined by :data:`sgkit.variables.covariates_spec`.
@@ -201,7 +201,7 @@ def gwas_linear_regression(
 
     variables.validate(
         ds,
-        {dosage: variables.dosage_spec},
+        {dosage: variables.call_dosage_spec},
         {c: variables.covariates_spec for c in covariates},
         {t: variables.traits_spec for t in traits},
     )
@@ -271,7 +271,7 @@ def regenie_loco_regression(
         Dataset containing necessary dependent and independent variables.
     dosage
         Name of genetic dosage variable.
-        Defined by :data:`sgkit.variables.dosage_spec`.
+        Defined by :data:`sgkit.variables.call_dosage_spec`.
     covariates
         Name of covariate variable (1D or 2D), map_blocks_asnumpy
         Defined by :data:`sgkit.variables.traits_spec`.
@@ -319,7 +319,7 @@ def regenie_loco_regression(
 
     variables.validate(
         ds,
-        {dosage: variables.dosage_spec},
+        {dosage: variables.call_dosage_spec},
         {covariates: variables.covariates_spec},
         {traits: variables.traits_spec},
         {variant_contig: variables.variant_contig_spec},

--- a/sgkit/stats/grm.py
+++ b/sgkit/stats/grm.py
@@ -109,6 +109,11 @@ def genomic_relationship(
     genotyping-by-sequencing data"
     PhD thesis, University of Otago.
     """
+    variables.validate(
+        ds,
+        {call_dosage: variables.call_dosage_spec},
+    )
+
     estimator = estimator or "VanRaden"
     if estimator not in {"VanRaden"}:
         raise ValueError("Unknown estimator '{}'".format(estimator))

--- a/sgkit/stats/ld.py
+++ b/sgkit/stats/ld.py
@@ -75,7 +75,7 @@ def rogers_huff_r2_between(gn0: ArrayLike, gn1: ArrayLike) -> float:  # pragma: 
 def ld_matrix(
     ds: Dataset,
     *,
-    dosage: Hashable = variables.dosage,
+    dosage: Hashable = variables.call_dosage,
     threshold: Optional[float] = None,
     variant_score: Optional[Hashable] = None,
 ) -> DataFrame:
@@ -91,7 +91,7 @@ def ld_matrix(
         Dataset containing genotype dosages. Must already be windowed with :func:`window_by_position` or :func:`window_by_variant`.
     dosage
         Name of genetic dosage variable.
-        Defined by :data:`sgkit.variables.dosage_spec`.
+        Defined by :data:`sgkit.variables.call_dosage_spec`.
     threshold
         R2 threshold below which no variant pairs will be returned. This should almost
         always be something at least slightly above 0 to avoid the large density very
@@ -121,7 +121,7 @@ def ld_matrix(
             "Dataset must be windowed for ld_matrix. See the sgkit.window function."
         )
 
-    variables.validate(ds, {dosage: variables.dosage_spec})
+    variables.validate(ds, {dosage: variables.call_dosage_spec})
 
     x = da.asarray(ds[dosage])
 
@@ -396,7 +396,7 @@ def maximal_independent_set(df: DataFrame) -> Dataset:
 def ld_prune(
     ds: Dataset,
     *,
-    dosage: Hashable = variables.dosage,
+    dosage: Hashable = variables.call_dosage,
     threshold: float = 0.2,
     variant_score: Optional[Hashable] = None,
 ) -> Dataset:
@@ -418,7 +418,7 @@ def ld_prune(
         Dataset containing genotype dosages. Must already be windowed with :func:`window_by_position` or :func:`window_by_variant`.
     dosage
         Name of genetic dosage variable.
-        Defined by :data:`sgkit.variables.dosage_spec`.
+        Defined by :data:`sgkit.variables.call_dosage_spec`.
     threshold
         R2 threshold below which no variant pairs will be returned. This should almost
         always be something at least slightly above 0 to avoid the large density very
@@ -447,7 +447,7 @@ def ld_prune(
     10
 
     >>> # Calculate dosage
-    >>> ds["dosage"] = ds["call_genotype"].sum(dim="ploidy")
+    >>> ds["call_dosage"] = ds["call_genotype"].sum(dim="ploidy")
 
     >>> # Divide into windows of size five (variants)
     >>> ds = sg.window_by_variant(ds, size=5)

--- a/sgkit/stats/regenie.py
+++ b/sgkit/stats/regenie.py
@@ -773,7 +773,7 @@ def regenie(
     ----------
     dosage
         Name of genetic dosage variable.
-        Defined by :data:`sgkit.variables.dosage_spec`.
+        Defined by :data:`sgkit.variables.call_dosage_spec`.
     covariates
         Names of covariate variables (1D or 2D).
         Defined by :data:`sgkit.variables.covariates_spec`.
@@ -883,7 +883,10 @@ def regenie(
 
     variables.validate(
         ds,
-        {dosage: variables.dosage_spec, variant_contig: variables.variant_contig_spec},
+        {
+            dosage: variables.call_dosage_spec,
+            variant_contig: variables.variant_contig_spec,
+        },
         {c: variables.covariates_spec for c in covariates},
         {t: variables.traits_spec for t in traits},
     )

--- a/sgkit/tests/test_ld.py
+++ b/sgkit/tests/test_ld.py
@@ -71,7 +71,7 @@ def ldm_df(
     diag: bool = False,
 ) -> DataFrame:
     ds = simulate_genotype_call_dataset(n_variant=x.shape[0], n_sample=x.shape[1])
-    ds["dosage"] = (["variants", "samples"], x)
+    ds["call_dosage"] = (["variants", "samples"], x)
     ds = window_by_variant(ds, size=size, step=step)
     df = ld_matrix(ds, threshold=threshold).compute()
     if not diag:
@@ -127,7 +127,7 @@ def test_dtypes(dtype):
 def test_ld_matrix__raise_on_no_windows():
     x = np.zeros((5, 10))
     ds = simulate_genotype_call_dataset(n_variant=x.shape[0], n_sample=x.shape[1])
-    ds["dosage"] = (["variants", "samples"], x)
+    ds["call_dosage"] = (["variants", "samples"], x)
 
     with pytest.raises(ValueError, match="Dataset must be windowed for ld_matrix"):
         ld_matrix(ds)
@@ -164,7 +164,7 @@ def test_vs_skallel(args):
     x, size, step, threshold, chunks = args
 
     ds = simulate_genotype_call_dataset(n_variant=x.shape[0], n_sample=x.shape[1])
-    ds["dosage"] = (["variants", "samples"], da.asarray(x).rechunk({0: chunks}))
+    ds["call_dosage"] = (["variants", "samples"], da.asarray(x).rechunk({0: chunks}))
     ds = window_by_variant(ds, size=size, step=step)
 
     ldm = ld_matrix(ds, threshold=threshold)
@@ -191,7 +191,7 @@ def test_scores():
     x[8, :-5] = 1
 
     ds = simulate_genotype_call_dataset(n_variant=x.shape[0], n_sample=x.shape[1])
-    ds["dosage"] = (["variants", "samples"], x)
+    ds["call_dosage"] = (["variants", "samples"], x)
     ds = window_by_variant(ds, size=10)
 
     ldm = ld_matrix(ds, threshold=0.2)

--- a/sgkit/variables.py
+++ b/sgkit/variables.py
@@ -262,9 +262,16 @@ corresponding to the frequencies of non-missing occurrences of each allele.
 call_dosage, call_dosage_spec = SgkitVariables.register_variable(
     ArrayLikeSpec(
         "call_dosage",
-        kind="f",
+        kind={"f", "i", "u"},
         dims=("variants", "samples"),
-        __doc__="""Dosages, encoded as floats, with NaN indicating a missing value.""",
+        __doc__="""
+Dosages, encoded as floats, with NaN indicating a missing value.
+Dosages can represent one of several possible quantities, e.g.:
+- Alternate allele counts
+- Recessive or dominant allele encodings
+- True dosages as computed from imputed or probabilistic variant calls
+- Any other custom encoding in a user-defined variable
+""",
     )
 )
 
@@ -423,20 +430,6 @@ covariates, covariates_spec = SgkitVariables.register_variable(
 Covariate variable names. Must correspond to 1 or 2D dataset
 variables of shape (samples[, covariates]). All covariate arrays
 will be concatenated along the second axis (columns).
-""",
-    )
-)
-
-dosage, dosage_spec = SgkitVariables.register_variable(
-    ArrayLikeSpec(
-        "dosage",
-        __doc__="""
-Dosage variable name. Where "dosage" array can contain represent
-one of several possible quantities, e.g.:
-- Alternate allele counts
-- Recessive or dominant allele encodings
-- True dosages as computed from imputed or probabilistic variant calls
-- Any other custom encoding in a user-defined variable
 """,
     )
 )


### PR DESCRIPTION
Replaces variable `dosage` with `call_dosage`.

- [x] Fixes #875
- [x] Tests added
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

This is a bit more of a breaking change than originally anticipated. The main user facing change is the default argument in the `ld.py` methods. I have also had to generalize the `call_dosage` spec to allow ints and uints. I wonder if there's an elegant way to deprecate a variable from the spec?

[`test_regenie_loco_regression__raise_on_non_2D`](https://github.com/pystatgen/sgkit/blob/main/sgkit/tests/test_association.py#L505) is failing because the incorrect dimensionality is now caught early by variable validation. I could just remove the test but the comment  `# we also cover Q.rechunk(X.chunksize) in this test` suggests that a new test would be required. However, I'm not quite confident I understand the code well enough. Could @pentschev or @eric-czech advise?

