### PR TITLE
Improve performance of `variant_stats`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ New Features
   (:user:`timothymillar`, :pr:`1100`, :issue:`1062`)
 - Add :func:`display_pedigree` function.
   (:user:`timothymillar`, :pr:`1104`, :issue:`1097`)
+- Add option to count variant alleles directly from call genotypes in function :func:`count_variant_alleles`.
+  (:user:`timothymillar`, :pr:`1119`, :issue:`1116`)
 
 .. Breaking changes
 .. ~~~~~~~~~~~~~~~~
@@ -26,8 +28,11 @@ New Features
 .. Deprecations
 .. ~~~~~~~~~~~~
 
-.. Improvements
-.. ~~~~~~~~~~~~
+Improvements
+~~~~~~~~~~~~
+
+- Improve performance of :func:`variant_stats` and :func:`sample_stats` functions.
+  (:user:`timothymillar`, :pr:`1119`, :issue:`1116`)
 
 .. Bug fixes
 .. ~~~~~~~~~

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -203,7 +203,7 @@ shows how it can be used in the context of doing something simple like counting 
 
     # Now the result is correct -- only the third sample is heterozygous so the count should be 1.
     # This how many sgkit functions handle missing data internally:
-    sg.variant_stats(ds).variant_n_het.item(0)
+    sg.variant_stats(ds).variant_n_het.values.item(0)
 
 Windowing
 ---------
@@ -320,8 +320,8 @@ Xarray and Pandas operations in a single pipeline:
     # for windows of size 20 variants
     (
         ds
-        # Add call rate and other statistics
-        .pipe(sg.variant_stats)
+        # Add and compute call rate and other statistics
+        .pipe(sg.variant_stats).compute()
         # Apply filter to include variants present across > 80% of samples
         .pipe(lambda ds: ds.sel(variants=ds.variant_call_rate > .8))
         # Create windows of size 20 variants

--- a/sgkit/stats/aggregation_numba_fns.py
+++ b/sgkit/stats/aggregation_numba_fns.py
@@ -2,7 +2,7 @@
 # in a separate file here, and imported dynamically to avoid
 # initial compilation overhead.
 
-from sgkit.accelerate import numba_guvectorize
+from sgkit.accelerate import numba_guvectorize, numba_jit
 from sgkit.typing import ArrayLike
 
 
@@ -12,6 +12,10 @@ from sgkit.typing import ArrayLike
         "void(int16[:], uint8[:], uint8[:])",
         "void(int32[:], uint8[:], uint8[:])",
         "void(int64[:], uint8[:], uint8[:])",
+        "void(int8[:], uint64[:], uint64[:])",
+        "void(int16[:], uint64[:], uint64[:])",
+        "void(int32[:], uint64[:], uint64[:])",
+        "void(int64[:], uint64[:], uint64[:])",
     ],
     "(k),(n)->(n)",
 )
@@ -26,9 +30,10 @@ def count_alleles(
         Genotype call of shape (ploidy,) containing alleles encoded as
         type `int` with values < 0 indicating a missing allele.
     _
-        Dummy variable of type `uint8` and shape (alleles,) used to
-        define the number of unique alleles to be counted in the
-        return value.
+        Dummy variable of type `uint8` or `uint64` and shape (alleles,)
+        used to define the number of unique alleles to be counted in the
+        return value. The dtype of this array determines the dtype of the
+        returned array.
 
     Returns
     -------
@@ -43,3 +48,57 @@ def count_alleles(
         a = g[i]
         if a >= 0:
             out[a] += 1
+
+
+@numba_jit(nogil=True)
+def _classify_hom(genotype: ArrayLike) -> int:  # pragma: no cover
+    a0 = genotype[0]
+    cat = min(a0, 1)  # -1, 0, 1
+    for i in range(1, len(genotype)):
+        if cat < 0:
+            break
+        a = genotype[i]
+        if a != a0:
+            cat = 2  # het
+        if a < 0:
+            cat = -1
+    return cat
+
+
+@numba_guvectorize(  # type: ignore
+    [
+        "void(int8[:,:], uint64[:], int64[:])",
+        "void(int16[:,:], uint64[:], int64[:])",
+        "void(int32[:,:], uint64[:], int64[:])",
+        "void(int64[:,:], uint64[:], int64[:])",
+    ],
+    "(n, k),(c)->(c)",
+)
+def count_hom(
+    genotypes: ArrayLike, _: ArrayLike, out: ArrayLike
+) -> None:  # pragma: no cover
+    """Generalized U-function for counting homozygous and heterozygous genotypes.
+
+    Parameters
+    ----------
+    g
+        Genotype call of shape (ploidy,) containing alleles encoded as
+        type `int` with values < 0 indicating a missing allele.
+    _
+        Dummy variable of type `uint64` with length 3 which determines the
+        number of categories returned (this should always be 3).
+
+    Note
+    ----
+    This method is not suitable for mixed-ploidy genotypes.
+
+    Returns
+    -------
+    counts : ndarray
+        Counts of homozygous reference, homozygous alternate, and heterozygous genotypes.
+    """
+    out[:] = 0
+    for i in range(len(genotypes)):
+        index = _classify_hom(genotypes[i])
+        if index >= 0:
+            out[index] += 1

--- a/sgkit/stats/popgen.py
+++ b/sgkit/stats/popgen.py
@@ -430,7 +430,11 @@ def Tajimas_D(
            [1.10393559, 1.10393559]])
     """
     ds = define_variable_if_absent(
-        ds, variables.variant_allele_count, variant_allele_count, count_variant_alleles
+        ds,
+        variables.variant_allele_count,
+        variant_allele_count,
+        count_variant_alleles,
+        using=variables.call_genotype,
     )
     ds = define_variable_if_absent(
         ds, variables.stat_diversity, stat_diversity, diversity


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Fixes #1116
- [x] Tests added
- [x] Update the relate `sample_stats` function
- [x] Update Tajimas_D to use faster  `count_variant_alleles`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

This updates `variant_stats` to use a pair of gufuncs to calculate variant counts and hom/het genotype counts respectively.
This seems to be the sweet spot for performance, It may be possible to use a single gufunc but I can't seem to maintain the same performance (probably due to the complexity of the inner loop). The two gufunc soultion is also nice for modularity. I also looked at using [`da.apply_gufunc`](https://docs.dask.org/en/stable/generated/dask.array.gufunc.apply_gufunc.html) to have multiple return values but the performance seems to be worse than `map_blocks` with a single return value.

This also changes the `count_variant_alleles` function to give the option of counting alleles from the `call_genotype` array directly rather than via the `call_allele_count` array. This introduces the `using` argument to specify the array to use. Feedback on this approach/argument name would be appreciated as this pattern could be used elsewhere. I have kept the old behavior as the default for now.

I seem to be getting around an 18-22x speedup compared to the current master branch. This is variable and seems to increase with numbers of samples which makes sense given the changes to `count_variant_alleles` (no longer producing intermediate counts for each sample). It'd be good if someone else can verify this as it's better than I expected.

Relative speedup was calculated using biallelic diploid data with 1% missing allele calls. The variants array was split into 8 chunks in all cases to ensure CPU saturation on an 8 core machine.

Relative speedup:

|  Threads |   100k * 1k |  20k * 5k |   10k * 10k |
|----------:|------------:|-----------:|------------:|
|         1 |        21.1 |       22   |        23.4 |
|         2 |        19.5 |       19.7 |        19.8 |
|         4 |        18.6 |       18.9 |        19.1 |
|         6 |        19.2 |       19.8 |        20.5 |
|         8 |        17.8 |       18.6 |        18.7 |

The first value in each column name is the number of variants and the second is the number samples.

Note: I'm using `dask.config.set(pool=ThreadPool(<number>))` to control thread number.