### PR TITLE
Use Codecov GitHub action since the PyPi package has been removed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
       run: |
         pytest -v --cov=sgkit --cov-report=term-missing
     - name: Upload coverage to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 callee
-codecov
 pre-commit
 pytest
 pytest-cov


### PR DESCRIPTION
The build is breaking due to this (e.g. https://github.com/pystatgen/sgkit/actions/runs/4710629116).

See https://about.codecov.io/blog/message-regarding-the-pypi-package/ for context.
