### PR TITLE
Give hint for how to work around Number='.' error when reading VCF

### DIFF
--- a/sgkit/io/vcfzarr_reader.py
+++ b/sgkit/io/vcfzarr_reader.py
@@ -524,5 +524,5 @@ def vcf_number_to_dimension_and_size(
             )
             return (dim_name, int(vcf_number))
     raise ValueError(
-        f"{category} field '{key}' is defined as Number '{vcf_number}', which is not supported."
+        f"{category} field '{key}' is defined as Number '{vcf_number}', which is not supported. Consider specifying `field_defs` to provide a concrete size for this field."
     )

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -1185,7 +1185,7 @@ def test_vcf_to_zarr__fields_errors(shared_datadir, tmp_path):
 
     with pytest.raises(
         ValueError,
-        match=r"INFO field 'AC' is defined as Number '.', which is not supported.",
+        match=r"INFO field 'AC' is defined as Number '.', which is not supported. Consider specifying `field_defs` to provide a concrete size for this field.",
     ):
         vcf_to_zarr(path, output, fields=["INFO/AC"])
 


### PR DESCRIPTION
- [x] Related to #1059
- [x] Tests added

