### PR TITLE
Turn off numba cache by default

### DIFF
--- a/sgkit/accelerate.py
+++ b/sgkit/accelerate.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 from numba import guvectorize, jit
 
-_DISABLE_CACHE = os.environ.get("SGKIT_DISABLE_NUMBA_CACHE", "0")
+_DISABLE_CACHE = os.environ.get("SGKIT_DISABLE_NUMBA_CACHE", "1")
 
 try:
     CACHE_NUMBA = {"0": True, "1": False}[_DISABLE_CACHE]


### PR DESCRIPTION
Partial fix for  #1156

This turns off numba caching by default, and at least lets us use the current git version of sgkit without hitting this issue repeatedly.

To fully address I think we probably need to undocument this variable by removing the mention to it in the docs, and maybe add some comments in the source laying out the issue.