### PR TITLE
Remove Python 3.8 on Windows from mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ queue_rules:
       - status-success=build (3.8)
       - status-success=build (3.9)
       - status-success=build (3.10)
-      - status-success=win_build (3.8)
       - status-success=win_build (3.9)
       - approved-reviews-by=@pystatgen/committers
       - "#approved-reviews-by>=1"
@@ -18,7 +17,6 @@ pull_request_rules:
       - status-success=build (3.8)
       - status-success=build (3.9)
       - status-success=build (3.10)
-      - status-success=win_build (3.8)
       - status-success=win_build (3.9)
       - approved-reviews-by=@pystatgen/committers
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

The Python 3.8 build on Windows was removed in #1122. This updates the mergify config to reflect that so auto-merge labels work again.

- [x] Fixes #1134

