### PR TITLE
Add experimental `vcf_to_parquet` function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ zarr >= 2.10.0, != 2.11.0, != 2.11.1, != 2.11.2
 fsspec != 2021.6.*
 scikit-learn
 pandas
+pyarrow


### PR DESCRIPTION
- [ ] Fixes #xxxx
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`
- [ ] New functions are listed in `api.rst`

Inspired by the discussion in #1059, I've written some code to export the fixed fields of a VCF file (including INFO fields) to a collection of Parquet files. The idea is that you can run filtering-style queries on this variant metadata, and use that to subset/mask the variants in a Zarr dataset. I explored this a bit in https://github.com/pystatgen/sgkit/issues/634#issuecomment-1523285115.

This is not to be merged, just posting for interest.