### PR TITLE
Add variant id to simulate dataset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,12 +35,15 @@ New Features
 - Add :func:`sgkit.io.vcf.read_vcf` convenience function.
   (:user:`tomwhite`, :pr:`1052`, :issue:`1004`)
 
-- Add :func:`sgkit.hybrid_relationship`, :func:`sgkit.hybrid_inverse_relationship` 
+- Add :func:`sgkit.hybrid_relationship`, :func:`sgkit.hybrid_inverse_relationship`
   and :func:`invert_relationship_matrix` methods.
   (:user:`timothymillar`, :pr:`1053`, :issue:`993`)
 
 - Add :func:`sgkit.io.vcf.zarr_array_sizes` for determining array sizes for storage in Zarr.
   (:user:`tomwhite`, :pr:`1073`, :issue:`734`)
+
+- Add `additional_variant_fields` to :func:`sgkit.simulate_genotype_call_dataset` function.
+  (:user:`benjeffery`, :pr:`1056`)
 
 Bug fixes
 ~~~~~~~~~

--- a/sgkit/tests/test_testing.py
+++ b/sgkit/tests/test_testing.py
@@ -29,3 +29,35 @@ def test_simulate_genotype_call_dataset__phased(tmp_path):
     ds = simulate_genotype_call_dataset(n_variant=10, n_sample=10, phased=False)
     assert "call_genotype_phased" in ds
     assert not np.any(ds["call_genotype_phased"])
+
+
+def test_simulate_genotype_call_dataset__additional_variant_fields():
+    ds = simulate_genotype_call_dataset(
+        n_variant=10,
+        n_sample=10,
+        phased=True,
+        additional_variant_fields={
+            "variant_id": np.str,
+            "variant_filter": np.bool,
+            "variant_quality": np.int8,
+            "variant_yummyness": np.float32,
+        },
+    )
+    assert "variant_id" in ds
+    assert np.all(ds["variant_id"] == np.arange(10).astype("S"))
+    assert "variant_filter" in ds
+    assert ds["variant_filter"].dtype == np.bool
+    assert "variant_quality" in ds
+    assert ds["variant_quality"].dtype == np.int8
+    assert "variant_yummyness" in ds
+    assert ds["variant_yummyness"].dtype == np.float32
+
+    with pytest.raises(ValueError, match="Unrecognized dtype"):
+        simulate_genotype_call_dataset(
+            n_variant=10,
+            n_sample=10,
+            phased=True,
+            additional_variant_fields={
+                "variant_id": None,
+            },
+        )


### PR DESCRIPTION
Came across this while trying to save a VCF of a simulated callset - seems like it should be in the simulated set?
