### PR TITLE
Fix edgecase in Hypothesis VCF generation by filtering out INFO field…

### DIFF
--- a/sgkit/tests/io/vcf/hypothesis_vcf.py
+++ b/sgkit/tests/io/vcf/hypothesis_vcf.py
@@ -67,6 +67,7 @@ RESERVED_INFO_KEYS = [
     "SOMATIC",
     "VALIDATED",
     "1000G",
+    "id",  # conflicts with 'variant_id' variable; see RESERVED_VARIABLE_NAMES in vcf_reader.py
 ]
 
 # [Table 2: Reserved genotype keys]


### PR DESCRIPTION
… with name 'id'

Fixes Hypothesis failure in https://github.com/pystatgen/sgkit/actions/runs/3916074044/jobs/6694856867#step:9:1381:

```
FAILED sgkit/tests/io/vcf/test_hypothesis_vcf.py::test_vcf_to_zarr - ValueError: Generated name for INFO field 'id' clashes with 'variant_id' from fixed VCF fields.
Falsifying example: test_vcf_to_zarr(
    vcf_string='##fileformat=VCFv4.3\n##FILTER=<ID=PASS,Description="All filters passed">\n##source=sgkit-vcf-hypothesis-unknown\n##contig=<ID=0>\n##INFO=<ID=id,Type=Integer,Number=A,Description="INFO,Type=Integer,Number=A">\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n0\t0\t.\tA\t.\t.\t.\t.\n',
    tmp_path=PosixPath('/tmp/pytest-of-runner/pytest-1/test_vcf_to_zarr0'),
)
vcf:
##fileformat=VCFv4.3
##FILTER=<ID=PASS,Description="All filters passed">
##source=sgkit-vcf-hypothesis-unknown
##contig=<ID=0>
##INFO=<ID=id,Type=Integer,Number=A,Description="INFO,Type=Integer,Number=A">
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
0	0	.	A	.	.	.	.


You can reproduce this example by temporarily adding @reproduce_failure('6.62.0', b'AXicY1TWZGBkAAIwASbBLAAHDABS') as a decorator on your test case
```
