### PR TITLE
Change `max_str_len` utility function to return a Python int rather than an array scalar

### DIFF
--- a/sgkit/io/utils.py
+++ b/sgkit/io/utils.py
@@ -35,7 +35,7 @@ def dataframe_to_dict(
         kind = np.dtype(dt).kind
         if kind in ["U", "S"]:
             # Compute fixed-length string dtype for array
-            max_len = int(max_str_len(a))
+            max_len = max_str_len(a)
             dt = f"{kind}{max_len}"
         arrs[c] = a.astype(dt)
     return arrs

--- a/sgkit/io/vcfzarr_reader.py
+++ b/sgkit/io/vcfzarr_reader.py
@@ -263,7 +263,7 @@ def _vcfzarr_to_dataset(
                 # Compute fixed-length string dtype for array
                 if kind == "O" or var in ("variant_id", "variant_allele"):
                     kind = "S"
-                max_len = max_str_len(arr).values  # type: ignore
+                max_len = max_str_len(arr)
                 dt = f"{kind}{max_len}"
                 ds[var] = arr.astype(dt)
 

--- a/sgkit/tests/test_utils.py
+++ b/sgkit/tests/test_utils.py
@@ -216,7 +216,7 @@ def test_max_str_len(dtype, chunks, backend, data):
             max_str_len(x)
     else:
         expected = max(map(len, np.asarray(x).ravel()))
-        actual = int(max_str_len(x))
+        actual = max_str_len(x)
         assert expected == actual
 
 

--- a/sgkit/utils.py
+++ b/sgkit/utils.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Hashable, List, Mapping, Optional, Set, Tuple,
 
 import dask.array as da
 import numpy as np
+import xarray as xr
 from xarray import Dataset
 
 from . import variables
@@ -375,8 +376,7 @@ def max_str_len(a: ArrayLike) -> ArrayLike:
 
     Returns
     -------
-    max_length
-        Scalar array with same type as provided array
+    max_length : int
     """
     if a.size == 0:
         raise ValueError("Max string length cannot be calculated for empty array")
@@ -389,9 +389,17 @@ def max_str_len(a: ArrayLike) -> ArrayLike:
     if isinstance(a, np.ndarray):
         lens = np.asarray(lens)
     if a.ndim == 0:
-        return lens
+        max_len = lens
     else:
-        return lens.max()
+        max_len = lens.max()
+    # convert to a python int
+    if isinstance(max_len, da.Array):
+        max_len = max_len.compute()
+    elif isinstance(max_len, xr.DataArray):
+        max_len = max_len.values
+    if isinstance(max_len, np.ndarray):
+        max_len = max_len.item()
+    return max_len
 
 
 def smallest_numpy_int_dtype(value: int) -> Optional[DType]:


### PR DESCRIPTION
- [x] Fixes #1085 
- [x] Tests added

Array scalars are problematic (and are [not in the Python array API standard](https://numpy.org/doc/stable/reference/array_api.html#array-object-differences)), so this change simplifies things by returning a regular int. All call sites converted to an int anyway, so it shouldn't be a problem.