### PR TITLE
Run upstream tests on python>=3.9, since xarray no longer supports 3.8

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Upstream tests have started [failing](https://github.com/pystatgen/sgkit/actions/runs/4219412116/jobs/7324741739#step:4:99) with

```
ERROR: Package 'xarray' requires a different Python: 3.8.16 not in '>=3.9'
```

This PR removes 3.8 for upstream (we still test on 3.8 for the other tests).