### PR TITLE
Fix memory leak (see cyvcf2 #280)

### DIFF
--- a/sgkit/io/vcf/vcf_reader.py
+++ b/sgkit/io/vcf/vcf_reader.py
@@ -100,10 +100,11 @@ class MaxAltAllelesExceededWarning(UserWarning):
 def open_vcf(path: PathType) -> Iterator[VCF]:
     """A context manager for opening a VCF file."""
     vcf = VCF(path)
-    try:
-        yield vcf
-    finally:
-        vcf.close()
+    yield vcf
+    # This line is commented out as it causes a memory leak in cyvcf2
+    # See https://github.com/brentp/cyvcf2/pull/280
+    # We should reinstate this after a new release of cyvcf2
+    # vcf.close()
 
 
 def region_filter(


### PR DESCRIPTION
Calling`vcf.close` leaks memory, the good news is that we don't have to! `vcf.__dealloc__` calls it anyway.

See https://github.com/brentp/cyvcf2/pull/280