### PR TITLE
NumPy 1.24 fixes

### DIFF
--- a/sgkit/io/vcf/vcf_writer.py
+++ b/sgkit/io/vcf/vcf_writer.py
@@ -211,7 +211,7 @@ def dataset_chunk_to_vcf(
         var = f"variant_{key}"
         if var not in ds:
             continue
-        if ds[var].dtype == np.bool:
+        if ds[var].dtype == bool:
             values = ds[var].values
             info_mask[k] = create_mask(values)
             info_bufs.append(np.zeros(0, dtype=np.uint8))

--- a/sgkit/io/vcf/vcf_writer_utils.py
+++ b/sgkit/io/vcf/vcf_writer_utils.py
@@ -496,7 +496,7 @@ def vcf_genotypes_to_byte_buf_size(call_genotype):
 def create_mask(arr):
     """Return a mask array of shape ``arr.shape[0]` for masking out fill values."""
     axis = tuple(range(1, len(arr.shape)))
-    if arr.dtype == np.bool:
+    if arr.dtype == bool:
         return ~arr
     elif arr.dtype in (np.int8, np.int16, np.int32):
         return np.all(arr == INT_FILL, axis=axis)

--- a/sgkit/stats/pedigree.py
+++ b/sgkit/stats/pedigree.py
@@ -293,7 +293,7 @@ def kinship_diploid(
 @numba_jit
 def _identify_founders_diploid(parent: ArrayLike) -> ArrayLike:
     n = len(parent)
-    out = np.zeros(n, dtype=np.bool8)
+    out = np.zeros(n, dtype=np.bool_)
     for i in range(n):
         if (parent[i, 0] < 0) or (parent[i, 1] < 0):
             out[i] = True
@@ -657,7 +657,7 @@ def kinship_Hamilton_Kerr(
 @numba_jit
 def _identify_founders_Hamilton_Kerr(parent: ArrayLike, tau: ArrayLike) -> ArrayLike:
     n, p = parent.shape
-    out = np.zeros(n, dtype=np.bool8)
+    out = np.zeros(n, dtype=np.bool_)
     for i in range(n):
         for j in range(p):
             if (parent[i, j] < 0) and tau[i, j] > 0:

--- a/sgkit/testing.py
+++ b/sgkit/testing.py
@@ -108,7 +108,7 @@ def simulate_genotype_call_dataset(
                 field = rs.rand(n_variant).astype(field_dtype)
             elif field_dtype in (np.int8, np.int16, np.int32, np.int64):
                 field = rs.randint(0, 100, n_variant, dtype=field_dtype)
-            elif field_dtype is np.bool:
+            elif field_dtype is bool:
                 field = rs.rand(n_variant) > 0.5
             elif field_dtype is np.str:
                 field = np.arange(n_variant).astype("S")

--- a/sgkit/testing.py
+++ b/sgkit/testing.py
@@ -110,7 +110,7 @@ def simulate_genotype_call_dataset(
                 field = rs.randint(0, 100, n_variant, dtype=field_dtype)
             elif field_dtype is bool:
                 field = rs.rand(n_variant) > 0.5
-            elif field_dtype is np.str:
+            elif field_dtype is str:
                 field = np.arange(n_variant).astype("S")
             else:
                 raise ValueError(f"Unrecognized dtype {field_dtype}")

--- a/sgkit/tests/io/vcf/test_vcf_reader.py
+++ b/sgkit/tests/io/vcf/test_vcf_reader.py
@@ -1452,7 +1452,7 @@ def test_spec(shared_datadir, tmp_path):
         ndim=1,
         shape=(variants,),
         dimension_names=["variants"],
-        dtype=np.bool_,
+        dtype=bool,
     )
     check_field(
         group,
@@ -1468,7 +1468,7 @@ def test_spec(shared_datadir, tmp_path):
         ndim=1,
         shape=(variants,),
         dimension_names=["variants"],
-        dtype=np.bool_,
+        dtype=bool,
     )
     check_field(
         group,
@@ -1518,7 +1518,7 @@ def test_spec(shared_datadir, tmp_path):
         ndim=2,
         shape=(variants, samples),
         dimension_names=["variants", "samples"],
-        dtype=np.bool_,
+        dtype=bool,
     )
 
     # Sample information

--- a/sgkit/tests/io/vcf/vcf_writer.py
+++ b/sgkit/tests/io/vcf/vcf_writer.py
@@ -205,7 +205,7 @@ def array_to_values(arr, name="unknown"):
     """Convert an array from cyvcf2 to a 'present' flag, and an array with fill removed."""
     if isinstance(arr, str):  # this happens for the Type=String, Number=1 path
         arr = np.array([arr], dtype="O")
-    if arr.dtype == np.bool_:
+    if arr.dtype == bool:
         if arr.size == 1:
             return True, arr.item()
         else:

--- a/sgkit/tests/test_testing.py
+++ b/sgkit/tests/test_testing.py
@@ -37,7 +37,7 @@ def test_simulate_genotype_call_dataset__additional_variant_fields():
         n_sample=10,
         phased=True,
         additional_variant_fields={
-            "variant_id": np.str,
+            "variant_id": str,
             "variant_filter": bool,
             "variant_quality": np.int8,
             "variant_yummyness": np.float32,

--- a/sgkit/tests/test_testing.py
+++ b/sgkit/tests/test_testing.py
@@ -38,7 +38,7 @@ def test_simulate_genotype_call_dataset__additional_variant_fields():
         phased=True,
         additional_variant_fields={
             "variant_id": np.str,
-            "variant_filter": np.bool,
+            "variant_filter": bool,
             "variant_quality": np.int8,
             "variant_yummyness": np.float32,
         },
@@ -46,7 +46,7 @@ def test_simulate_genotype_call_dataset__additional_variant_fields():
     assert "variant_id" in ds
     assert np.all(ds["variant_id"] == np.arange(10).astype("S"))
     assert "variant_filter" in ds
-    assert ds["variant_filter"].dtype == np.bool
+    assert ds["variant_filter"].dtype == bool
     assert "variant_quality" in ds
     assert ds["variant_quality"].dtype == np.int8
     assert "variant_yummyness" in ds


### PR DESCRIPTION
Now that [Numba 0.57.0 is out](https://github.com/numba/numba/releases/tag/0.57.0) our automated tests are running on NumPy 1.24, which have exposed some deprecation errors, e.g.

```
FAILED sgkit/tests/io/vcf/test_vcf_writer.py::test_write_vcf__add_drop_fields[False] - FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.
```

See https://github.com/pystatgen/sgkit/actions/runs/4867183070/jobs/8679511958#step:8:3273